### PR TITLE
Rewrite: Handle authorization states

### DIFF
--- a/data/com.github.melix99.telegrand.gschema.xml.in
+++ b/data/com.github.melix99.telegrand.gschema.xml.in
@@ -16,5 +16,10 @@
       <summary>Default window maximized behaviour</summary>
       <description></description>
     </key>
+    <key name="use-test-dc" type="b">
+      <default>false</default>
+      <summary>Use Telegram's test data center</summary>
+      <description>Use Telegram's test data center</description>
+    </key>
   </schema>
 </schemalist>

--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -96,6 +96,43 @@
                 </property>
               </object>
             </child>
+            <child>
+              <object class="AdwLeafletPage">
+                <property name="name">password_page</property>
+                <property name="child">
+                  <object class="AdwStatusPage">
+                    <property name="valign">start</property>
+                    <property name="icon-name">user-available-symbolic</property>
+                    <property name="title" translatable="yes">Welcome to Telegrand</property>
+                    <child>
+                      <object class="GtkListBox">
+                        <child>
+                          <object class="GtkListBoxRow">
+                            <property name="halign">center</property>
+                            <property name="focusable">False</property>
+                            <property name="selectable">False</property>
+                            <property name="activatable">False</property>
+                            <property name="child">
+                              <object class="GtkPasswordEntry" id="password_entry">
+                                <property name="activates-default">True</property>
+                                <property name="placeholder-text">Password</property>
+                                <property name="margin-top">6</property>
+                                <property name="margin-bottom">6</property>
+                                <property name="margin-start">6</property>
+                                <property name="margin-end">6</property>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="content"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -6,6 +6,14 @@
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkHeaderBar">
+            <child type="start">
+              <object class="GtkButton" id="previous_button">
+                <property name="visible">False</property>
+                <property name="action_name">login.previous</property>
+                <property name="label" translatable="yes">_Previous</property>
+                <property name="use_underline">True</property>
+              </object>
+            </child>
             <child type="end">
               <object class="GtkButton">
                 <property name="action_name">login.next</property>

--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -9,8 +9,23 @@
             <child type="end">
               <object class="GtkButton">
                 <property name="action_name">login.next</property>
-                <property name="use_underline">True</property>
-                <property name="label" translatable="yes">_Next</property>
+                <property name="child">
+                  <object class="GtkStack" id="next_stack">
+                    <child>
+                      <object class="GtkLabel" id="next_label">
+                        <property name="use_underline">True</property>
+                        <property name="label" translatable="yes">_Next</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSpinner" id="next_spinner">
+                        <property name="spinning">True</property>
+                        <property name="valign">center</property>
+                        <property name="halign">center</property>
+                      </object>
+                    </child>
+                  </object>
+                </property>
                 <style>
                   <class name="suggested-action"/>
                 </style>

--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -94,20 +94,26 @@
                                     <property name="activatable">False</property>
                                     <property name="title" translatable="yes">Advanced</property>
                                     <child>
-                                      <object class="GtkListBoxRow">
-                                        <property name="focusable">False</property>
-                                        <property name="selectable">False</property>
-                                        <property name="activatable">False</property>
-                                        <property name="child">
+                                      <object class="AdwActionRow">
+                                        <property name="title" translatable="yes">Encryption Key</property>
+                                        <child>
                                           <object class="GtkPasswordEntry" id="encryption_key_entry">
                                             <property name="activates-default">True</property>
-                                            <property name="placeholder-text" translatable="yes">Encryption Key</property>
-                                            <property name="margin-top">6</property>
-                                            <property name="margin-bottom">6</property>
-                                            <property name="margin-start">6</property>
-                                            <property name="margin-end">6</property>
+                                            <property name="valign">center</property>
                                           </object>
-                                        </property>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="AdwActionRow">
+                                        <property name="activatable_widget">use_test_dc_switch</property>
+                                        <property name="title" translatable="yes">Use Test Data Center</property>
+                                        <property name="subtitle" translatable="yes">This requires a restart to apply</property>
+                                        <child>
+                                          <object class="GtkSwitch" id="use_test_dc_switch">
+                                            <property name="valign">center</property>
+                                          </object>
+                                        </child>
                                       </object>
                                     </child>
                                   </object>

--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -54,42 +54,79 @@
                     <property name="icon-name">user-available-symbolic</property>
                     <property name="title" translatable="yes">Welcome to Telegrand</property>
                     <child>
-                      <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">12</property>
-                        <child>
-                          <object class="GtkListBox">
+                      <object class="AdwClamp">
+                        <property name="maximum-size">300</property>
+                        <property name="tightening-threshold">200</property>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">12</property>
                             <child>
-                              <object class="GtkListBoxRow">
-                                <property name="halign">center</property>
-                                <property name="focusable">False</property>
-                                <property name="selectable">False</property>
-                                <property name="activatable">False</property>
-                                <property name="child">
-                                  <object class="GtkEntry" id="phone_number_entry">
-                                    <property name="activates-default">True</property>
-                                    <property name="placeholder-text">Phone Number</property>
-                                    <property name="margin-top">6</property>
-                                    <property name="margin-bottom">6</property>
-                                    <property name="margin-start">6</property>
-                                    <property name="margin-end">6</property>
+                              <object class="GtkListBox">
+                                <child>
+                                  <object class="GtkListBoxRow">
+                                    <property name="focusable">False</property>
+                                    <property name="selectable">False</property>
+                                    <property name="activatable">False</property>
+                                    <property name="child">
+                                      <object class="GtkEntry" id="phone_number_entry">
+                                        <property name="activates-default">True</property>
+                                        <property name="placeholder-text" translatable="yes">Phone Number</property>
+                                        <property name="margin-top">6</property>
+                                        <property name="margin-bottom">6</property>
+                                        <property name="margin-start">6</property>
+                                        <property name="margin-end">6</property>
+                                      </object>
+                                    </property>
                                   </object>
-                                </property>
+                                </child>
+                                <style>
+                                  <class name="content"/>
+                                </style>
                               </object>
                             </child>
-                            <style>
-                              <class name="content"/>
-                            </style>
+                            <child>
+                              <object class="GtkListBox">
+                                <child>
+                                  <object class="AdwExpanderRow">
+                                    <property name="focusable">False</property>
+                                    <property name="selectable">False</property>
+                                    <property name="activatable">False</property>
+                                    <property name="title" translatable="yes">Advanced</property>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="focusable">False</property>
+                                        <property name="selectable">False</property>
+                                        <property name="activatable">False</property>
+                                        <property name="child">
+                                          <object class="GtkPasswordEntry" id="encryption_key_entry">
+                                            <property name="activates-default">True</property>
+                                            <property name="placeholder-text" translatable="yes">Encryption Key</property>
+                                            <property name="margin-top">6</property>
+                                            <property name="margin-bottom">6</property>
+                                            <property name="margin-start">6</property>
+                                            <property name="margin-end">6</property>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="content"/>
+                                </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="phone_number_error_label">
+                                <property name="visible">False</property>
+                                <style>
+                                  <class name="error"/>
+                                </style>
+                              </object>
+                            </child>
                           </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="phone_number_error_label">
-                            <property name="visible">False</property>
-                            <style>
-                              <class name="error"/>
-                            </style>
-                          </object>
-                        </child>
+                        </property>
                       </object>
                     </child>
                   </object>
@@ -105,42 +142,47 @@
                     <property name="icon-name">mail-send-symbolic</property>
                     <property name="title" translatable="yes">Enter the Verification Code</property>
                     <child>
-                      <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">12</property>
-                        <child>
-                          <object class="GtkListBox">
+                      <object class="AdwClamp">
+                        <property name="maximum-size">300</property>
+                        <property name="tightening-threshold">200</property>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">12</property>
                             <child>
-                              <object class="GtkListBoxRow">
-                                <property name="halign">center</property>
-                                <property name="focusable">False</property>
-                                <property name="selectable">False</property>
-                                <property name="activatable">False</property>
-                                <property name="child">
-                                  <object class="GtkEntry" id="code_entry">
-                                    <property name="activates-default">True</property>
-                                    <property name="placeholder-text">Code</property>
-                                    <property name="margin-top">6</property>
-                                    <property name="margin-bottom">6</property>
-                                    <property name="margin-start">6</property>
-                                    <property name="margin-end">6</property>
+                              <object class="GtkListBox">
+                                <child>
+                                  <object class="GtkListBoxRow">
+                                    <property name="focusable">False</property>
+                                    <property name="selectable">False</property>
+                                    <property name="activatable">False</property>
+                                    <property name="child">
+                                      <object class="GtkEntry" id="code_entry">
+                                        <property name="activates-default">True</property>
+                                        <property name="placeholder-text" translatable="yes">Code</property>
+                                        <property name="margin-top">6</property>
+                                        <property name="margin-bottom">6</property>
+                                        <property name="margin-start">6</property>
+                                        <property name="margin-end">6</property>
+                                      </object>
+                                    </property>
                                   </object>
-                                </property>
+                                </child>
+                                <style>
+                                  <class name="content"/>
+                                </style>
                               </object>
                             </child>
-                            <style>
-                              <class name="content"/>
-                            </style>
+                            <child>
+                              <object class="GtkLabel" id="code_error_label">
+                                <property name="visible">False</property>
+                                <style>
+                                  <class name="error"/>
+                                </style>
+                              </object>
+                            </child>
                           </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="code_error_label">
-                            <property name="visible">False</property>
-                            <style>
-                              <class name="error"/>
-                            </style>
-                          </object>
-                        </child>
+                        </property>
                       </object>
                     </child>
                   </object>
@@ -156,42 +198,47 @@
                     <property name="icon-name">dialog-password-symbolic</property>
                     <property name="title" translatable="yes">Enter Your Password</property>
                     <child>
-                      <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">12</property>
-                        <child>
-                          <object class="GtkListBox">
+                      <object class="AdwClamp">
+                        <property name="maximum-size">300</property>
+                        <property name="tightening-threshold">200</property>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">12</property>
                             <child>
-                              <object class="GtkListBoxRow">
-                                <property name="halign">center</property>
-                                <property name="focusable">False</property>
-                                <property name="selectable">False</property>
-                                <property name="activatable">False</property>
-                                <property name="child">
-                                  <object class="GtkPasswordEntry" id="password_entry">
-                                    <property name="activates-default">True</property>
-                                    <property name="placeholder-text">Password</property>
-                                    <property name="margin-top">6</property>
-                                    <property name="margin-bottom">6</property>
-                                    <property name="margin-start">6</property>
-                                    <property name="margin-end">6</property>
+                              <object class="GtkListBox">
+                                <child>
+                                  <object class="GtkListBoxRow">
+                                    <property name="focusable">False</property>
+                                    <property name="selectable">False</property>
+                                    <property name="activatable">False</property>
+                                    <property name="child">
+                                      <object class="GtkPasswordEntry" id="password_entry">
+                                        <property name="activates-default">True</property>
+                                        <property name="placeholder-text" translatable="yes">Password</property>
+                                        <property name="margin-top">6</property>
+                                        <property name="margin-bottom">6</property>
+                                        <property name="margin-start">6</property>
+                                        <property name="margin-end">6</property>
+                                      </object>
+                                    </property>
                                   </object>
-                                </property>
+                                </child>
+                                <style>
+                                  <class name="content"/>
+                                </style>
                               </object>
                             </child>
-                            <style>
-                              <class name="content"/>
-                            </style>
+                            <child>
+                              <object class="GtkLabel" id="password_error_label">
+                                <property name="visible">False</property>
+                                <style>
+                                  <class name="error"/>
+                                </style>
+                              </object>
+                            </child>
                           </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="password_error_label">
-                            <property name="visible">False</property>
-                            <style>
-                              <class name="error"/>
-                            </style>
-                          </object>
-                        </child>
+                        </property>
                       </object>
                     </child>
                   </object>

--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -9,19 +9,19 @@
             <child type="start">
               <object class="GtkButton" id="previous_button">
                 <property name="visible">False</property>
-                <property name="action_name">login.previous</property>
+                <property name="action-name">login.previous</property>
+                <property name="use-underline">True</property>
                 <property name="label" translatable="yes">_Previous</property>
-                <property name="use_underline">True</property>
               </object>
             </child>
             <child type="end">
               <object class="GtkButton">
-                <property name="action_name">login.next</property>
+                <property name="action-name">login.next</property>
                 <property name="child">
                   <object class="GtkStack" id="next_stack">
                     <child>
                       <object class="GtkLabel" id="next_label">
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">True</property>
                         <property name="label" translatable="yes">_Next</property>
                       </object>
                     </child>
@@ -47,7 +47,7 @@
             <property name="vexpand">True</property>
             <child>
               <object class="AdwLeafletPage">
-                <property name="name">phone_number_page</property>
+                <property name="name">phone-number-page</property>
                 <property name="child">
                   <object class="AdwStatusPage">
                     <property name="valign">start</property>
@@ -98,12 +98,12 @@
             </child>
             <child>
               <object class="AdwLeafletPage">
-                <property name="name">code_page</property>
+                <property name="name">code-page</property>
                 <property name="child">
                   <object class="AdwStatusPage">
                     <property name="valign">start</property>
-                    <property name="icon-name">user-available-symbolic</property>
-                    <property name="title" translatable="yes">Welcome to Telegrand</property>
+                    <property name="icon-name">mail-send-symbolic</property>
+                    <property name="title" translatable="yes">Enter the Verification Code</property>
                     <child>
                       <object class="GtkBox">
                         <property name="orientation">vertical</property>
@@ -149,12 +149,12 @@
             </child>
             <child>
               <object class="AdwLeafletPage">
-                <property name="name">password_page</property>
+                <property name="name">password-page</property>
                 <property name="child">
                   <object class="AdwStatusPage">
                     <property name="valign">start</property>
-                    <property name="icon-name">user-available-symbolic</property>
-                    <property name="title" translatable="yes">Welcome to Telegrand</property>
+                    <property name="icon-name">dialog-password-symbolic</property>
+                    <property name="title" translatable="yes">Enter Your Password</property>
                     <child>
                       <object class="GtkBox">
                         <property name="orientation">vertical</property>

--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -8,6 +8,7 @@
           <object class="GtkHeaderBar">
             <child type="end">
               <object class="GtkButton">
+                <property name="action_name">login.next</property>
                 <property name="use_underline">True</property>
                 <property name="label" translatable="yes">_Next</property>
                 <style>
@@ -18,32 +19,81 @@
           </object>
         </child>
         <child>
-          <object class="AdwStatusPage">
-            <property name="icon-name">user-available-symbolic</property>
-            <property name="title" translatable="yes">Welcome to Telegrand</property>
+          <object class="AdwLeaflet" id="content">
+            <property name="can-unfold">False</property>
+            <property name="vexpand">True</property>
             <child>
-              <object class="GtkListBox">
-                <child>
-                  <object class="GtkListBoxRow">
-                    <property name="halign">center</property>
-                    <property name="focusable">False</property>
-                    <property name="selectable">False</property>
-                    <property name="activatable">False</property>
-                    <property name="child">
-                      <object class="GtkEntry" id="phone_number_entry">
-                        <property name="activates-default">True</property>
-                        <property name="placeholder-text">Phone Number</property>
-                        <property name="margin-top">6</property>
-                        <property name="margin-bottom">6</property>
-                        <property name="margin-start">6</property>
-                        <property name="margin-end">6</property>
+              <object class="AdwLeafletPage">
+                <property name="name">phone_number_page</property>
+                <property name="child">
+                  <object class="AdwStatusPage">
+                    <property name="valign">start</property>
+                    <property name="icon-name">user-available-symbolic</property>
+                    <property name="title" translatable="yes">Welcome to Telegrand</property>
+                    <child>
+                      <object class="GtkListBox">
+                        <child>
+                          <object class="GtkListBoxRow">
+                            <property name="halign">center</property>
+                            <property name="focusable">False</property>
+                            <property name="selectable">False</property>
+                            <property name="activatable">False</property>
+                            <property name="child">
+                              <object class="GtkEntry" id="phone_number_entry">
+                                <property name="activates-default">True</property>
+                                <property name="placeholder-text">Phone Number</property>
+                                <property name="margin-top">6</property>
+                                <property name="margin-bottom">6</property>
+                                <property name="margin-start">6</property>
+                                <property name="margin-end">6</property>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="content"/>
+                        </style>
                       </object>
-                    </property>
+                    </child>
                   </object>
-                </child>
-                <style>
-                  <class name="content"/>
-                </style>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwLeafletPage">
+                <property name="name">code_page</property>
+                <property name="child">
+                  <object class="AdwStatusPage">
+                    <property name="valign">start</property>
+                    <property name="icon-name">user-available-symbolic</property>
+                    <property name="title" translatable="yes">Welcome to Telegrand</property>
+                    <child>
+                      <object class="GtkListBox">
+                        <child>
+                          <object class="GtkListBoxRow">
+                            <property name="halign">center</property>
+                            <property name="focusable">False</property>
+                            <property name="selectable">False</property>
+                            <property name="activatable">False</property>
+                            <property name="child">
+                              <object class="GtkEntry" id="code_entry">
+                                <property name="activates-default">True</property>
+                                <property name="placeholder-text">Code</property>
+                                <property name="margin-top">6</property>
+                                <property name="margin-bottom">6</property>
+                                <property name="margin-start">6</property>
+                                <property name="margin-end">6</property>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="content"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                </property>
               </object>
             </child>
           </object>

--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -97,7 +97,7 @@
                                       <object class="AdwActionRow">
                                         <property name="title" translatable="yes">Encryption Key</property>
                                         <child>
-                                          <object class="GtkPasswordEntry" id="encryption_key_entry">
+                                          <object class="GtkPasswordEntry" id="custom_encryption_key_entry">
                                             <property name="activates-default">True</property>
                                             <property name="valign">center</property>
                                           </object>
@@ -124,7 +124,7 @@
                               </object>
                             </child>
                             <child>
-                              <object class="GtkLabel" id="phone_number_error_label">
+                              <object class="GtkLabel" id="welcome_page_error_label">
                                 <property name="visible">False</property>
                                 <style>
                                   <class name="error"/>
@@ -237,6 +237,62 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="password_error_label">
+                                <property name="visible">False</property>
+                                <style>
+                                  <class name="error"/>
+                                </style>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwLeafletPage">
+                <property name="name">encryption-key-page</property>
+                <property name="child">
+                  <object class="AdwStatusPage">
+                    <property name="valign">start</property>
+                    <property name="icon-name">system-lock-screen-symbolic</property>
+                    <property name="title" translatable="yes">Enter the Encryption Key</property>
+                    <child>
+                      <object class="AdwClamp">
+                        <property name="maximum-size">300</property>
+                        <property name="tightening-threshold">200</property>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkListBox">
+                                <child>
+                                  <object class="GtkListBoxRow">
+                                    <property name="focusable">False</property>
+                                    <property name="selectable">False</property>
+                                    <property name="activatable">False</property>
+                                    <property name="child">
+                                      <object class="GtkPasswordEntry" id="encryption_key_entry">
+                                        <property name="activates-default">True</property>
+                                        <property name="placeholder-text" translatable="yes">Encryption Key</property>
+                                        <property name="margin-top">6</property>
+                                        <property name="margin-bottom">6</property>
+                                        <property name="margin-start">6</property>
+                                        <property name="margin-end">6</property>
+                                      </object>
+                                    </property>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="content"/>
+                                </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="encryption_key_error_label">
                                 <property name="visible">False</property>
                                 <style>
                                   <class name="error"/>

--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -31,28 +31,42 @@
                     <property name="icon-name">user-available-symbolic</property>
                     <property name="title" translatable="yes">Welcome to Telegrand</property>
                     <child>
-                      <object class="GtkListBox">
+                      <object class="GtkBox">
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">12</property>
                         <child>
-                          <object class="GtkListBoxRow">
-                            <property name="halign">center</property>
-                            <property name="focusable">False</property>
-                            <property name="selectable">False</property>
-                            <property name="activatable">False</property>
-                            <property name="child">
-                              <object class="GtkEntry" id="phone_number_entry">
-                                <property name="activates-default">True</property>
-                                <property name="placeholder-text">Phone Number</property>
-                                <property name="margin-top">6</property>
-                                <property name="margin-bottom">6</property>
-                                <property name="margin-start">6</property>
-                                <property name="margin-end">6</property>
+                          <object class="GtkListBox">
+                            <child>
+                              <object class="GtkListBoxRow">
+                                <property name="halign">center</property>
+                                <property name="focusable">False</property>
+                                <property name="selectable">False</property>
+                                <property name="activatable">False</property>
+                                <property name="child">
+                                  <object class="GtkEntry" id="phone_number_entry">
+                                    <property name="activates-default">True</property>
+                                    <property name="placeholder-text">Phone Number</property>
+                                    <property name="margin-top">6</property>
+                                    <property name="margin-bottom">6</property>
+                                    <property name="margin-start">6</property>
+                                    <property name="margin-end">6</property>
+                                  </object>
+                                </property>
                               </object>
-                            </property>
+                            </child>
+                            <style>
+                              <class name="content"/>
+                            </style>
                           </object>
                         </child>
-                        <style>
-                          <class name="content"/>
-                        </style>
+                        <child>
+                          <object class="GtkLabel" id="phone_number_error_label">
+                            <property name="visible">False</property>
+                            <style>
+                              <class name="error"/>
+                            </style>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>
@@ -68,28 +82,42 @@
                     <property name="icon-name">user-available-symbolic</property>
                     <property name="title" translatable="yes">Welcome to Telegrand</property>
                     <child>
-                      <object class="GtkListBox">
+                      <object class="GtkBox">
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">12</property>
                         <child>
-                          <object class="GtkListBoxRow">
-                            <property name="halign">center</property>
-                            <property name="focusable">False</property>
-                            <property name="selectable">False</property>
-                            <property name="activatable">False</property>
-                            <property name="child">
-                              <object class="GtkEntry" id="code_entry">
-                                <property name="activates-default">True</property>
-                                <property name="placeholder-text">Code</property>
-                                <property name="margin-top">6</property>
-                                <property name="margin-bottom">6</property>
-                                <property name="margin-start">6</property>
-                                <property name="margin-end">6</property>
+                          <object class="GtkListBox">
+                            <child>
+                              <object class="GtkListBoxRow">
+                                <property name="halign">center</property>
+                                <property name="focusable">False</property>
+                                <property name="selectable">False</property>
+                                <property name="activatable">False</property>
+                                <property name="child">
+                                  <object class="GtkEntry" id="code_entry">
+                                    <property name="activates-default">True</property>
+                                    <property name="placeholder-text">Code</property>
+                                    <property name="margin-top">6</property>
+                                    <property name="margin-bottom">6</property>
+                                    <property name="margin-start">6</property>
+                                    <property name="margin-end">6</property>
+                                  </object>
+                                </property>
                               </object>
-                            </property>
+                            </child>
+                            <style>
+                              <class name="content"/>
+                            </style>
                           </object>
                         </child>
-                        <style>
-                          <class name="content"/>
-                        </style>
+                        <child>
+                          <object class="GtkLabel" id="code_error_label">
+                            <property name="visible">False</property>
+                            <style>
+                              <class name="error"/>
+                            </style>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>
@@ -105,28 +133,42 @@
                     <property name="icon-name">user-available-symbolic</property>
                     <property name="title" translatable="yes">Welcome to Telegrand</property>
                     <child>
-                      <object class="GtkListBox">
+                      <object class="GtkBox">
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">12</property>
                         <child>
-                          <object class="GtkListBoxRow">
-                            <property name="halign">center</property>
-                            <property name="focusable">False</property>
-                            <property name="selectable">False</property>
-                            <property name="activatable">False</property>
-                            <property name="child">
-                              <object class="GtkPasswordEntry" id="password_entry">
-                                <property name="activates-default">True</property>
-                                <property name="placeholder-text">Password</property>
-                                <property name="margin-top">6</property>
-                                <property name="margin-bottom">6</property>
-                                <property name="margin-start">6</property>
-                                <property name="margin-end">6</property>
+                          <object class="GtkListBox">
+                            <child>
+                              <object class="GtkListBoxRow">
+                                <property name="halign">center</property>
+                                <property name="focusable">False</property>
+                                <property name="selectable">False</property>
+                                <property name="activatable">False</property>
+                                <property name="child">
+                                  <object class="GtkPasswordEntry" id="password_entry">
+                                    <property name="activates-default">True</property>
+                                    <property name="placeholder-text">Password</property>
+                                    <property name="margin-top">6</property>
+                                    <property name="margin-bottom">6</property>
+                                    <property name="margin-start">6</property>
+                                    <property name="margin-end">6</property>
+                                  </object>
+                                </property>
                               </object>
-                            </property>
+                            </child>
+                            <style>
+                              <class name="content"/>
+                            </style>
                           </object>
                         </child>
-                        <style>
-                          <class name="content"/>
-                        </style>
+                        <child>
+                          <object class="GtkLabel" id="password_error_label">
+                            <property name="visible">False</property>
+                            <style>
+                              <class name="error"/>
+                            </style>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,9 @@ iconsdir = datadir / 'icons'
 podir = meson.source_root() / 'po'
 gettext_package = meson.project_name()
 
+tg_api_id = get_option('tg_api_id')
+tg_api_hash = get_option('tg_api_hash')
+
 if get_option('profile') == 'development'
   profile = 'Devel'
   vcs_tag = run_command('git', 'rev-parse', '--short', 'HEAD').stdout().strip()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,16 @@ option(
   value: 'default',
   description: 'The build profile for Telegrand. One of "default" or "development".'
 )
+
+option(
+  'tg_api_id',
+  type: 'integer',
+  value: 1,
+  description: 'Application identifier for accessing the Telegram API, which can be obtained at https://my.telegram.org.'
+)
+
+option(
+  'tg_api_hash',
+  type: 'string',
+  description: 'Hash of the Application identifier for accessing the Telegram API, which can be obtained at https://my.telegram.org.'
+)

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,3 +1,4 @@
+data/resources/ui/login.ui
 data/resources/ui/shortcuts.ui
 data/resources/ui/window.ui
 data/com.github.melix99.telegrand.desktop.in.in

--- a/src/config.rs.in
+++ b/src/config.rs.in
@@ -4,4 +4,6 @@ pub const LOCALEDIR: &str = @LOCALEDIR@;
 pub const PKGDATADIR: &str = @PKGDATADIR@;
 pub const PROFILE: &str = @PROFILE@;
 pub const RESOURCES_FILE: &str = concat!(@PKGDATADIR@, "/resources.gresource");
+pub const TG_API_HASH: &str = @TG_API_HASH@;
+pub const TG_API_ID: i32 = @TG_API_ID@;
 pub const VERSION: &str = @VERSION@;

--- a/src/login.rs
+++ b/src/login.rs
@@ -13,7 +13,7 @@ use tdgrand::{
 mod imp {
     use super::*;
     use adw::subclass::prelude::BinImpl;
-    use gtk::CompositeTemplate;
+    use gtk::{CompositeTemplate, gio};
     use std::cell::Cell;
 
     #[derive(Debug, Default, CompositeTemplate)]
@@ -36,6 +36,8 @@ mod imp {
         pub phone_number_error_label: TemplateChild<gtk::Label>,
         #[template_child]
         pub encryption_key_entry: TemplateChild<gtk::PasswordEntry>,
+        #[template_child]
+        pub use_test_dc_switch: TemplateChild<gtk::Switch>,
         #[template_child]
         pub code_entry: TemplateChild<gtk::Entry>,
         #[template_child]
@@ -79,6 +81,13 @@ mod imp {
                     previous_button.set_visible(true);
                 }
             }));
+
+            // Bind the use-test-dc setting to the relative switch
+            let use_test_dc_switch = &*priv_.use_test_dc_switch;
+            let settings = gio::Settings::new(config::APP_ID);
+            settings
+                .bind("use-test-dc", use_test_dc_switch, "state")
+                .build();
         }
     }
 
@@ -178,9 +187,11 @@ impl Login {
     }
 
     fn send_tdlib_parameters(&self) {
-        // TODO: make this parameters customizable
-        let client_id = imp::Login::from_instance(self).client_id.get();
+        let priv_ = imp::Login::from_instance(self);
+        let client_id = priv_.client_id.get();
+        let use_test_dc = priv_.use_test_dc_switch.state();
         let params = TdlibParameters {
+            use_test_dc: use_test_dc,
             database_directory: "telegrand".to_string(),
             api_id: config::TG_API_ID,
             api_hash: config::TG_API_HASH.to_string(),

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,6 +1,5 @@
 use crate::utils::do_async;
 use crate::config;
-use adw::NavigationDirection;
 use glib::clone;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
@@ -95,9 +94,8 @@ impl Login {
             AuthorizationState::WaitPhoneNumber => {
             }
             AuthorizationState::WaitCode(_) => {
-                // Go to the next page
                 let content = &imp::Login::from_instance(self).content;
-                content.navigate(NavigationDirection::Forward);
+                content.set_visible_child_name("code_page");
             }
             AuthorizationState::WaitOtherDeviceConfirmation(_) => {
                 todo!()
@@ -106,9 +104,8 @@ impl Login {
                 todo!()
             }
             AuthorizationState::WaitPassword(_) => {
-                // Go to the next page
                 let content = &imp::Login::from_instance(self).content;
-                content.navigate(NavigationDirection::Forward);
+                content.set_visible_child_name("password_page");
             }
             AuthorizationState::Ready => {
                 todo!()

--- a/src/login.rs
+++ b/src/login.rs
@@ -6,10 +6,12 @@ mod imp {
     use super::*;
     use adw::subclass::prelude::BinImpl;
     use gtk::CompositeTemplate;
+    use std::cell::Cell;
 
     #[derive(Debug, Default, CompositeTemplate)]
     #[template(resource = "/com/github/melix99/telegrand/ui/login.ui")]
     pub struct Login {
+        pub client_id: Cell<i32>,
     }
 
     #[glib::object_subclass]
@@ -45,5 +47,10 @@ glib::wrapper! {
 impl Login {
     pub fn new() -> Self {
         glib::Object::new(&[]).expect("Failed to create Login")
+    }
+
+    pub fn set_client_id(&self, client_id: i32) {
+        let priv_ = imp::Login::from_instance(self);
+        priv_.client_id.set(client_id);
     }
 }

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,5 +1,7 @@
-use crate::{RUNTIME, config};
+use crate::utils::do_async;
+use crate::config;
 use adw::NavigationDirection;
+use glib::clone;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::glib;
@@ -24,9 +26,15 @@ mod imp {
         #[template_child]
         pub phone_number_entry: TemplateChild<gtk::Entry>,
         #[template_child]
+        pub phone_number_error_label: TemplateChild<gtk::Label>,
+        #[template_child]
         pub code_entry: TemplateChild<gtk::Entry>,
         #[template_child]
+        pub code_error_label: TemplateChild<gtk::Label>,
+        #[template_child]
         pub password_entry: TemplateChild<gtk::PasswordEntry>,
+        #[template_child]
+        pub password_error_label: TemplateChild<gtk::Label>,
     }
 
     #[glib::object_subclass]
@@ -139,49 +147,94 @@ impl Login {
             application_version: config::VERSION.to_string(),
             ..TdlibParameters::default()
         };
-
-        // TODO: handle errors
-        RUNTIME.spawn(async move {
-            functions::set_tdlib_parameters(client_id, params).await.unwrap();
-        });
+        do_async(
+            glib::PRIORITY_DEFAULT_IDLE,
+            async move {
+                functions::set_tdlib_parameters(client_id, params).await
+            },
+            clone!(@weak self as obj => move |result| async move {
+                if let Err(err) = result {
+                    let phone_number_error_label = &imp::Login::from_instance(&obj).phone_number_error_label;
+                    phone_number_error_label.set_text(&err.message);
+                    phone_number_error_label.set_visible(true);
+                }
+            }),
+        );
     }
 
     fn send_encryption_key(&self) {
-        // TODO: make the key customizable and handle errors
+        // TODO: make the key customizable
         let client_id = imp::Login::from_instance(self).client_id.get();
-        RUNTIME.spawn(async move {
-            functions::check_database_encryption_key(client_id, String::new()).await.unwrap();
-        });
+        do_async(
+            glib::PRIORITY_DEFAULT_IDLE,
+            async move {
+                functions::check_database_encryption_key(client_id, String::new()).await
+            },
+            clone!(@weak self as obj => move |result| async move {
+                if let Err(err) = result {
+                    let phone_number_error_label = &imp::Login::from_instance(&obj).phone_number_error_label;
+                    phone_number_error_label.set_text(&err.message);
+                    phone_number_error_label.set_visible(true);
+                }
+            }),
+        );
     }
 
     fn send_phone_number(&self) {
-        // TODO: handle errors
         let priv_ = imp::Login::from_instance(self);
         let client_id = priv_.client_id.get();
         let phone_number = priv_.phone_number_entry.text().to_string();
         let settings = PhoneNumberAuthenticationSettings::default();
-        RUNTIME.spawn(async move {
-            functions::set_authentication_phone_number(client_id, phone_number, settings).await.unwrap();
-        });
+        do_async(
+            glib::PRIORITY_DEFAULT_IDLE,
+            async move {
+                functions::set_authentication_phone_number(client_id, phone_number, settings).await
+            },
+            clone!(@weak self as obj => move |result| async move {
+                if let Err(err) = result {
+                    let phone_number_error_label = &imp::Login::from_instance(&obj).phone_number_error_label;
+                    phone_number_error_label.set_text(&err.message);
+                    phone_number_error_label.set_visible(true);
+                }
+            }),
+        );
     }
 
     fn send_code(&self) {
-        // TODO: handle errors
         let priv_ = imp::Login::from_instance(self);
         let client_id = priv_.client_id.get();
         let code = priv_.code_entry.text().to_string();
-        RUNTIME.spawn(async move {
-            functions::check_authentication_code(client_id, code).await.unwrap();
-        });
+        do_async(
+            glib::PRIORITY_DEFAULT_IDLE,
+            async move {
+                functions::check_authentication_code(client_id, code).await
+            },
+            clone!(@weak self as obj => move |result| async move {
+                if let Err(err) = result {
+                    let code_error_label = &imp::Login::from_instance(&obj).code_error_label;
+                    code_error_label.set_text(&err.message);
+                    code_error_label.set_visible(true);
+                }
+            }),
+        );
     }
 
     fn send_password(&self) {
-        // TODO: handle errors
         let priv_ = imp::Login::from_instance(self);
         let client_id = priv_.client_id.get();
         let password = priv_.password_entry.text().to_string();
-        RUNTIME.spawn(async move {
-            functions::check_authentication_password(client_id, password).await.unwrap();
-        });
+        do_async(
+            glib::PRIORITY_DEFAULT_IDLE,
+            async move {
+                functions::check_authentication_password(client_id, password).await
+            },
+            clone!(@weak self as obj => move |result| async move {
+                if let Err(err) = result {
+                    let password_error_label = &imp::Login::from_instance(&obj).password_error_label;
+                    password_error_label.set_text(&err.message);
+                    password_error_label.set_visible(true);
+                }
+            }),
+        );
     }
 }

--- a/src/login.rs
+++ b/src/login.rs
@@ -71,6 +71,8 @@ mod imp {
 
     impl ObjectImpl for Login {
         fn constructed(&self, obj: &Self::Type) {
+            obj.action_set_enabled("login.next", false);
+
             self.parent_constructed(obj);
 
             // Show the previous button on all pages except the
@@ -123,6 +125,7 @@ impl Login {
                 self.send_encryption_key(true);
             }
             AuthorizationState::WaitPhoneNumber => {
+                self.action_set_enabled("login.next", true);
             }
             AuthorizationState::WaitCode(_) => {
                 let content = &imp::Login::from_instance(self).content;
@@ -245,6 +248,7 @@ impl Login {
                     // Otherwise just show the error in the relative label.
                     if use_empty_key {
                         priv_.content.set_visible_child_name("encryption-key-page");
+                        obj.action_set_enabled("login.next", true);
                     } else {
                         let encryption_key_error_label = &priv_.encryption_key_error_label;
                         encryption_key_error_label.set_text(&err.message);

--- a/src/login.rs
+++ b/src/login.rs
@@ -113,12 +113,7 @@ impl Login {
             AuthorizationState::LoggingOut => {
                 todo!()
             }
-            AuthorizationState::Closing => {
-                todo!()
-            }
-            AuthorizationState::Closed => {
-                todo!()
-            }
+            _ => ()
         }
     }
 

--- a/src/login.rs
+++ b/src/login.rs
@@ -25,6 +25,8 @@ mod imp {
         pub phone_number_entry: TemplateChild<gtk::Entry>,
         #[template_child]
         pub code_entry: TemplateChild<gtk::Entry>,
+        #[template_child]
+        pub password_entry: TemplateChild<gtk::PasswordEntry>,
     }
 
     #[glib::object_subclass]
@@ -93,7 +95,9 @@ impl Login {
                 todo!()
             }
             AuthorizationState::WaitPassword(_) => {
-                todo!()
+                // Go to the next page
+                let content = &imp::Login::from_instance(self).content;
+                content.navigate(NavigationDirection::Forward);
             }
             AuthorizationState::Ready => {
                 todo!()
@@ -118,6 +122,8 @@ impl Login {
             self.send_phone_number();
         } else if visible_page == "code_page" {
             self.send_code();
+        } else if visible_page == "password_page" {
+            self.send_password();
         }
     }
 
@@ -166,6 +172,16 @@ impl Login {
         let code = priv_.code_entry.text().to_string();
         RUNTIME.spawn(async move {
             functions::check_authentication_code(client_id, code).await.unwrap();
+        });
+    }
+
+    fn send_password(&self) {
+        // TODO: handle errors
+        let priv_ = imp::Login::from_instance(self);
+        let client_id = priv_.client_id.get();
+        let password = priv_.password_entry.text().to_string();
+        RUNTIME.spawn(async move {
+            functions::check_authentication_password(client_id, password).await.unwrap();
         });
     }
 }

--- a/src/login.rs
+++ b/src/login.rs
@@ -75,13 +75,13 @@ mod imp {
 
             self.parent_constructed(obj);
 
-            // Show the previous button on all pages except the
-            // "phone number" page
+            // Show the previous button on all pages except in the
+            // "phone number" and "encryption key" pages
             let priv_ = imp::Login::from_instance(obj);
             let previous_button = &*priv_.previous_button;
             priv_.content.connect_property_visible_child_name_notify(clone!(@weak previous_button => move |content| {
                 let visible_page = content.visible_child_name().unwrap();
-                if visible_page == "phone-number-page" {
+                if visible_page == "phone-number-page" || visible_page == "encryption-key-page" {
                     previous_button.set_visible(false);
                 } else {
                     previous_button.set_visible(true);

--- a/src/login.rs
+++ b/src/login.rs
@@ -71,7 +71,7 @@ mod imp {
             let previous_button = &*priv_.previous_button;
             priv_.content.connect_property_visible_child_name_notify(clone!(@weak previous_button => move |content| {
                 let visible_page = content.visible_child_name().unwrap();
-                if visible_page == "phone_number_page" {
+                if visible_page == "phone-number-page" {
                     previous_button.set_visible(false);
                 } else {
                     previous_button.set_visible(true);
@@ -111,7 +111,7 @@ impl Login {
             }
             AuthorizationState::WaitCode(_) => {
                 let content = &imp::Login::from_instance(self).content;
-                content.set_visible_child_name("code_page");
+                content.set_visible_child_name("code-page");
             }
             AuthorizationState::WaitOtherDeviceConfirmation(_) => {
                 todo!()
@@ -121,7 +121,7 @@ impl Login {
             }
             AuthorizationState::WaitPassword(_) => {
                 let content = &imp::Login::from_instance(self).content;
-                content.set_visible_child_name("password_page");
+                content.set_visible_child_name("password-page");
             }
             AuthorizationState::Ready => {
                 todo!()
@@ -135,7 +135,7 @@ impl Login {
 
     fn previous(&self) {
         let content = &imp::Login::from_instance(self).content;
-        content.set_visible_child_name("phone_number_page");
+        content.set_visible_child_name("phone-number-page");
     }
 
     fn next(&self) {
@@ -143,11 +143,11 @@ impl Login {
 
         let content = &imp::Login::from_instance(self).content;
         let visible_page = content.visible_child_name().unwrap();
-        if visible_page == "phone_number_page" {
+        if visible_page == "phone-number-page" {
             self.send_phone_number();
-        } else if visible_page == "code_page" {
+        } else if visible_page == "code-page" {
             self.send_code();
-        } else if visible_page == "password_page" {
+        } else if visible_page == "password-page" {
             self.send_password();
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod application;
 #[rustfmt::skip]
 mod config;
 mod login;
+mod utils;
 mod window;
 
 use self::application::Application;

--- a/src/meson.build
+++ b/src/meson.build
@@ -25,6 +25,7 @@ sources = files(
   'config.rs',
   'login.rs',
   'main.rs',
+  'utils.rs',
   'window.rs',
 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,6 +5,8 @@ global_conf.set_quoted('PROFILE', profile)
 global_conf.set_quoted('VERSION', version + version_suffix)
 global_conf.set_quoted('GETTEXT_PACKAGE', gettext_package)
 global_conf.set_quoted('LOCALEDIR', localedir)
+global_conf.set('TG_API_ID', tg_api_id)
+global_conf.set_quoted('TG_API_HASH', tg_api_hash)
 config = configure_file(
   input: 'config.rs.in',
   output: 'config.rs',

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,23 @@
+use crate::RUNTIME;
+use gtk::glib;
+use std::future::Future;
+
+// Function from https://gitlab.gnome.org/GNOME/fractal/-/blob/fractal-next/src/utils.rs
+pub fn do_async<
+    R: Send + 'static,
+    F1: Future<Output = R> + Send + 'static,
+    F2: Future<Output = ()> + 'static,
+    FN: FnOnce(R) -> F2 + 'static,
+>(
+    priority: glib::source::Priority,
+    tokio_fut: F1,
+    glib_closure: FN,
+) {
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+
+    glib::MainContext::default().spawn_local_with_priority(priority, async move {
+        glib_closure(receiver.await.unwrap()).await
+    });
+
+    RUNTIME.spawn(async move { sender.send(tokio_fut.await) });
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -192,8 +192,9 @@ impl Window {
     }
 
     fn handle_update(&self, update: Update) {
-        if let Update::AuthorizationState(_update) = update {
-            todo!()
+        if let Update::AuthorizationState(update) = update {
+            let login = &imp::Window::from_instance(self).login;
+            login.set_authorization_state(update.authorization_state);
         }
     }
 }


### PR DESCRIPTION
TO-DO list:

- [x] Handle basic login (default TDLib params, empty encryption key, phone number and verification code)
- [x] Handle 2FA state
- [x] Allow to set non-empty encryption key
- [x] Allow to set custom TDLib's parameters (just the use_test_dc is fine for now)
- [x] Try to login with an empty encryption key automatically, if it fails ask the key to the user
- [x] Close the client when the user closes the window (handling the close state)
- [x] Add a "previous" button to allow to go back with the login pages (e.g. if the user wants to change the phone number)
- [x] Handle all authorization errors

Closes #21 and #14.