### PR TITLE
Implement notifications

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -8,4 +8,5 @@ data/resources/ui/shortcuts.ui
 data/resources/ui/sidebar.ui
 
 src/utils.rs
+src/window.rs
 src/session/content/message_row.rs

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -7,5 +7,5 @@ data/resources/ui/login.ui
 data/resources/ui/shortcuts.ui
 data/resources/ui/sidebar.ui
 
-src/session/chat/chat.rs
+src/utils.rs
 src/session/content/message_row.rs

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,23 @@
+use gettextrs::gettext;
 use gtk::glib;
 use std::future::Future;
+use tdgrand::enums::MessageContent as TelegramMessageContent;
 
 use crate::RUNTIME;
+
+pub fn stringify_message_content(content: TelegramMessageContent, use_markup: bool) -> String {
+    match content {
+        TelegramMessageContent::MessageText(content) => content.text.text,
+        _ => {
+            let text = gettext("Unsupported message");
+            if use_markup {
+                format!("<i>{}</i>", text)
+            } else {
+                text
+            }
+        }
+    }
+}
 
 // Function from https://gitlab.gnome.org/GNOME/fractal/-/blob/fractal-next/src/utils.rs
 pub fn do_async<


### PR DESCRIPTION
Updates handled:
- [x] ~Notification~ GApplication can't edit notifications without showing them again, so this update is useless
- [x] NotificationGroup

Notification types handled:
- [x] NewMessage
- [x] ~NewSecretChat~ I'll postpone this until Telegrand will have full support for secret chats (it should arrive soon™)
- [x] NewCall
- [x] ~NewPushMessage~ Apparently they're not needed for Telegrand for now because this function is meant for mobile where apps in the background are suspended. Idk if the mobile linux distros suspend the apps like Android and iOS do, so for now I think that I'll leave this as is. Future support for them can always be added if needed.

Other needed features:
- [x] If a notification is from a group, show the sender
- [x] ~Open the relative chat when clicking the notification~ Unfortunately I have to postpone this feature because it requires some bigger modifications to the code than I initially thought, I'll open an issue about it after the merge

Closes #34 