### PR TITLE
message-row: Add http:// to URLs without protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,7 @@ dependencies = [
  "log",
  "once_cell",
  "pretty_env_logger",
+ "regex",
  "tdgrand",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ indexmap = "1.7"
 log = "0.4"
 once_cell = "1.8"
 pretty_env_logger = "0.4"
+regex = "1.5"
 tdgrand = { git = "https://github.com/melix99/tdgrand", branch = "main" }
 tokio = { version = "1.9", features = ["rt-multi-thread"] }
 

--- a/src/session/content/message_row.rs
+++ b/src/session/content/message_row.rs
@@ -8,11 +8,11 @@ use tdgrand::types::FormattedText;
 
 use crate::session::chat::{BoxedMessageContent, Message};
 use crate::session::{Chat, User};
-use crate::utils::escape;
+use crate::utils::{escape, linkify};
 
 fn convert_to_markup(text: String, entity: &TextEntityType) -> String {
     match entity {
-        TextEntityType::Url => format!("<a href='{0}'>{0}</a>", text),
+        TextEntityType::Url => format!("<a href='{}'>{}</a>", linkify(&text), text),
         TextEntityType::EmailAddress => format!("<a href='mailto:{0}'>{0}</a>", text),
         TextEntityType::PhoneNumber => format!("<a href='tel:{0}'>{0}</a>", text),
         TextEntityType::Bold => format!("<b>{}</b>", text),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,14 +1,26 @@
 use gettextrs::gettext;
 use gtk::glib;
+use once_cell::sync::Lazy;
+use regex::Regex;
 use std::future::Future;
 use tdgrand::enums::MessageContent as TelegramMessageContent;
 
 use crate::RUNTIME;
 
+pub static PROTOCOL_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\w+://").unwrap());
+
 pub fn escape(text: &str) -> String {
     text.replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")
+}
+
+pub fn linkify(text: &str) -> String {
+    if !PROTOCOL_RE.is_match(text) {
+        format!("http://{}", text)
+    } else {
+        text.to_string()
+    }
 }
 
 pub fn stringify_message_content(content: TelegramMessageContent, use_markup: bool) -> String {


### PR DESCRIPTION
This fixes opening URLs without a protocol specified.

I'm not sure if using Regex is the best option here, but I see that it was already being used in other crates, so no additional crates will be compiled.