### PR TITLE
Switch flatpak runtime version to stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,13 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-nightly
+      image: bilelmoussaoui/flatpak-github-actions:gnome-40
       options: --privileged
     steps:
     - uses: actions/checkout@v2
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
       with:
         bundle: telegrand.flatpak
         manifest-path: build-aux/com.github.melix99.telegrand.Devel.json
-        repository-name: flathub-beta
         run-tests: true
         cache-key: flatpak-builder-${{ github.sha }}

--- a/build-aux/com.github.melix99.telegrand.Devel.json
+++ b/build-aux/com.github.melix99.telegrand.Devel.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.melix99.telegrand.Devel",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "master",
+    "runtime-version": "40",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
Rust + gnome-nightly broke again, so the only way to make flatpak builds work again is switching to 40 runtime (again). From now on I'll just use the stable versions to avoid bothering with these problems again.