### PR TITLE
Show icon for pinned chats in sidebar

### DIFF
--- a/data/resources/ui/sidebar-chat-row.ui
+++ b/data/resources/ui/sidebar-chat-row.ui
@@ -69,50 +69,31 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkStack" id="badge_stack">
-                    <child>
-                      <object class="GtkStackPage">
-                        <property name="name">empty</property>
-                        <property name="child">
-                          <object class="GtkBox">
-                            <property name="can-focus">False</property>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkStackPage">
-                        <property name="name">pin</property>
-                        <property name="child">
-                          <object class="GtkImage">
-                            <property name="icon-name">view-pin-symbolic</property>
-                            <style>
-                              <class name="dim-label"/>
-                            </style>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkStackPage">
-                        <property name="name">unread</property>
-                        <property name="child">
-                          <object class="GtkLabel">
-                            <property name="valign">center</property>
-                            <property name="ellipsize">end</property>
-                            <property name="justify">center</property>
-                            <binding name="label">
-                              <lookup name="unread-count">
-                                <lookup name="chat">SidebarChatRow</lookup>
-                              </lookup>
-                            </binding>
-                            <style>
-                              <class name="unread-count"/>
-                            </style>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
+                  <object class="GtkImage" id="pin_image">
+                    <property name="icon-name">view-pin-symbolic</property>
+                    <style>
+                      <class name="dim-label"/>
+                    </style>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="valign">center</property>
+                    <property name="ellipsize">end</property>
+                    <property name="justify">center</property>
+                    <binding name="label">
+                      <lookup name="unread-count">
+                        <lookup name="chat">SidebarChatRow</lookup>
+                      </lookup>
+                    </binding>
+                    <binding name="visible">
+                      <lookup name="unread-count">
+                        <lookup name="chat">SidebarChatRow</lookup>
+                      </lookup>
+                    </binding>
+                    <style>
+                      <class name="unread-count"/>
+                    </style>
                   </object>
                 </child>
               </object>

--- a/data/resources/ui/sidebar-chat-row.ui
+++ b/data/resources/ui/sidebar-chat-row.ui
@@ -58,6 +58,7 @@
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="last_message_label">
+                    <property name="hexpand">True</property>
                     <property name="halign">start</property>
                     <property name="ellipsize">end</property>
                     <property name="single-line-mode">True</property>
@@ -68,25 +69,40 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkLabel">
-                    <property name="hexpand">True</property>
-                    <property name="halign">end</property>
-                    <property name="valign">center</property>
-                    <property name="ellipsize">end</property>
-                    <property name="justify">center</property>
-                    <binding name="label">
-                      <lookup name="unread-count">
-                        <lookup name="chat">SidebarChatRow</lookup>
-                      </lookup>
-                    </binding>
-                    <binding name="visible">
-                      <lookup name="unread-count">
-                        <lookup name="chat">SidebarChatRow</lookup>
-                      </lookup>
-                    </binding>
-                    <style>
-                      <class name="unread-count"/>
-                    </style>
+                  <object class="GtkStack">
+                    <child>
+                      <object class="GtkImage">
+                        <property name="icon-name">view-pin-symbolic</property>
+                        <binding name="visible">
+                          <lookup name="is-pinned">
+                            <lookup name="chat">SidebarChatRow</lookup>
+                          </lookup>
+                        </binding>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="valign">center</property>
+                        <property name="ellipsize">end</property>
+                        <property name="justify">center</property>
+                        <binding name="label">
+                          <lookup name="unread-count">
+                            <lookup name="chat">SidebarChatRow</lookup>
+                          </lookup>
+                        </binding>
+                        <binding name="visible">
+                          <lookup name="unread-count">
+                            <lookup name="chat">SidebarChatRow</lookup>
+                          </lookup>
+                        </binding>
+                        <style>
+                          <class name="unread-count"/>
+                        </style>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/data/resources/ui/sidebar-chat-row.ui
+++ b/data/resources/ui/sidebar-chat-row.ui
@@ -69,38 +69,48 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkStack">
+                  <object class="GtkStack" id="badge_stack">
                     <child>
-                      <object class="GtkImage">
-                        <property name="icon-name">view-pin-symbolic</property>
-                        <binding name="visible">
-                          <lookup name="is-pinned">
-                            <lookup name="chat">SidebarChatRow</lookup>
-                          </lookup>
-                        </binding>
-                        <style>
-                          <class name="dim-label"/>
-                        </style>
+                      <object class="GtkStackPage">
+                        <property name="name">empty</property>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <property name="can-focus">False</property>
+                          </object>
+                        </property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkLabel">
-                        <property name="valign">center</property>
-                        <property name="ellipsize">end</property>
-                        <property name="justify">center</property>
-                        <binding name="label">
-                          <lookup name="unread-count">
-                            <lookup name="chat">SidebarChatRow</lookup>
-                          </lookup>
-                        </binding>
-                        <binding name="visible">
-                          <lookup name="unread-count">
-                            <lookup name="chat">SidebarChatRow</lookup>
-                          </lookup>
-                        </binding>
-                        <style>
-                          <class name="unread-count"/>
-                        </style>
+                      <object class="GtkStackPage">
+                        <property name="name">pin</property>
+                        <property name="child">
+                          <object class="GtkImage">
+                            <property name="icon-name">view-pin-symbolic</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkStackPage">
+                        <property name="name">unread</property>
+                        <property name="child">
+                          <object class="GtkLabel">
+                            <property name="valign">center</property>
+                            <property name="ellipsize">end</property>
+                            <property name="justify">center</property>
+                            <binding name="label">
+                              <lookup name="unread-count">
+                                <lookup name="chat">SidebarChatRow</lookup>
+                              </lookup>
+                            </binding>
+                            <style>
+                              <class name="unread-count"/>
+                            </style>
+                          </object>
+                        </property>
                       </object>
                     </child>
                   </object>

--- a/src/session/sidebar/chat_row.rs
+++ b/src/session/sidebar/chat_row.rs
@@ -32,7 +32,7 @@ mod imp {
         #[template_child]
         pub last_message_label: TemplateChild<gtk::Label>,
         #[template_child]
-        pub badge_stack: TemplateChild<gtk::Stack>,
+        pub pin_image: TemplateChild<gtk::Image>,
     }
 
     #[glib::object_subclass]
@@ -202,40 +202,20 @@ impl ChatRow {
                 Some(&chat_expression),
                 "unread-count",
             );
-            let badge_stack_page_expression = gtk::ClosureExpression::new(
-                move |expressions| -> String {
+            let pin_visibility_expression = gtk::ClosureExpression::new(
+                move |expressions| -> bool {
                     let is_pinned = expressions[1].get::<bool>().unwrap();
                     let unread_count = expressions[2].get::<i32>().unwrap();
 
-                    if unread_count > 0 {
-                        "unread".to_string()
-                    } else if is_pinned {
-                        "pin".to_string()
-                    } else {
-                        "empty".to_string()
-                    }
+                    is_pinned && unread_count <= 0
                 },
                 &[is_pinned_expression.upcast(), unread_count_expression.upcast()],
             );
-            let badge_stack = self_.badge_stack.get();
-            badge_stack_page_expression.bind(
-                &badge_stack,
-                "visible-child-name",
-                Some(&badge_stack),
-            );
-            // Hide the whole stack if page is "empty"
-            let badge_stack_visibility_expression = gtk::ClosureExpression::new(
-                move |expressions| -> bool {
-                    let child_name = expressions[1].get::<String>().unwrap();
-
-                    child_name != "empty"
-                },
-                &[badge_stack_page_expression.upcast()],
-            );
-            badge_stack_visibility_expression.bind(
-                &badge_stack,
+            let pin_image = self_.pin_image.get();
+            pin_visibility_expression.bind(
+                &pin_image,
                 "visible",
-                Some(&badge_stack),
+                Some(&pin_image),
             );
         }
 


### PR DESCRIPTION
I'm not very good in Rust, so this is what I could come up with.

Basically, I added a property to the chat object, which is updated from TDlib's position update.

Also, I put the unread count stacked over the pinned icon, instead of hiding the latter (because, in the official clients, the pin disappears when the unread badge is shown). ~I don't if this would be the best approach, but it seems to work.~ **Edit:** I just realized GtkStack is supposed to only show one widget at a time, so its use here is correct.

Closes #30