### PR TITLE
Add color to user names in groups

### DIFF
--- a/data/resources/style-dark.css
+++ b/data/resources/style-dark.css
@@ -5,3 +5,31 @@
 .event-row {
   background-color: alpha(white, 0.05);
 }
+
+.sender-text-red {
+  color: #fb6169;
+}
+
+.sender-text-orange {
+  color: #faa357;
+}
+
+.sender-text-violet {
+  color: #b48bf2;
+}
+
+.sender-text-green {
+  color: #85de85;
+}
+
+.sender-text-cyan {
+  color: #62d4e3;
+}
+
+.sender-text-blue {
+  color: #65bdf3;
+}
+
+.sender-text-pink {
+  color: #ff5694;
+}

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -60,31 +60,31 @@
 }
 
 .sender-text-red {
-  color: #c01c28;
+  color: #c03d33;
 }
 
 .sender-text-orange {
-  color: #e66100;
+  color: #ce671b;
 }
 
 .sender-text-violet {
-  color: #813d9c;
+  color: #8544d6;
 }
 
 .sender-text-green {
-  color: #26a269;
+  color: #4fad2d;
 }
 
 .sender-text-cyan {
-  color: #2eacc2;
+  color: #2996ad;
 }
 
 .sender-text-blue {
-  color: #1c71d8;
+  color: #168acd;
 }
 
 .sender-text-pink {
-  color: #9c3d80;
+  color: #cd4073;
 }
 
 .message-text {

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -59,6 +59,34 @@
   font-weight: bold;
 }
 
+.sender-text-red {
+  color: #c01c28;
+}
+
+.sender-text-orange {
+  color: #e66100;
+}
+
+.sender-text-violet {
+  color: #813d9c;
+}
+
+.sender-text-green {
+  color: #26a269;
+}
+
+.sender-text-cyan {
+  color: #2eacc2;
+}
+
+.sender-text-blue {
+  color: #1c71d8;
+}
+
+.sender-text-pink {
+  color: #9c3d80;
+}
+
 .message-text {
   font-size: 0.95em;
 }

--- a/src/session/content/message_row.rs
+++ b/src/session/content/message_row.rs
@@ -269,6 +269,19 @@ impl MessageRow {
                 );
 
                 full_name_expression.bind(&label, "label", Some(&label));
+
+                let classes = vec![
+                    "sender-text-red".to_string(),
+                    "sender-text-orange".to_string(),
+                    "sender-text-violet".to_string(),
+                    "sender-text-green".to_string(),
+                    "sender-text-cyan".to_string(),
+                    "sender-text-blue".to_string(),
+                    "sender-text-pink".to_string(),
+                ];
+
+                let user_class = &classes[user.id() as usize % classes.len()];
+                label.add_css_class(&user_class.to_string());
             }
             MessageSender::Chat(chat) => {
                 let chat_expression = gtk::ConstantExpression::new(&chat);


### PR DESCRIPTION
I used a list of 7 colors, and assigned them based on the user id. This seems to be consistent with colors generated in the official clients.

The colors, except for cyan and pink, were taken from [GNOME's Color Palette app](https://flathub.org/apps/details/org.gnome.design.Palette).