### PR TITLE
Improve message-row

### DIFF
--- a/data/resources/resources.gresource.xml
+++ b/data/resources/resources.gresource.xml
@@ -5,6 +5,7 @@
     <file compressed="true" preprocess="xml-stripblanks">ui/content.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content-chat-history.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content-event-row.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/content-message-bubble.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content-message-row.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/login.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/session.ui</file>

--- a/data/resources/resources.gresource.xml
+++ b/data/resources/resources.gresource.xml
@@ -5,6 +5,7 @@
     <file compressed="true" preprocess="xml-stripblanks">ui/content.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content-chat-history.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content-event-row.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/content-message-row.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/login.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/session.ui</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="gtk/help-overlay.ui">ui/shortcuts.ui</file>

--- a/data/resources/ui/components-avatar.ui
+++ b/data/resources/ui/components-avatar.ui
@@ -9,6 +9,11 @@
             <lookup name="item">ComponentsAvatar</lookup>
           </lookup>
         </binding>
+        <binding name="text">
+          <lookup name="display-name" type="Avatar">
+            <lookup name="item">ComponentsAvatar</lookup>
+          </lookup>
+        </binding>
       </object>
     </property>
   </template>

--- a/data/resources/ui/content-message-bubble.ui
+++ b/data/resources/ui/content-message-bubble.ui
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="ContentMessageBubble" parent="AdwBin">
+    <style>
+      <class name="message-bubble"/>
+    </style>
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="AdwBin" id="sender_bin"/>
+        </child>
+        <child>
+          <object class="GtkLabel" id="content_label">
+            <property name="selectable">True</property>
+            <property name="use-markup">True</property>
+            <property name="wrap">True</property>
+            <property name="wrap-mode">word-char</property>
+            <property name="xalign">0</property>
+            <style>
+              <class name="message-text"/>
+            </style>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/resources/ui/content-message-row.ui
+++ b/data/resources/ui/content-message-row.ui
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="ContentMessageRow" parent="AdwBin">
+    <child>
+      <object class="GtkBox">
+        <property name="spacing">6</property>
+        <child>
+          <object class="AdwBin" id="avatar_bin"/>
+        </child>
+        <child>
+          <object class="AdwBin" id="content_bin"/>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/resources/ui/sidebar-chat-row.ui
+++ b/data/resources/ui/sidebar-chat-row.ui
@@ -12,11 +12,6 @@
                 <lookup name="chat">SidebarChatRow</lookup>
               </lookup>
             </binding>
-            <binding name="display-name">
-              <lookup name="title">
-                <lookup name="chat">SidebarChatRow</lookup>
-              </lookup>
-            </binding>
           </object>
         </child>
         <child>

--- a/src/meson.build
+++ b/src/meson.build
@@ -41,6 +41,7 @@ sources = files(
   'session/content/chat_history.rs',
   'session/content/event_row.rs',
   'session/content/item_row.rs',
+  'session/content/message_bubble.rs',
   'session/content/message_row.rs',
   'session/content/mod.rs',
   'session/sidebar/chat_row.rs',

--- a/src/session/avatar.rs
+++ b/src/session/avatar.rs
@@ -15,6 +15,7 @@ mod imp {
     pub struct Avatar {
         pub image: RefCell<Option<gdk::Paintable>>,
         pub needed: Cell<bool>,
+        pub display_name: RefCell<Option<String>>,
         pub session: OnceCell<Session>,
 
         pub image_file: RefCell<Option<File>>,
@@ -45,6 +46,13 @@ mod imp {
                         false,
                         glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
                     ),
+                    glib::ParamSpec::new_string(
+                        "display-name",
+                        "Display Name",
+                        "The display name used for this avatar",
+                        None,
+                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                    ),
                     glib::ParamSpec::new_object(
                         "session",
                         "Session",
@@ -67,6 +75,7 @@ mod imp {
         ) {
             match pspec.name() {
                 "needed" => obj.set_needed(value.get().unwrap()),
+                "display-name" => obj.set_display_name(value.get().unwrap()),
                 "session" => self.session.set(value.get().unwrap()).unwrap(),
                 _ => unimplemented!(),
             }
@@ -76,6 +85,7 @@ mod imp {
             match pspec.name() {
                 "image" => obj.image().to_value(),
                 "needed" => obj.needed().to_value(),
+                "display-name" => obj.display_name().to_value(),
                 "session" => obj.session().to_value(),
                 _ => unimplemented!(),
             }
@@ -176,6 +186,22 @@ impl Avatar {
         }
 
         self.notify("needed");
+    }
+
+    pub fn display_name(&self) -> Option<String> {
+        let self_ = imp::Avatar::from_instance(self);
+        self_.display_name.borrow().clone()
+    }
+
+    pub fn set_display_name(&self, display_name: Option<String>) {
+        if self.display_name() == display_name {
+            return;
+        }
+
+        let self_ = imp::Avatar::from_instance(self);
+        self_.display_name.replace(display_name);
+
+        self.notify("display-name");
     }
 
     pub fn session(&self) -> &Session {

--- a/src/session/chat/message.rs
+++ b/src/session/chat/message.rs
@@ -203,4 +203,41 @@ impl Message {
         let self_ = imp::Message::from_instance(self);
         self_.chat.get().unwrap()
     }
+
+    pub fn sender_name_expression(&self) -> gtk::Expression {
+        match self.sender() {
+            MessageSender::User(user) => {
+                let user_expression = gtk::ConstantExpression::new(&user);
+                let first_name_expression = gtk::PropertyExpression::new(
+                    User::static_type(),
+                    Some(&user_expression),
+                    "first-name",
+                );
+                let last_name_expression = gtk::PropertyExpression::new(
+                    User::static_type(),
+                    Some(&user_expression),
+                    "last-name",
+                );
+
+                gtk::ClosureExpression::new(
+                    move |expressions| -> String {
+                        let first_name = expressions[1].get::<&str>().unwrap();
+                        let last_name = expressions[2].get::<&str>().unwrap();
+                        format!("{} {}", first_name, last_name).trim().to_string()
+                    },
+                    &[
+                        first_name_expression.upcast(),
+                        last_name_expression.upcast(),
+                    ],
+                )
+                .upcast()
+            }
+            MessageSender::Chat(chat) => {
+                let chat_expression = gtk::ConstantExpression::new(&chat);
+
+                gtk::PropertyExpression::new(Chat::static_type(), Some(&chat_expression), "title")
+                    .upcast()
+            }
+        }
+    }
 }

--- a/src/session/chat/message.rs
+++ b/src/session/chat/message.rs
@@ -206,38 +206,8 @@ impl Message {
 
     pub fn sender_name_expression(&self) -> gtk::Expression {
         match self.sender() {
-            MessageSender::User(user) => {
-                let user_expression = gtk::ConstantExpression::new(&user);
-                let first_name_expression = gtk::PropertyExpression::new(
-                    User::static_type(),
-                    Some(&user_expression),
-                    "first-name",
-                );
-                let last_name_expression = gtk::PropertyExpression::new(
-                    User::static_type(),
-                    Some(&user_expression),
-                    "last-name",
-                );
-
-                gtk::ClosureExpression::new(
-                    move |expressions| -> String {
-                        let first_name = expressions[1].get::<&str>().unwrap();
-                        let last_name = expressions[2].get::<&str>().unwrap();
-                        format!("{} {}", first_name, last_name).trim().to_string()
-                    },
-                    &[
-                        first_name_expression.upcast(),
-                        last_name_expression.upcast(),
-                    ],
-                )
-                .upcast()
-            }
-            MessageSender::Chat(chat) => {
-                let chat_expression = gtk::ConstantExpression::new(&chat);
-
-                gtk::PropertyExpression::new(Chat::static_type(), Some(&chat_expression), "title")
-                    .upcast()
-            }
+            MessageSender::User(user) => user.full_name_expression(),
+            MessageSender::Chat(chat) => chat.title_expression(),
         }
     }
 }

--- a/src/session/chat/mod.rs
+++ b/src/session/chat/mod.rs
@@ -210,6 +210,10 @@ mod imp {
             self.parent_constructed(obj);
 
             self.history.set(History::new(obj)).unwrap();
+
+            let avatar = obj.avatar();
+            let title_expression = obj.title_expression();
+            title_expression.bind(avatar, "display-name", Some(avatar));
         }
     }
 }
@@ -383,5 +387,10 @@ impl Chat {
 
     pub fn session(&self) -> Session {
         self.property("session").unwrap().get().unwrap()
+    }
+
+    pub fn title_expression(&self) -> gtk::Expression {
+        let chat_expression = gtk::ConstantExpression::new(self);
+        gtk::PropertyExpression::new(Chat::static_type(), Some(&chat_expression), "title").upcast()
     }
 }

--- a/src/session/components/avatar.rs
+++ b/src/session/components/avatar.rs
@@ -45,13 +45,6 @@ mod imp {
                         AvatarItem::static_type(),
                         glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
                     ),
-                    glib::ParamSpec::new_string(
-                        "display-name",
-                        "Display Name",
-                        "The display name used for this avatar",
-                        None,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
-                    ),
                     glib::ParamSpec::new_int(
                         "size",
                         "Size",
@@ -76,7 +69,6 @@ mod imp {
         ) {
             match pspec.name() {
                 "item" => obj.set_item(value.get().unwrap()),
-                "display-name" => obj.set_display_name(value.get().unwrap()),
                 "size" => obj.set_size(value.get().unwrap()),
                 _ => unimplemented!(),
             }
@@ -85,7 +77,6 @@ mod imp {
         fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
             match pspec.name() {
                 "item" => obj.item().to_value(),
-                "display-name" => obj.display_name().to_value(),
                 "size" => obj.size().to_value(),
                 _ => unimplemented!(),
             }
@@ -131,18 +122,6 @@ impl Avatar {
         self.request_avatar_image();
 
         self.notify("item");
-    }
-
-    pub fn display_name(&self) -> Option<String> {
-        let self_ = imp::Avatar::from_instance(self);
-        self_.avatar.text().map(|s| s.to_string())
-    }
-
-    pub fn set_display_name(&self, display_name: Option<&str>) {
-        let self_ = imp::Avatar::from_instance(self);
-        self_.avatar.set_text(display_name);
-
-        self.notify("display-name");
     }
 
     pub fn size(&self) -> i32 {

--- a/src/session/content/message_bubble.rs
+++ b/src/session/content/message_bubble.rs
@@ -1,0 +1,241 @@
+use adw::{prelude::BinExt, subclass::prelude::BinImpl};
+use gettextrs::gettext;
+use gtk::{glib, pango, prelude::*, subclass::prelude::*, CompositeTemplate};
+use tdgrand::enums::{ChatType, MessageContent, TextEntityType};
+use tdgrand::types::FormattedText;
+
+use crate::session::chat::{BoxedMessageContent, Message, MessageSender};
+use crate::utils::{escape, linkify};
+
+mod imp {
+    use super::*;
+    use std::cell::{Cell, RefCell};
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(resource = "/com/github/melix99/telegrand/ui/content-message-bubble.ui")]
+    pub struct MessageBubble {
+        pub is_outgoing: Cell<bool>,
+        pub sender_color_class: RefCell<Option<String>>,
+        #[template_child]
+        pub sender_bin: TemplateChild<adw::Bin>,
+        #[template_child]
+        pub content_label: TemplateChild<gtk::Label>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MessageBubble {
+        const NAME: &'static str = "ContentMessageBubble";
+        type Type = super::MessageBubble;
+        type ParentType = adw::Bin;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for MessageBubble {}
+    impl WidgetImpl for MessageBubble {}
+    impl BinImpl for MessageBubble {}
+}
+
+glib::wrapper! {
+    pub struct MessageBubble(ObjectSubclass<imp::MessageBubble>)
+        @extends gtk::Widget, adw::Bin;
+}
+
+impl Default for MessageBubble {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MessageBubble {
+    pub fn new() -> Self {
+        glib::Object::new(&[]).expect("Failed to create MessageBubble")
+    }
+
+    pub fn set_message(&self, message: &Message) {
+        let self_ = imp::MessageBubble::from_instance(self);
+
+        // Remove previous css class
+        if self_.is_outgoing.get() {
+            self.remove_css_class("outgoing")
+        } else {
+            self.remove_css_class("incoming")
+        }
+
+        // Set new css class
+        if message.is_outgoing() {
+            self.add_css_class("outgoing");
+        } else {
+            self.add_css_class("incoming");
+        }
+        self_.is_outgoing.set(message.is_outgoing());
+
+        // Show sender label, if needed
+        let show_sender = {
+            if !message.is_outgoing() {
+                matches!(
+                    message.chat().type_(),
+                    ChatType::BasicGroup(_) | ChatType::Supergroup(_)
+                )
+            } else {
+                false
+            }
+        };
+        if show_sender {
+            let label = if let Some(Ok(label)) =
+                self_.sender_bin.child().map(|w| w.downcast::<gtk::Label>())
+            {
+                label
+            } else {
+                let label = gtk::LabelBuilder::new()
+                    .css_classes(vec!["sender-text".to_string()])
+                    .halign(gtk::Align::Start)
+                    .ellipsize(pango::EllipsizeMode::End)
+                    .single_line_mode(true)
+                    .build();
+                self_.sender_bin.set_child(Some(&label));
+                label
+            };
+            let sender_name_expression = message.sender_name_expression();
+            sender_name_expression.bind(&label, "label", Some(&label));
+
+            // Remove the previous color css class
+            if let Some(class) = self_.sender_color_class.borrow().as_ref() {
+                label.remove_css_class(class);
+            }
+
+            // Color sender label
+            if let MessageSender::User(user) = message.sender() {
+                let classes = vec![
+                    "sender-text-red",
+                    "sender-text-orange",
+                    "sender-text-violet",
+                    "sender-text-green",
+                    "sender-text-cyan",
+                    "sender-text-blue",
+                    "sender-text-pink",
+                ];
+
+                let color_class = classes[user.id() as usize % classes.len()];
+                label.add_css_class(color_class);
+
+                self_.sender_color_class.replace(Some(color_class.into()));
+            } else {
+                self_.sender_color_class.replace(None);
+            }
+        } else {
+            self_.sender_bin.set_child(None::<&gtk::Widget>);
+            self_.sender_color_class.replace(None);
+        }
+
+        // Set content label expression
+        let message_expression = gtk::ConstantExpression::new(message);
+        let content_expression = gtk::PropertyExpression::new(
+            Message::static_type(),
+            Some(&message_expression),
+            "content",
+        );
+        let text_expression = gtk::ClosureExpression::new(
+            move |expressions| -> String {
+                let content = expressions[1].get::<BoxedMessageContent>().unwrap();
+                format_message_content_text(content.0)
+            },
+            &[content_expression.upcast()],
+        );
+        let content_label = self_.content_label.get();
+        text_expression.bind(&content_label, "label", Some(&content_label));
+    }
+}
+
+fn convert_to_markup(text: String, entity: &TextEntityType) -> String {
+    match entity {
+        TextEntityType::Url => format!("<a href='{}'>{}</a>", linkify(&text), text),
+        TextEntityType::EmailAddress => format!("<a href='mailto:{0}'>{0}</a>", text),
+        TextEntityType::PhoneNumber => format!("<a href='tel:{0}'>{0}</a>", text),
+        TextEntityType::Bold => format!("<b>{}</b>", text),
+        TextEntityType::Italic => format!("<i>{}</i>", text),
+        TextEntityType::Underline => format!("<u>{}</u>", text),
+        TextEntityType::Strikethrough => format!("<s>{}</s>", text),
+        TextEntityType::Code | TextEntityType::Pre | TextEntityType::PreCode(_) => {
+            format!("<tt>{}</tt>", text)
+        }
+        TextEntityType::TextUrl(data) => format!("<a href='{}'>{}</a>", escape(&data.url), text),
+        _ => text,
+    }
+}
+
+fn parse_formatted_text(formatted_text: FormattedText) -> String {
+    let mut entities = formatted_text.entities.iter();
+    let mut entity = entities.next();
+    let mut output = String::new();
+    let mut buffer = String::new();
+    let mut is_inside_entity = false;
+
+    // This is the offset in utf16 code units of the text to parse. We need this variable
+    // because tdlib stores the offset and length parameters as utf16 code units instead
+    // of regular code points.
+    let mut code_units_offset = 0;
+
+    for c in formatted_text.text.chars() {
+        if !is_inside_entity
+            && entity.is_some()
+            && code_units_offset >= entity.unwrap().offset as usize
+        {
+            is_inside_entity = true;
+
+            if !buffer.is_empty() {
+                output.push_str(&escape(&buffer));
+                buffer = String::new();
+            }
+        }
+
+        buffer.push(c);
+        code_units_offset += c.len_utf16();
+
+        if let Some(entity_) = entity {
+            if code_units_offset >= (entity_.offset + entity_.length) as usize {
+                buffer = escape(&buffer);
+
+                entity = loop {
+                    let entity = entities.next();
+
+                    // Handle eventual nested entities
+                    match entity {
+                        Some(entity) => {
+                            if entity.offset == entity_.offset {
+                                buffer = convert_to_markup(buffer, &entity.r#type);
+                            } else {
+                                break Some(entity);
+                            }
+                        }
+                        None => break None,
+                    }
+                };
+
+                output.push_str(&convert_to_markup(buffer, &entity_.r#type));
+                buffer = String::new();
+                is_inside_entity = false;
+            }
+        }
+    }
+
+    // Add the eventual leftovers from the buffer to the output
+    if !buffer.is_empty() {
+        output.push_str(&escape(&buffer));
+    }
+
+    output
+}
+
+fn format_message_content_text(content: MessageContent) -> String {
+    match content {
+        MessageContent::MessageText(content) => parse_formatted_text(content.text),
+        _ => format!("<i>{}</i>", gettext("This message is unsupported")),
+    }
+}

--- a/src/session/content/message_row.rs
+++ b/src/session/content/message_row.rs
@@ -92,8 +92,6 @@ impl MessageRow {
                 MessageSender::User(user) => avatar.set_item(Some(user.avatar().clone())),
                 MessageSender::Chat(chat) => avatar.set_item(Some(chat.avatar().clone())),
             }
-            let sender_name_expression = message.sender_name_expression();
-            sender_name_expression.bind(&avatar, "display-name", Some(&avatar));
         } else {
             self_.avatar_bin.set_child(None::<&gtk::Widget>);
         }

--- a/src/session/content/mod.rs
+++ b/src/session/content/mod.rs
@@ -1,11 +1,13 @@
 mod chat_history;
 mod event_row;
 mod item_row;
+mod message_bubble;
 mod message_row;
 
 use self::chat_history::ChatHistory;
 use self::event_row::EventRow;
 use self::item_row::ItemRow;
+use self::message_bubble::MessageBubble;
 use self::message_row::MessageRow;
 
 use gtk::glib;


### PR DESCRIPTION
This is an effort for simplifying the message-row and turning it to a more general widget for representing the messages. Its structure is changed to be more modular: it has a "content" bin widget that can be used to show the appropriate child widget that represents the type of the message associated with it. This means that most of the "message bubble" code is moved away from the message-row into a separate message-bubble module. With this approach we can add more message types more easily.

Also, both the message-row and the message-bubble have been rewritten to be more recyclable for the listview. This should result in better performance while scrolling. But don't expect perfect scrolling, unfortunately listview's scrolling [is quite broken](https://gitlab.gnome.org/GNOME/gtk/-/issues/2971).