### PR TITLE
Add vscode setting to handle meson project

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug telegrand",
+            "program": "${env:HOME}/.cache/vscode/install/telegrand/bin/telegrand",
+            "args": [],
+            "env": {
+                "GDK_BACKEND": "wayland",
+                "GSETTINGS_SCHEMA_DIR": "${env:HOME}/.cache/vscode/install/telegrand/share/glib-2.0/schemas",
+            },
+            "cwd": "${workspaceFolder}",
+            "preLaunchTask": "Meson: Install"
+        },
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "shell",
+            "command": "meson",
+            "args": [
+                "setup",
+                "--reconfigure",
+                "$HOME/.cache/vscode/build/telegrand",
+                "-Dprefix=/tmp/telegrand/usr",
+                "-Dprofile=development"
+            ],
+            "problemMatcher": [],
+            "group": "build",
+            "label": "Meson: Reconfigure"
+        },
+        {
+            "type": "shell",
+            "command": "meson",
+            "args": [
+                "setup",
+                "$HOME/.cache/vscode/build/telegrand",
+                "-Dprefix=$HOME/.cache/vscode/install/telegrand",
+                "-Dprofile=development"
+            ],
+            "problemMatcher": [],
+            "group": "build",
+            "label": "Meson: Build"
+        },
+        {
+            "type": "shell",
+            "command": "meson",
+            "args": [
+                "install",
+                "-C",
+                "$HOME/.cache/vscode/build/telegrand",
+            ],
+            "problemMatcher": [],
+            "group": "build",
+            "dependsOn": "Meson: Build",
+            "label": "Meson: Install",
+        }
+    ]
+}


### PR DESCRIPTION
This commit adds the minimum required settings to work with telegrand in
vscode and derivates in a more convenient way (as an alternative to
Gnome Builder).
First, the commit defines tasks for setting up and installing meson
development builds. It then adds a launch configuration that is based on
these tasks. This can be used together with the extension
https://github.com/vadimcn/vscode-lldb to debug the application.