### PR TITLE
Add some new message types to chat row and notification

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -150,11 +150,11 @@ msgstr "_Dreceres de teclat"
 msgid "_About Telegrand"
 msgstr "_Sobre el Telegrand"
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "Missatge no suportat"
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "Trucada entrant"
 
@@ -172,6 +172,6 @@ msgstr "%e de %B del %Y"
 msgid "This message is unsupported"
 msgstr "Aquest missatge no està suportat"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr "Vós"

--- a/po/de.po
+++ b/po/de.po
@@ -150,6 +150,15 @@ msgstr "_Tastaturkurzbefehle"
 msgid "_About Telegrand"
 msgstr "_Über Telegrand"
 
+#: src/window.rs::91 src/session/sidebar/chat_row.rs:286
+msgid "Voice message"
+msgstr "Sprachnachricht"
+
+#. Translators: '{}' is the placeholder for the full name of the contact who joined Telegram
+#: src/window.rs::110 src/session/sidebar/chat_row.rs:311
+msgid "{} joined Telegram"
+msgstr "{} benutzt jetzt Telegram"
+
 #: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "Nicht unterstützte Nachricht"

--- a/po/de.po
+++ b/po/de.po
@@ -150,11 +150,11 @@ msgstr "_Tastaturkurzbefehle"
 msgid "_About Telegrand"
 msgstr "_Über Telegrand"
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "Nicht unterstützte Nachricht"
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "Eingehender Anruf"
 
@@ -172,6 +172,6 @@ msgstr "%e %B %Y"
 msgid "This message is unsupported"
 msgstr "Diese Nachricht wird nicht unterstützt"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr "Sie"

--- a/po/es.po
+++ b/po/es.po
@@ -150,11 +150,11 @@ msgstr "_Atajos de teclado"
 msgid "_About Telegrand"
 msgstr "_Acerca de Telegrand"
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "Mensaje no soportado"
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "Llamada entrante"
 
@@ -172,7 +172,7 @@ msgstr "%e de %B del %Y"
 msgid "This message is unsupported"
 msgstr "Este mensaje no está soportado"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr "Usted"
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -150,11 +150,11 @@ msgstr "_Teklatu-lasterbideak"
 msgid "_About Telegrand"
 msgstr "_Telegrand-ri buruz"
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "Mezua ez dago jasanda"
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "Sarrerako deia"
 
@@ -172,6 +172,6 @@ msgstr "%Y, %B %e"
 msgid "This message is unsupported"
 msgstr "Mezu hau ez dago jasanda"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr "Zu"

--- a/po/fa.po
+++ b/po/fa.po
@@ -148,11 +148,11 @@ msgstr "_میانبرهای صفحه‌کلید"
 msgid "_About Telegrand"
 msgstr "_درباره تلگراند"
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "پیام پشتیبانی نشده"
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "تماس دریافتی"
 
@@ -170,6 +170,6 @@ msgstr ""
 msgid "This message is unsupported"
 msgstr "این پیام پشتیبانی نمی‌شود"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -148,11 +148,11 @@ msgstr "_Näppäimistön pikavalinnat"
 msgid "_About Telegrand"
 msgstr "_Tietoja Telegrandista"
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "Ei tuettu viesti"
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "Saapuva puhelu"
 
@@ -170,6 +170,6 @@ msgstr "%e %B %Y"
 msgid "This message is unsupported"
 msgstr "Tätä viestiä ei tueta"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr "Sinä"

--- a/po/fr.po
+++ b/po/fr.po
@@ -148,11 +148,11 @@ msgstr "_Raccourcis clavier"
 msgid "_About Telegrand"
 msgstr "_À propos de Telegrand"
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "Message non pris en charge"
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "Appel entrant"
 
@@ -170,6 +170,6 @@ msgstr "%e %B %Y"
 msgid "This message is unsupported"
 msgstr "Ce message n'est pas pris en charge"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr "Vous"

--- a/po/he.po
+++ b/po/he.po
@@ -150,11 +150,11 @@ msgstr ""
 msgid "_About Telegrand"
 msgstr ""
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr ""
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "שיחה נכנסת"
 
@@ -172,6 +172,6 @@ msgstr ""
 msgid "This message is unsupported"
 msgstr "הודעה לא נתמכת"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -148,11 +148,11 @@ msgstr "_Pintasan Papan Ketik"
 msgid "_About Telegrand"
 msgstr "_Tentang Telegrand"
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "Pesan tidak didukung"
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "Panggilan masuk"
 
@@ -170,6 +170,6 @@ msgstr ""
 msgid "This message is unsupported"
 msgstr "Pesan ini tidak didukung"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -148,11 +148,11 @@ msgstr "_Scorciatoie da tastiera"
 msgid "_About Telegrand"
 msgstr "Inform_azioni"
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "Messaggio non supportato"
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "Chiamata in arrivo"
 
@@ -170,6 +170,6 @@ msgstr "%e %B %Y"
 msgid "This message is unsupported"
 msgstr "Questo messaggio non è supportato"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr "Tu"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -151,11 +151,11 @@ msgstr "_Tastatursnarveier"
 msgid "_About Telegrand"
 msgstr "_Om Telegrand"
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "Ustøttet melding"
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "Innkommende anrop"
 
@@ -173,7 +173,7 @@ msgstr "%e %B %Y"
 msgid "This message is unsupported"
 msgstr "Denne meldingen er ustøttet"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr "Du"
 

--- a/po/oc.po
+++ b/po/oc.po
@@ -146,11 +146,11 @@ msgstr "Acorchis de _clavièr"
 msgid "_About Telegrand"
 msgstr "_A prepaus de Telegrand"
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "Messatge pas pres en carga"
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "Sonada entranta"
 
@@ -168,6 +168,6 @@ msgstr "%e %B de %Y"
 msgid "This message is unsupported"
 msgstr "Aqueste messatge pas pres en carga"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr "Vos"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -148,11 +148,11 @@ msgstr "_Atalhos do teclado"
 msgid "_About Telegrand"
 msgstr "_Sobre o Telegrand"
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "Mensagem não suportada"
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "Chamada recebida"
 
@@ -170,6 +170,6 @@ msgstr "%e de %B de %Y"
 msgid "This message is unsupported"
 msgstr "Esta mensagem não é suportada"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr "Você"

--- a/po/ru.po
+++ b/po/ru.po
@@ -149,11 +149,11 @@ msgstr "_Комбинации клавиш"
 msgid "_About Telegrand"
 msgstr "_О приложении"
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "Неподдерживаемое сообщение"
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "Входящий звонок"
 
@@ -171,6 +171,6 @@ msgstr "%e %B %Y"
 msgid "This message is unsupported"
 msgstr "Это сообщение не поддерживается"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr "Вы"

--- a/po/sv.po
+++ b/po/sv.po
@@ -148,11 +148,11 @@ msgstr "_Tangentbordsgenvägar"
 msgid "_About Telegrand"
 msgstr "_Om Telegrand"
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr "Icke-stött meddelande"
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr "Inkommande samtal"
 
@@ -170,6 +170,6 @@ msgstr "%e %B %Y"
 msgid "This message is unsupported"
 msgstr "Det här meddelandet stöds inte"
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr "Du"

--- a/po/telegrand.pot
+++ b/po/telegrand.pot
@@ -146,11 +146,32 @@ msgstr ""
 msgid "_About Telegrand"
 msgstr ""
 
-#: src/window.rs:21 src/session/sidebar/chat_row.rs:230
+#: src/window.rs:45 src/session/sidebar/chat_row.rs:240
+msgid "Photo"
+msgstr ""
+
+#: src/window.rs:64 src/session/sidebar/chat_row.rs:259
+msgid "GIF"
+msgstr ""
+
+#: src/window.rs:73 src/session/sidebar/chat_row.rs:268
+msgid "Video"
+msgstr ""
+
+#: src/window.rs::91 src/session/sidebar/chat_row.rs:286
+msgid "Voice message"
+msgstr ""
+
+#. Translators: '{}' is the placeholder for the full name of the contact who joined Telegram
+#: src/window.rs::110 src/session/sidebar/chat_row.rs:311
+msgid "{} joined Telegram"
+msgstr ""
+
+#: src/window.rs:112 src/session/sidebar/chat_row.rs:313
 msgid "Unsupported message"
 msgstr ""
 
-#: src/window.rs:325
+#: src/window.rs:409
 msgid "Incoming call"
 msgstr ""
 
@@ -168,6 +189,6 @@ msgstr ""
 msgid "This message is unsupported"
 msgstr ""
 
-#: src/session/sidebar/chat_row.rs:241
+#: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr ""

--- a/src/session/sidebar/chat_row.rs
+++ b/src/session/sidebar/chat_row.rs
@@ -5,7 +5,7 @@ use tdgrand::enums::{ChatType, MessageContent};
 use crate::session::chat::{Message, MessageSender};
 use crate::session::components::Avatar;
 use crate::session::Chat;
-use crate::utils::escape;
+use crate::utils::{dim_and_escape, escape};
 
 mod imp {
     use super::*;
@@ -230,12 +230,66 @@ fn stringify_message(message: Message) -> String {
 
     let text_content = match message.content().0 {
         MessageContent::MessageText(data) => {
-            // The alpha value should be kept in sync with Adwaita's dim-label alpha value
-            format!("<span alpha=\"55%\">{}</span>", escape(&data.text.text))
+            dim_and_escape(&data.text.text)
         }
         MessageContent::MessageSticker(data) => {
             format!("{} {}", data.sticker.emoji, gettext("Sticker"))
         }
+        MessageContent::MessagePhoto(data) => format!(
+            "{}{}",
+            gettext("Photo"),
+            if data.caption.text.is_empty() {
+                String::new()
+            } else {
+                format!(", {}", dim_and_escape(&data.caption.text))
+            }
+        ),
+        MessageContent::MessageAudio(data) => format!(
+            "{} - {}{}",
+            data.audio.performer,
+            data.audio.title,
+            if data.caption.text.is_empty() {
+                String::new()
+            } else {
+                format!(", {}", dim_and_escape(&data.caption.text))
+            }
+        ),
+        MessageContent::MessageAnimation(data) => format!(
+            "{}{}",
+            gettext("GIF"),
+            if data.caption.text.is_empty() {
+                String::new()
+            } else {
+                format!(", {}", dim_and_escape(&data.caption.text))
+            }
+        ),
+        MessageContent::MessageVideo(data) => format!(
+            "{}{}",
+            gettext("Video"),
+            if data.caption.text.is_empty() {
+                String::new()
+            } else {
+                format!(", {}", dim_and_escape(&data.caption.text))
+            }
+        ),
+        MessageContent::MessageDocument(data) => format!(
+            "{}{}",
+            data.document.file_name,
+            if data.caption.text.is_empty() {
+                String::new()
+            } else {
+                format!(", {}", dim_and_escape(&data.caption.text))
+            }
+        ),
+        MessageContent::MessageVoiceNote(data) => format!(
+            "{}{}",
+            gettext("Voice message"),
+            if data.caption.text.is_empty() {
+                String::new()
+            } else {
+                format!(", {}", dim_and_escape(&data.caption.text))
+            }
+        ),
         MessageContent::MessageChatDeletePhoto => {
             show_sender = false;
 
@@ -252,6 +306,9 @@ fn stringify_message(message: Message) -> String {
                     }
                 }
             }
+        }
+        MessageContent::MessageContactRegistered => {
+            gettext!("{} joined Telegram", sender_name(message.sender(), true))
         }
         _ => gettext("Unsupported message"),
     };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,6 +15,15 @@ pub fn escape(text: &str) -> String {
         .replace('"', "&quot;")
 }
 
+pub fn dim(text: &str) -> String {
+    // The alpha value should be kept in sync with Adwaita's dim-label alpha value
+    format!("<span alpha=\"55%\">{}</span>", text)
+}
+
+pub fn dim_and_escape(text: &str) -> String {
+    dim(&escape(text))
+}
+
 pub fn linkify(text: &str) -> String {
     if !PROTOCOL_RE.is_match(text) {
         format!("http://{}", text)

--- a/src/window.rs
+++ b/src/window.rs
@@ -40,6 +40,61 @@ fn stringify_message_content(message: &TelegramMessage, chat: &Chat) -> String {
         MessageContent::MessageSticker(data) => {
             format!("{} {}", data.sticker.emoji, gettext("Sticker"))
         }
+        MessageContent::MessagePhoto(data) => format!(
+            "{}{}",
+            gettext("Photo"),
+            if data.caption.text.is_empty() {
+                String::new()
+            } else {
+                format!(", {}", data.caption.text)
+            }
+        ),
+        MessageContent::MessageAudio(data) => format!(
+            "{} - {}{}",
+            data.audio.performer,
+            data.audio.title,
+            if data.caption.text.is_empty() {
+                String::new()
+            } else {
+                format!(", {}", data.caption.text)
+            }
+        ),
+        MessageContent::MessageAnimation(data) => format!(
+            "{}{}",
+            gettext("GIF"),
+            if data.caption.text.is_empty() {
+                String::new()
+            } else {
+                format!(", {}", data.caption.text)
+            }
+        ),
+        MessageContent::MessageVideo(data) => format!(
+            "{}{}",
+            gettext("Video"),
+            if data.caption.text.is_empty() {
+                String::new()
+            } else {
+                format!(", {}", data.caption.text)
+            }
+        ),
+        MessageContent::MessageDocument(data) => format!(
+            "{}{}",
+            data.document.file_name,
+            if data.caption.text.is_empty() {
+                String::new()
+            } else {
+                format!(", {}", data.caption.text)
+            }
+        ),
+        MessageContent::MessageVoiceNote(data) => format!(
+            "{}{}",
+            gettext("Voice message"),
+            if data.caption.text.is_empty() {
+                String::new()
+            } else {
+                format!(", {}", data.caption.text)
+            }
+        ),
         MessageContent::MessageChatDeletePhoto => match chat.type_() {
             ChatType::Supergroup(data) if data.is_channel => gettext("Channel photo removed"),
             _ => {
@@ -51,6 +106,9 @@ fn stringify_message_content(message: &TelegramMessage, chat: &Chat) -> String {
                 }
             }
         },
+        MessageContent::MessageContactRegistered => {
+            gettext!("{} joined Telegram", sender_name(&message.sender, chat))
+        }
         _ => gettext("Unsupported message"),
     }
 }


### PR DESCRIPTION
These are MessagePhoto, MessageAudio, MessageAnimation, MessageVideo,
MessageDocument, MessageVoiceNote and MessageContactRegistered.
They are based on the message format in the official telegram client.
 
I also updated the po files to reflect the changed line numbers and to add new
translatable strings. Additionally, I also updated the German translations.
But I am not sure if directly updating the po files is the typical workflow in pull
requests.

I look forward to your review.