### PR TITLE
Implement registration page

### DIFF
--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -195,6 +195,101 @@
             </child>
             <child>
               <object class="AdwLeafletPage">
+                <property name="name">registration-page</property>
+                <property name="child">
+                  <object class="GtkBox">
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="AdwStatusPage">
+                        <property name="icon-name">contact-new-symbolic</property>
+                        <property name="title" translatable="yes">Register New Account</property>
+                        <property name="vexpand">True</property>
+                        <child>
+                          <object class="AdwClamp">
+                            <property name="maximum-size">300</property>
+                            <property name="tightening-threshold">200</property>
+                            <property name="child">
+                              <object class="GtkBox">
+                                <property name="orientation">vertical</property>
+                                <property name="spacing">12</property>
+                                <child>
+                                  <object class="GtkListBox">
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="focusable">False</property>
+                                        <property name="selectable">False</property>
+                                        <property name="activatable">False</property>
+                                        <property name="child">
+                                          <object class="GtkEntry" id="registration_first_name_entry">
+                                            <property name="activates-default">True</property>
+                                            <property name="placeholder-text" translatable="yes">First Name</property>
+                                            <property name="margin-top">6</property>
+                                            <property name="margin-bottom">6</property>
+                                            <property name="margin-start">6</property>
+                                            <property name="margin-end">6</property>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="focusable">False</property>
+                                        <property name="selectable">False</property>
+                                        <property name="activatable">False</property>
+                                        <property name="child">
+                                          <object class="GtkEntry" id="registration_last_name_entry">
+                                            <property name="activates-default">True</property>
+                                            <property name="placeholder-text" translatable="yes">Last Name</property>
+                                            <property name="margin-top">6</property>
+                                            <property name="margin-bottom">6</property>
+                                            <property name="margin-start">6</property>
+                                            <property name="margin-end">6</property>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <style>
+                                      <class name="content"/>
+                                    </style>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="registration_error_label">
+                                    <property name="visible">False</property>
+                                    <style>
+                                      <class name="error"/>
+                                    </style>
+                                  </object>
+                                </child>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwClamp">
+                        <property name="maximum-size">300</property>
+                        <property name="tightening-threshold">200</property>
+                        <property name="child">
+                          <object class="GtkLabel" id="tos_label">
+                            <property name="ellipsize">middle</property>
+                            <property name="justify">center</property>
+                            <property name="margin-bottom">18</property>
+                            <property name="use-markup">True</property>
+                            <property name="valign">end</property>
+                            <property name="label" translatable="yes">By signing up,
+you agree to the &lt;a href=&quot;&quot;&gt;Terms of Service&lt;/a&gt;.</property>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwLeafletPage">
                 <property name="name">password-page</property>
                 <property name="child">
                   <object class="AdwStatusPage">

--- a/po/de.po
+++ b/po/de.po
@@ -112,6 +112,18 @@ msgid "Code"
 msgstr "Code"
 
 #: data/resources/ui/login.ui:205
+msgid "Register New Account"
+msgstr "Registrieren Sie einen Neuen Account"
+
+#: data/resources/ui/login.ui:225
+msgid "First Name"
+msgstr "Vorname"
+
+#: data/resources/ui/login.ui:242
+msgid "Last Name"
+msgstr "Nachname"
+
+#: data/resources/ui/login.ui:205
 msgid "Enter Your Password"
 msgstr "Geben Sie Ihr Passwort ein"
 
@@ -184,3 +196,15 @@ msgstr "Diese Nachricht wird nicht unterstützt"
 #: src/session/sidebar/chat_row.rs:318
 msgid "You"
 msgstr "Sie"
+
+#: data/resources/ui/login.ui:267
+msgid "By signing up,\nyou agree to the <a href=\"\">Terms of Service</a>."
+msgstr "Mit der Registrierung\nstimmst du den <a href=\"\">Nutzungsbedingungen</a> zu."
+
+#: src/login.rs:251
+msgid "Do You Accept the Terms of Service?"
+msgstr "Akzeptieren Sie die Nutzungsbedingungen?"
+
+#: src/login.rs:255
+msgid "Terms of Service"
+msgstr "Nutzungsbedingungen"

--- a/po/telegrand.pot
+++ b/po/telegrand.pot
@@ -108,6 +108,18 @@ msgid "Code"
 msgstr ""
 
 #: data/resources/ui/login.ui:205
+msgid "Register New Account"
+msgstr ""
+
+#: data/resources/ui/login.ui:225
+msgid "First Name"
+msgstr ""
+
+#: data/resources/ui/login.ui:242
+msgid "Last Name"
+msgstr ""
+
+#: data/resources/ui/login.ui:205
 msgid "Enter Your Password"
 msgstr ""
 
@@ -191,4 +203,22 @@ msgstr ""
 
 #: src/session/sidebar/chat_row.rs:318
 msgid "You"
+msgstr ""
+
+#. Translators: This is the hint that is shown to the user on the registratian page.
+#. Translators: Ideally, it consist of 2 lines but it may need more in order to be not ellipsized.
+#. Translators: Insert a '\n' in the text to produce a line break.
+#. Translators: The text 'Terms of Service' within the tag '<a href=\"\">Terms of Service</a>' is
+#. Translators: displayed as a clickable link. Please translate the text within the tags and take
+#. Translators: care of keeping the link intact.
+#: data/resources/ui/login.ui:281
+msgid "By signing up,\nyou agree to the <a href=\"\">Terms of Service</a>."
+msgstr ""
+
+#: src/login.rs:251
+msgid "Do You Accept the Terms of Service?"
+msgstr ""
+
+#: src/login.rs:255
+msgid "Terms of Service"
 msgstr ""

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,3 +1,4 @@
+use gettextrs::gettext;
 use glib::clone;
 use gtk::glib;
 use gtk::prelude::*;
@@ -5,7 +6,7 @@ use gtk::subclass::prelude::*;
 use tdgrand::{enums::AuthorizationState, functions, types};
 
 use crate::config;
-use crate::utils::do_async;
+use crate::utils::{do_async, parse_formatted_text};
 
 mod imp {
     use super::*;
@@ -13,12 +14,14 @@ mod imp {
     use glib::subclass::Signal;
     use gtk::{gio, CompositeTemplate};
     use once_cell::sync::Lazy;
-    use std::cell::Cell;
+    use std::cell::{Cell, RefCell};
 
     #[derive(Debug, Default, CompositeTemplate)]
     #[template(resource = "/com/github/melix99/telegrand/ui/login.ui")]
     pub struct Login {
         pub client_id: Cell<i32>,
+        pub tos_text: RefCell<String>,
+        pub show_tos_popup: Cell<bool>,
         #[template_child]
         pub previous_button: TemplateChild<gtk::Button>,
         #[template_child]
@@ -42,6 +45,14 @@ mod imp {
         #[template_child]
         pub code_error_label: TemplateChild<gtk::Label>,
         #[template_child]
+        pub registration_first_name_entry: TemplateChild<gtk::Entry>,
+        #[template_child]
+        pub registration_last_name_entry: TemplateChild<gtk::Entry>,
+        #[template_child]
+        pub registration_error_label: TemplateChild<gtk::Label>,
+        #[template_child]
+        pub tos_label: TemplateChild<gtk::Label>,
+        #[template_child]
         pub password_entry: TemplateChild<gtk::PasswordEntry>,
         #[template_child]
         pub password_error_label: TemplateChild<gtk::Label>,
@@ -63,6 +74,9 @@ mod imp {
                 widget.previous()
             });
             klass.install_action("login.next", None, move |widget, _, _| widget.next());
+            klass.install_action("tos.dialog", None, move |widget, _, _| {
+                widget.show_tos_dialog(false)
+            });
         }
 
         fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
@@ -100,6 +114,11 @@ mod imp {
             settings
                 .bind("use-test-dc", use_test_dc_switch, "state")
                 .build();
+
+            self_.tos_label.connect_activate_link(|label, _| {
+                label.activate_action("tos.dialog", None);
+                gtk::Inhibit(true)
+            });
         }
     }
 
@@ -130,6 +149,8 @@ impl Login {
 
         self_.phone_number_entry.set_text("");
         self_.custom_encryption_key_entry.set_text("");
+        self_.registration_first_name_entry.set_text("");
+        self_.registration_last_name_entry.set_text("");
         self_.code_entry.set_text("");
         self_.password_entry.set_text("");
         self_.encryption_key_entry.set_text("");
@@ -158,8 +179,14 @@ impl Login {
             AuthorizationState::WaitOtherDeviceConfirmation(_) => {
                 todo!()
             }
-            AuthorizationState::WaitRegistration(_) => {
-                todo!()
+            AuthorizationState::WaitRegistration(data) => {
+                self_.show_tos_popup.set(data.terms_of_service.show_popup);
+                self_
+                    .tos_text
+                    .replace(parse_formatted_text(data.terms_of_service.text));
+
+                self_.content.set_visible_child_name("registration-page");
+                self.unfreeze();
             }
             AuthorizationState::WaitPassword(_) => {
                 self_.content.set_visible_child_name("password-page");
@@ -182,20 +209,64 @@ impl Login {
 
         let self_ = imp::Login::from_instance(self);
         let visible_page = self_.content.visible_child_name().unwrap();
-        if visible_page == "phone-number-page" {
-            let encryption_key = self_.custom_encryption_key_entry.text().to_string();
-            if !encryption_key.is_empty() {
-                self.change_encryption_key();
-            }
 
-            self.send_phone_number();
-        } else if visible_page == "code-page" {
-            self.send_code();
-        } else if visible_page == "password-page" {
-            self.send_password();
-        } else if visible_page == "encryption-key-page" {
-            self.send_encryption_key(false);
+        match visible_page.as_str() {
+            "phone-number-page" => {
+                let encryption_key = self_.custom_encryption_key_entry.text().to_string();
+                if !encryption_key.is_empty() {
+                    self.change_encryption_key();
+                }
+
+                self.send_phone_number();
+            }
+            "code-page" => self.send_code(),
+            "registration-page" => {
+                if self_.show_tos_popup.get() {
+                    // Force the ToS dialog for the user before he can proceed
+                    self.show_tos_dialog(true);
+                } else {
+                    // Just proceed if the user either doesn't need to accept the ToS
+                    self.send_registration()
+                }
+            }
+            "password-page" => self.send_password(),
+            "encryption-key-page" => self.send_encryption_key(false),
+            other => unreachable!("no page named '{}'", other),
         }
+    }
+
+    fn show_tos_dialog(&self, user_needs_to_accept: bool) {
+        let self_ = imp::Login::from_instance(self);
+
+        let builder = gtk::MessageDialog::builder()
+            .use_markup(true)
+            .secondary_text(&*self_.tos_text.borrow())
+            .modal(true)
+            .transient_for(self.root().unwrap().downcast_ref::<gtk::Window>().unwrap());
+
+        let dialog = if user_needs_to_accept {
+            builder
+                .buttons(gtk::ButtonsType::YesNo)
+                .text(&gettext("Do You Accept the Terms of Service?"))
+        } else {
+            builder
+                .buttons(gtk::ButtonsType::Ok)
+                .text(&gettext("Terms of Service"))
+        }
+        .build();
+
+        dialog.run_async(clone!(@weak self as obj => move |dialog, response| {
+            if matches!(response, gtk::ResponseType::No) {
+                // If the user declines the ToS, don't proceed and just stay in
+                // the view but unfreeze it again.
+                obj.unfreeze();
+            } else if matches!(response, gtk::ResponseType::Yes) {
+                // User has accepted the ToS, so we can proceed in the login
+                // flow.
+                obj.send_registration();
+            }
+            dialog.close();
+        }));
     }
 
     fn freeze(&self) {
@@ -358,6 +429,32 @@ impl Login {
                     let self_ = imp::Login::from_instance(&obj);
                     self_.code_error_label.set_text(&err.message);
                     self_.code_error_label.set_visible(true);
+
+                    obj.unfreeze();
+                }
+            }),
+        );
+    }
+
+    fn send_registration(&self) {
+        let self_ = imp::Login::from_instance(self);
+        let client_id = self_.client_id.get();
+        let first_name = self_.registration_first_name_entry.text().to_string();
+        let last_name = self_.registration_last_name_entry.text().to_string();
+        do_async(
+            glib::PRIORITY_DEFAULT_IDLE,
+            async move {
+                functions::RegisterUser::new()
+                    .first_name(first_name)
+                    .last_name(last_name)
+                    .send(client_id)
+                    .await
+            },
+            clone!(@weak self as obj => move |result| async move {
+                if let Err(err) = result {
+                    let self_ = imp::Login::from_instance(&obj);
+                    self_.registration_error_label.set_text(&err.message);
+                    self_.registration_error_label.set_visible(true);
 
                     obj.unfreeze();
                 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,8 @@ use gtk::glib;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::future::Future;
+use tdgrand::enums::TextEntityType;
+use tdgrand::types::FormattedText;
 
 use crate::RUNTIME;
 
@@ -30,6 +32,86 @@ pub fn linkify(text: &str) -> String {
     } else {
         text.to_string()
     }
+}
+
+pub fn convert_to_markup(text: String, entity: &TextEntityType) -> String {
+    match entity {
+        TextEntityType::Url => format!("<a href='{}'>{}</a>", linkify(&text), text),
+        TextEntityType::EmailAddress => format!("<a href='mailto:{0}'>{0}</a>", text),
+        TextEntityType::PhoneNumber => format!("<a href='tel:{0}'>{0}</a>", text),
+        TextEntityType::Bold => format!("<b>{}</b>", text),
+        TextEntityType::Italic => format!("<i>{}</i>", text),
+        TextEntityType::Underline => format!("<u>{}</u>", text),
+        TextEntityType::Strikethrough => format!("<s>{}</s>", text),
+        TextEntityType::Code | TextEntityType::Pre | TextEntityType::PreCode(_) => {
+            format!("<tt>{}</tt>", text)
+        }
+        TextEntityType::TextUrl(data) => format!("<a href='{}'>{}</a>", escape(&data.url), text),
+        _ => text,
+    }
+}
+
+pub fn parse_formatted_text(formatted_text: FormattedText) -> String {
+    let mut entities = formatted_text.entities.iter();
+    let mut entity = entities.next();
+    let mut output = String::new();
+    let mut buffer = String::new();
+    let mut is_inside_entity = false;
+
+    // This is the offset in utf16 code units of the text to parse. We need this variable
+    // because tdlib stores the offset and length parameters as utf16 code units instead
+    // of regular code points.
+    let mut code_units_offset = 0;
+
+    for c in formatted_text.text.chars() {
+        if !is_inside_entity
+            && entity.is_some()
+            && code_units_offset >= entity.unwrap().offset as usize
+        {
+            is_inside_entity = true;
+
+            if !buffer.is_empty() {
+                output.push_str(&escape(&buffer));
+                buffer = String::new();
+            }
+        }
+
+        buffer.push(c);
+        code_units_offset += c.len_utf16();
+
+        if let Some(entity_) = entity {
+            if code_units_offset >= (entity_.offset + entity_.length) as usize {
+                buffer = escape(&buffer);
+
+                entity = loop {
+                    let entity = entities.next();
+
+                    // Handle eventual nested entities
+                    match entity {
+                        Some(entity) => {
+                            if entity.offset == entity_.offset {
+                                buffer = convert_to_markup(buffer, &entity.r#type);
+                            } else {
+                                break Some(entity);
+                            }
+                        }
+                        None => break None,
+                    }
+                };
+
+                output.push_str(&convert_to_markup(buffer, &entity_.r#type));
+                buffer = String::new();
+                is_inside_entity = false;
+            }
+        }
+    }
+
+    // Add the eventual leftovers from the buffer to the output
+    if !buffer.is_empty() {
+        output.push_str(&escape(&buffer));
+    }
+
+    output
 }
 
 // Function from https://gitlab.gnome.org/GNOME/fractal/-/blob/fractal-next/src/utils.rs


### PR DESCRIPTION
This commit just adds simple page for registration.
What is still missing is an option to display the Telegram terms of
Service.
But the design how to display the ToS needs to be discussed first.

![register](https://user-images.githubusercontent.com/3630213/134645180-bc679d70-74e8-4d34-aaf4-3e57f1649f3c.png)
