### PR TITLE
Improve login navigation with keyboard (fixes #59)

### DIFF
--- a/src/login.rs
+++ b/src/login.rs
@@ -211,6 +211,12 @@ impl Login {
         imp.registration_last_name_entry.set_text("");
         imp.code_entry.set_text("");
         imp.password_entry.set_text("");
+
+        self.root()
+            .unwrap()
+            .downcast_ref::<gtk::Window>()
+            .unwrap()
+            .set_default_widget(Some(&*imp.next_button));
     }
 
     pub(crate) fn set_authorization_state(&self, state: AuthorizationState) {
@@ -394,6 +400,12 @@ impl Login {
                     imp.session.take().unwrap(),
                     true,
                 );
+
+                self.root()
+                    .unwrap()
+                    .downcast_ref::<gtk::Window>()
+                    .unwrap()
+                    .set_default_widget(None::<&gtk::Widget>);
 
                 // Make everything invisible.
                 imp.outer_box.set_visible(false);


### PR DESCRIPTION
~~Besides trying to fix #59 this commit tries to do the following:~~ It just tries to

1. Allowing the user to hit the enter key to proceed
2. ~~Grabbing focus for the relevant entry after the view has changed~~
3. ~~Re-grabbing focus for the relevant entry after an error ocurred.~~

https://user-images.githubusercontent.com/3630213/134697738-88ba1590-c72e-456c-920a-97db433888b0.mp4


