### PR TITLE
Center content on all pages in the login flow

### DIFF
--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -50,7 +50,6 @@
                 <property name="name">phone-number-page</property>
                 <property name="child">
                   <object class="AdwStatusPage">
-                    <property name="valign">start</property>
                     <property name="icon-name">user-available-symbolic</property>
                     <property name="title" translatable="yes">Welcome to Telegrand</property>
                     <child>
@@ -144,7 +143,6 @@
                 <property name="name">code-page</property>
                 <property name="child">
                   <object class="AdwStatusPage">
-                    <property name="valign">start</property>
                     <property name="icon-name">mail-send-symbolic</property>
                     <property name="title" translatable="yes">Enter the Verification Code</property>
                     <child>
@@ -200,7 +198,6 @@
                 <property name="name">password-page</property>
                 <property name="child">
                   <object class="AdwStatusPage">
-                    <property name="valign">start</property>
                     <property name="icon-name">dialog-password-symbolic</property>
                     <property name="title" translatable="yes">Enter Your Password</property>
                     <child>
@@ -256,7 +253,6 @@
                 <property name="name">encryption-key-page</property>
                 <property name="child">
                   <object class="AdwStatusPage">
-                    <property name="valign">start</property>
                     <property name="icon-name">system-lock-screen-symbolic</property>
                     <property name="title" translatable="yes">Enter the Encryption Key</property>
                     <child>


### PR DESCRIPTION
During the implementing of a ToS dialog (#89) I noticed that the
contents of the pages in the login flow are not centered but are 'start'
aligned.
This looks weird, especially in maximized windows.
In comparison, Fractal and the official client do center their
contents.

This is some preparation for #89 as I would place the clickable label  
at the bottom (like the official client) and having everything else centered
would minimize the distance.

Before:
![before_1](https://user-images.githubusercontent.com/3630213/134739636-9c4ae5e3-2293-4543-9297-a6c3aac78ce7.png)
![before_2](https://user-images.githubusercontent.com/3630213/134739658-1d3dff8b-3099-4dd4-9cee-1a40b1d44807.png)

Now in comparison to Fractal and the official client:

![comparision](https://user-images.githubusercontent.com/3630213/134739708-173fc935-a483-4abe-b428-4987ca88343a.png)

 