### PR TITLE
Set the correct system language code for tdlib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,6 +1067,7 @@ dependencies = [
  "gtk4",
  "indexmap",
  "libadwaita",
+ "locale_config",
  "log",
  "once_cell",
  "pretty_env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ adw = { version = "0.1.0-alpha-5", package = "libadwaita" }
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
 gtk = { version = "0.3", package = "gtk4" }
 indexmap = "1.7"
+locale_config = "0.3"
 log = "0.4"
 once_cell = "1.8"
 pretty_env_logger = "0.4"

--- a/src/login.rs
+++ b/src/login.rs
@@ -2,6 +2,7 @@ use glib::clone;
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
+use locale_config::Locale;
 use tdgrand::{enums::AuthorizationState, functions, types};
 
 use crate::config;
@@ -231,7 +232,7 @@ impl Login {
             use_secret_chats: true,
             api_id: config::TG_API_ID,
             api_hash: config::TG_API_HASH.to_string(),
-            system_language_code: "en-US".to_string(),
+            system_language_code: Locale::current().to_string(),
             device_model: "Desktop".to_string(),
             application_version: config::VERSION.to_string(),
             enable_storage_optimizer: true,


### PR DESCRIPTION
While working on #89, I noticed that the ToS text is shown in English
instead of my system language, German.
The reason is that the user's current locale for tdlib is always set
to 'en-US'.
With this commit, the user's locale is set for tdlib. The database
directory needs to be deleted in order to apply the new settings (at
least when the user is still in the login flow).

Before:
![tos_englisch](https://user-images.githubusercontent.com/3630213/134787204-07aea58a-0145-485b-ac66-2ef775c86778.png)

After:
![tos_german](https://user-images.githubusercontent.com/3630213/134787206-0ca6ef6c-5437-4117-93cb-a393167dfb57.png)

