### PR TITLE
Implement focus grabbing for relevant entries during login

### DIFF
--- a/src/login.rs
+++ b/src/login.rs
@@ -146,7 +146,6 @@ impl Login {
     pub fn login_client(&self, client_id: i32) {
         let self_ = imp::Login::from_instance(self);
         self_.client_id.set(client_id);
-        self_.content.set_visible_child_name("phone-number-page");
 
         self_.phone_number_entry.set_text("");
         self_.custom_encryption_key_entry.set_text("");
@@ -171,6 +170,7 @@ impl Login {
                 self.send_encryption_key(true);
             }
             AuthorizationState::WaitPhoneNumber => {
+                self_.content.set_visible_child_name("phone-number-page");
                 self.unfreeze();
             }
             AuthorizationState::WaitCode(_) => {

--- a/src/login.rs
+++ b/src/login.rs
@@ -369,6 +369,9 @@ impl Login {
 
                         obj.unfreeze();
                     }
+
+                    // In case of an empty key or an error, grab focus for entry again.
+                    self_.encryption_key_entry.grab_focus();
                 }
             }),
         );
@@ -391,6 +394,9 @@ impl Login {
                     let self_ = imp::Login::from_instance(&obj);
                     self_.welcome_page_error_label.set_text(&err.message);
                     self_.welcome_page_error_label.set_visible(true);
+
+                    // Grab focus for entry again after error.
+                    self_.custom_encryption_key_entry.grab_focus();
                 }
             }),
         );
@@ -415,6 +421,9 @@ impl Login {
                     self_.welcome_page_error_label.set_visible(true);
 
                     obj.unfreeze();
+
+                    // Grab focus for entry again after error.
+                    self_.phone_number_entry.grab_focus();
                 }
             }),
         );
@@ -439,6 +448,9 @@ impl Login {
                     self_.code_error_label.set_visible(true);
 
                     obj.unfreeze();
+
+                    // Grab focus for entry again after error.
+                    self_.code_entry.grab_focus();
                 }
             }),
         );
@@ -465,6 +477,9 @@ impl Login {
                     self_.registration_error_label.set_visible(true);
 
                     obj.unfreeze();
+
+                    // Grab focus for entry again after error.
+                    self_.registration_first_name_entry.grab_focus();
                 }
             }),
         );
@@ -489,6 +504,9 @@ impl Login {
                     self_.password_error_label.set_visible(true);
 
                     obj.unfreeze();
+
+                    // Grab focus for entry again after error.
+                    self_.password_entry.grab_focus();
                 }
             }),
         );

--- a/src/login.rs
+++ b/src/login.rs
@@ -172,10 +172,12 @@ impl Login {
             AuthorizationState::WaitPhoneNumber => {
                 self_.content.set_visible_child_name("phone-number-page");
                 self.unfreeze();
+                self_.phone_number_entry.grab_focus();
             }
             AuthorizationState::WaitCode(_) => {
                 self_.content.set_visible_child_name("code-page");
                 self.unfreeze();
+                self_.code_entry.grab_focus();
             }
             AuthorizationState::WaitOtherDeviceConfirmation(_) => {
                 todo!()
@@ -188,10 +190,12 @@ impl Login {
 
                 self_.content.set_visible_child_name("registration-page");
                 self.unfreeze();
+                self_.registration_first_name_entry.grab_focus();
             }
             AuthorizationState::WaitPassword(_) => {
                 self_.content.set_visible_child_name("password-page");
                 self.unfreeze();
+                self_.password_entry.grab_focus();
             }
             AuthorizationState::Ready => {
                 self.emit_by_name("new-session", &[]).unwrap();
@@ -203,6 +207,9 @@ impl Login {
     fn previous(&self) {
         let self_ = imp::Login::from_instance(self);
         self_.content.set_visible_child_name("phone-number-page");
+
+        // Grab focus for entry after reset.
+        self_.phone_number_entry.grab_focus();
     }
 
     fn next(&self) {


### PR DESCRIPTION
Originally, focus grabbing was supposed to be part of #90.
But I decided to make a separate PR for it because pressing the Enter key,
which was supposed to solve bug #59 and was also part of #90, gave me unwanted warnings.
The two things can be separated anyway, and so #90 can be more specific to the solution of #59.

So basically this PR tries to do the following within the login flow:
1. Grabbing focus for the relevant entry after the transition from a previous page
2. Re-grabbing focus for the relevant entry after an error occurred.