### PR TITLE
Show a loading screen (fix #63 and fix #71)

### DIFF
--- a/data/resources/ui/content-chat-history.ui
+++ b/data/resources/ui/content-chat-history.ui
@@ -26,20 +26,23 @@
           </object>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
-            <property name="vexpand">True</property>
-            <property name="hscrollbar-policy">never</property>
-            <style>
-              <class name="view"/>
-              <class name="chat-history"/>
-            </style>
-            <property name="child">
-              <object class="AdwClampScrollable">
+          <object class="GtkBox" id="scrolled_window">
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="vexpand">True</property>
+                <property name="hscrollbar-policy">never</property>
+                <style>
+                  <class name="view"/>
+                  <class name="chat-history"/>
+                </style>
                 <property name="child">
-                  <object class="GtkListView" id="history_list_view">
-                    <property name="factory">
-                      <object class="GtkBuilderListItemFactory">
-                        <property name="bytes"><![CDATA[
+                  <object class="AdwClampScrollable">
+                    <property name="child">
+                      <object class="GtkListView" id="history_list_view">
+                        <property name="factory">
+                          <object class="GtkBuilderListItemFactory">
+                            <property name="bytes"><![CDATA[
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <template class="GtkListItem">
@@ -54,57 +57,59 @@
     </property>
   </template>
 </interface>
-                        ]]></property>
-                      </object>
-                    </property>
-                  </object>
-                </property>
-              </object>
-            </property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkSeparator"/>
-        </child>
-        <child>
-          <object class="AdwClamp">
-            <child>
-              <object class="GtkBox">
-                <property name="spacing">6</property>
-                <style>
-                  <class name="send-message-area"/>
-                </style>
-                <child>
-                  <object class="GtkFrame">
-                    <property name="child">
-                      <object class="GtkScrolledWindow">
-                        <property name="hexpand">True</property>
-                        <property name="max-content-height">200</property>
-                        <property name="hscrollbar-policy">never</property>
-                        <property name="vscrollbar-policy">external</property>
-                        <property name="propagate-natural-height">True</property>
-                        <property name="child">
-                          <object class="GtkTextView" id="message_entry">
-                            <property name="top-margin">6</property>
-                            <property name="bottom-margin">6</property>
-                            <property name="left-margin">6</property>
-                            <property name="right-margin">6</property>
-                            <property name="wrap-mode">word-char</property>
+                         ]]></property>
                           </object>
                         </property>
                       </object>
                     </property>
                   </object>
-                </child>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSeparator"/>
+            </child>
+            <child>
+              <object class="AdwClamp">
                 <child>
-                  <object class="GtkButton">
-                    <property name="valign">end</property>
-                    <property name="action-name">history.send-message</property>
-                    <property name="icon-name">mail-send-symbolic</property>
+                  <object class="GtkBox">
+                    <property name="spacing">6</property>
                     <style>
-                      <class name="circular"/>
-                      <class name="suggested-action"/>
+                      <class name="send-message-area"/>
                     </style>
+                    <child>
+                      <object class="GtkFrame">
+                        <property name="child">
+                          <object class="GtkScrolledWindow">
+                            <property name="hexpand">True</property>
+                            <property name="max-content-height">200</property>
+                            <property name="hscrollbar-policy">never</property>
+                            <property name="vscrollbar-policy">external</property>
+                            <property name="propagate-natural-height">True</property>
+                            <property name="child">
+                              <object class="GtkTextView" id="message_entry">
+                                <property name="top-margin">6</property>
+                                <property name="bottom-margin">6</property>
+                                <property name="left-margin">6</property>
+                                <property name="right-margin">6</property>
+                                <property name="wrap-mode">word-char</property>
+                              </object>
+                            </property>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton">
+                        <property name="valign">end</property>
+                        <property name="action-name">history.send-message</property>
+                        <property name="icon-name">mail-send-symbolic</property>
+                        <style>
+                          <class name="circular"/>
+                          <class name="suggested-action"/>
+                        </style>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/data/resources/ui/content.ui
+++ b/data/resources/ui/content.ui
@@ -16,7 +16,7 @@
               </object>
             </child>
             <child>
-              <object class="AdwStatusPage">
+              <object class="AdwStatusPage" id="unselected_chat_status_page">
                 <property name="vexpand">True</property>
                 <property name="icon-name">user-available-symbolic</property>
                 <property name="title" translatable="yes">No Chat Selected</property>

--- a/data/resources/ui/session.ui
+++ b/data/resources/ui/session.ui
@@ -4,7 +4,7 @@
     <child>
       <object class="AdwLeaflet" id="leaflet">
         <child>
-          <object class="Sidebar">
+          <object class="Sidebar" id="sidebar">
             <property name="compact" bind-source="leaflet" bind-property="folded" bind-flags="sync-create"/>
             <property name="chat-list" bind-source="Session" bind-property="chat-list" bind-flags="sync-create"/>
             <property name="selected-chat" bind-source="Session" bind-property="selected-chat" bind-flags="sync-create | bidirectional"/>
@@ -24,7 +24,7 @@
           </object>
         </child>
         <child>
-          <object class="Content">
+          <object class="Content" id="content">
             <property name="compact" bind-source="leaflet" bind-property="folded" bind-flags="sync-create"/>
             <property name="chat" bind-source="Session" bind-property="selected-chat" bind-flags="sync-create | bidirectional"/>
           </object>

--- a/data/resources/ui/sidebar.ui
+++ b/data/resources/ui/sidebar.ui
@@ -27,7 +27,7 @@
           <object class="AdwHeaderBar">
             <property name="show-end-title-buttons" bind-source="Sidebar" bind-property="compact" bind-flags="sync-create"/>
             <child type="end">
-              <object class="GtkMenuButton">
+              <object class="GtkMenuButton" id="menu_button">
                 <property name="icon-name">open-menu-symbolic</property>
                 <property name="menu-model">primary_menu</property>
               </object>
@@ -35,7 +35,7 @@
           </object>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
+          <object class="GtkScrolledWindow" id="scrolled_window">
             <property name="vexpand">True</property>
             <property name="hscrollbar-policy">never</property>
             <child>

--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -5,8 +5,26 @@
     <property name="default-height">600</property>
     <property name="content">
       <object class="GtkStack" id="main_stack">
-        <property name="visible-child">login</property>
+        <property name="visible-child">loading_widget</property>
         <property name="transition-type">crossfade</property>
+        <child>
+          <object class="GtkBox" id="loading_widget">
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkHeaderBar"/>
+            </child>
+            <child>
+              <object class="GtkSpinner">
+                <property name="vexpand">True</property>
+                <property name="spinning">true</property>
+                <property name="width-request">32</property>
+                <property name="height-request">32</property>
+                <property name="valign">center</property>
+                <property name="halign">center</property>
+              </object>
+            </child>
+          </object>
+        </child>
         <child>
           <object class="Login" id="login" />
         </child>

--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -8,21 +8,8 @@
         <property name="visible-child">loading_widget</property>
         <property name="transition-type">crossfade</property>
         <child>
-          <object class="GtkBox" id="loading_widget">
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkHeaderBar"/>
-            </child>
-            <child>
-              <object class="GtkSpinner">
-                <property name="vexpand">True</property>
-                <property name="spinning">true</property>
-                <property name="width-request">32</property>
-                <property name="height-request">32</property>
-                <property name="valign">center</property>
-                <property name="halign">center</property>
-              </object>
-            </child>
+          <object class="GtkHeaderBar" id="loading_widget">
+            <property name="valign">start</property>
           </object>
         </child>
         <child>

--- a/src/session/content/chat_history.rs
+++ b/src/session/content/chat_history.rs
@@ -20,6 +20,8 @@ mod imp {
         pub compact: Cell<bool>,
         pub chat: RefCell<Option<Chat>>,
         #[template_child]
+        pub scrolled_window: TemplateChild<gtk::Box>,
+        #[template_child]
         pub history_list_view: TemplateChild<gtk::ListView>,
         #[template_child]
         pub message_entry: TemplateChild<gtk::TextView>,
@@ -156,6 +158,12 @@ impl Default for ChatHistory {
 impl ChatHistory {
     pub fn new() -> Self {
         glib::Object::new(&[]).expect("Failed to create ChatHistory")
+    }
+
+    pub fn freeze(&self) {
+        imp::ChatHistory::from_instance(self)
+            .scrolled_window
+            .set_sensitive(false);
     }
 
     fn send_message(&self) {

--- a/src/session/content/mod.rs
+++ b/src/session/content/mod.rs
@@ -35,6 +35,8 @@ mod imp {
         #[template_child]
         pub unselected_chat: TemplateChild<gtk::Box>,
         #[template_child]
+        pub unselected_chat_status_page: TemplateChild<adw::StatusPage>,
+        #[template_child]
         pub chat_history: TemplateChild<ChatHistory>,
     }
 
@@ -129,6 +131,12 @@ impl Default for Content {
 impl Content {
     pub fn new() -> Self {
         glib::Object::new(&[]).expect("Failed to create Content")
+    }
+
+    pub fn freeze(&self) {
+        let self_ = imp::Content::from_instance(self);
+        self_.unselected_chat_status_page.set_sensitive(false);
+        self_.chat_history.freeze();
     }
 
     pub fn chat(&self) -> Option<Chat> {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -44,6 +44,10 @@ mod imp {
         pub downloading_files: RefCell<HashMap<i32, Vec<SyncSender<File>>>>,
         #[template_child]
         pub leaflet: TemplateChild<adw::Leaflet>,
+        #[template_child]
+        pub sidebar: TemplateChild<Sidebar>,
+        #[template_child]
+        pub content: TemplateChild<Content>,
     }
 
     #[glib::object_subclass]
@@ -229,8 +233,14 @@ impl Session {
         }
     }
 
+    fn freeze(&self) {
+        let self_ = imp::Session::from_instance(self);
+        self_.sidebar.freeze();
+        self_.content.freeze();
+    }
+
     fn log_out(&self) {
-        self.emit_by_name("logging-out", &[]).unwrap();
+        self.freeze();
         let client_id = self.client_id();
         RUNTIME.spawn(async move {
             functions::LogOut::new().send(client_id).await.unwrap();

--- a/src/session/sidebar/mod.rs
+++ b/src/session/sidebar/mod.rs
@@ -25,6 +25,10 @@ mod imp {
         pub filter: OnceCell<gtk::CustomFilter>,
         pub sorter: OnceCell<gtk::CustomSorter>,
         #[template_child]
+        pub menu_button: TemplateChild<gtk::MenuButton>,
+        #[template_child]
+        pub scrolled_window: TemplateChild<gtk::ScrolledWindow>,
+        #[template_child]
         pub chat_list_view: TemplateChild<gtk::ListView>,
     }
 
@@ -126,6 +130,12 @@ impl Default for Sidebar {
 impl Sidebar {
     pub fn new() -> Self {
         glib::Object::new(&[]).expect("Failed to create Sidebar")
+    }
+
+    pub fn freeze(&self) {
+        let self_ = imp::Sidebar::from_instance(self);
+        self_.menu_button.set_sensitive(false);
+        self_.scrolled_window.set_sensitive(false);
     }
 
     pub fn set_chat_list(&self, chat_list: ChatList) {


### PR DESCRIPTION
With this commit, a loading screen is shown when the application starts
and when a user logs out.

This should fix #63 and resolve #71.

Btw, showing a loading screen when logging out will prevent a crash in a tokio worker thread.
This crash happens when the user tries to log out again while the session view is still visible.

```
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: Error { code: 8, message: "Already logging out" }', src/session/mod.rs:243:60
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR is still marked as draft, because there is one thing to discuss regarding the spinner.
It is currently maybe a bit too "heavy".
Solutions are
1. Leave it as it is?
2. make it smaller (fixed size or expanding with greater margin)?
3. remove it completely?

Also, I need to carefully look at the changes for myself and be sure that nothing is missing and also
check if I can split up the commit. 

I recorded the behaviour before and after the change (ignore the water sign, I was too lazy today for ffmeg :smiley:) 

Before (from 00:15 you can see the flashing)

https://user-images.githubusercontent.com/3630213/134986985-a422b87a-5c02-4ae9-a3df-32d98973b0fe.mp4

After (from 00:16)

https://user-images.githubusercontent.com/3630213/134987340-d26582b5-b8fb-469f-8ee1-d16c31b74016.mp4



