### PR TITLE
Send typing chat action

### DIFF
--- a/data/resources/resources.gresource.xml
+++ b/data/resources/resources.gresource.xml
@@ -8,6 +8,7 @@
     <file compressed="true" preprocess="xml-stripblanks">ui/content-message-bubble.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content-message-row.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content-message-sticker.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/content-send-message-area.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/login.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/session.ui</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="gtk/help-overlay.ui">ui/shortcuts.ui</file>

--- a/data/resources/ui/content-chat-history.ui
+++ b/data/resources/ui/content-chat-history.ui
@@ -36,7 +36,7 @@
             <property name="child">
               <object class="AdwClampScrollable">
                 <property name="child">
-                  <object class="GtkListView" id="history_list_view">
+                  <object class="GtkListView" id="list_view">
                     <property name="factory">
                       <object class="GtkBuilderListItemFactory">
                         <property name="bytes"><![CDATA[
@@ -68,47 +68,13 @@
         </child>
         <child>
           <object class="AdwClamp">
-            <child>
-              <object class="GtkBox">
-                <property name="spacing">6</property>
-                <style>
-                  <class name="send-message-area"/>
-                </style>
-                <child>
-                  <object class="GtkFrame">
-                    <property name="child">
-                      <object class="GtkScrolledWindow">
-                        <property name="hexpand">True</property>
-                        <property name="max-content-height">200</property>
-                        <property name="hscrollbar-policy">never</property>
-                        <property name="vscrollbar-policy">external</property>
-                        <property name="propagate-natural-height">True</property>
-                        <property name="child">
-                          <object class="GtkTextView" id="message_entry">
-                            <property name="top-margin">6</property>
-                            <property name="bottom-margin">6</property>
-                            <property name="left-margin">6</property>
-                            <property name="right-margin">6</property>
-                            <property name="wrap-mode">word-char</property>
-                          </object>
-                        </property>
-                      </object>
-                    </property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkButton">
-                    <property name="valign">end</property>
-                    <property name="action-name">history.send-message</property>
-                    <property name="icon-name">mail-send-symbolic</property>
-                    <style>
-                      <class name="circular"/>
-                      <class name="suggested-action"/>
-                    </style>
-                  </object>
-                </child>
+            <property name="child">
+              <object class="ContentSendMessageArea">
+                <binding name="chat">
+                  <lookup name="chat">ContentChatHistory</lookup>
+                </binding>
               </object>
-            </child>
+            </property>
           </object>
         </child>
       </object>

--- a/data/resources/ui/content-send-message-area.ui
+++ b/data/resources/ui/content-send-message-area.ui
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="ContentSendMessageArea" parent="AdwBin">
+    <style>
+      <class name="send-message-area"/>
+    </style>
+    <property name="child">
+      <object class="GtkBox">
+        <property name="spacing">6</property>
+        <child>
+          <object class="GtkFrame">
+            <property name="child">
+              <object class="GtkScrolledWindow">
+                <property name="hexpand">True</property>
+                <property name="max-content-height">200</property>
+                <property name="hscrollbar-policy">never</property>
+                <property name="vscrollbar-policy">external</property>
+                <property name="propagate-natural-height">True</property>
+                <property name="child">
+                  <object class="GtkTextView" id="message_entry">
+                    <property name="top-margin">6</property>
+                    <property name="bottom-margin">6</property>
+                    <property name="left-margin">6</property>
+                    <property name="right-margin">6</property>
+                    <property name="wrap-mode">word-char</property>
+                  </object>
+                </property>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton">
+            <property name="valign">end</property>
+            <property name="action-name">send-message-area.send-text-message</property>
+            <property name="icon-name">mail-send-symbolic</property>
+            <style>
+              <class name="circular"/>
+              <class name="suggested-action"/>
+            </style>
+          </object>
+        </child>
+      </object>
+    </property>
+  </template>
+</interface>

--- a/src/meson.build
+++ b/src/meson.build
@@ -45,6 +45,7 @@ rust_sources = files(
   'session/content/message_row.rs',
   'session/content/message_sticker.rs',
   'session/content/mod.rs',
+  'session/content/send_message_area.rs',
   'session/sidebar/chat_row.rs',
   'session/sidebar/mod.rs',
 )

--- a/src/session/content/chat_history.rs
+++ b/src/session/content/chat_history.rs
@@ -1,16 +1,14 @@
-use glib::{clone, signal::Inhibit};
-use gtk::prelude::*;
-use gtk::subclass::prelude::*;
-use gtk::{gdk, glib};
-use tdgrand::{enums, functions, types};
+use glib::clone;
+use gtk::{glib, prelude::*, subclass::prelude::*, CompositeTemplate};
 
-use crate::session::{content::ItemRow, Chat};
-use crate::RUNTIME;
+use crate::session::{
+    content::{ItemRow, SendMessageArea},
+    Chat,
+};
 
 mod imp {
     use super::*;
     use adw::subclass::prelude::BinImpl;
-    use gtk::CompositeTemplate;
     use once_cell::sync::Lazy;
     use std::cell::{Cell, RefCell};
 
@@ -20,9 +18,7 @@ mod imp {
         pub compact: Cell<bool>,
         pub chat: RefCell<Option<Chat>>,
         #[template_child]
-        pub history_list_view: TemplateChild<gtk::ListView>,
-        #[template_child]
-        pub message_entry: TemplateChild<gtk::TextView>,
+        pub list_view: TemplateChild<gtk::ListView>,
     }
 
     #[glib::object_subclass]
@@ -33,11 +29,8 @@ mod imp {
 
         fn class_init(klass: &mut Self::Class) {
             ItemRow::static_type();
+            SendMessageArea::static_type();
             Self::bind_template(klass);
-
-            klass.install_action("history.send-message", None, move |widget, _, _| {
-                widget.send_message();
-            });
         }
 
         fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
@@ -65,7 +58,6 @@ mod imp {
                     ),
                 ]
             });
-
             PROPERTIES.as_ref()
         }
 
@@ -100,41 +92,10 @@ mod imp {
         fn constructed(&self, obj: &Self::Type) {
             self.parent_constructed(obj);
 
-            let adj = self.history_list_view.vadjustment().unwrap();
+            let adj = self.list_view.vadjustment().unwrap();
             adj.connect_value_changed(clone!(@weak obj => move |adj| {
                 obj.load_older_messages(adj);
             }));
-
-            let message_buffer = self.message_entry.buffer();
-            self.message_entry.buffer().connect_text_notify(
-                clone!(@weak obj => move |_: &gtk::TextBuffer| {
-                    let should_enable = !message_buffer
-                            .text(&message_buffer.start_iter(), &message_buffer.end_iter(), true)
-                            .trim()
-                            .is_empty();
-                    obj.action_set_enabled("history.send-message", should_enable);
-                }),
-            );
-
-            // Buffer is always empty at this point, so unconditionally disable sending of messages
-            obj.action_set_enabled("history.send-message", false);
-
-            let key_events = gtk::EventControllerKey::new();
-            self.message_entry.add_controller(&key_events);
-
-            key_events.connect_key_pressed(
-                clone!(@weak obj => @default-return Inhibit(false), move |_, key, _, modifier| {
-                    if !modifier.contains(gdk::ModifierType::SHIFT_MASK)
-                        && (key == gdk::keys::constants::Return
-                            || key == gdk::keys::constants::KP_Enter)
-                    {
-                        obj.activate_action("history.send-message", None);
-                        Inhibit(true)
-                    } else {
-                        Inhibit(false)
-                    }
-                }),
-            );
         }
     }
 
@@ -158,76 +119,6 @@ impl ChatHistory {
         glib::Object::new(&[]).expect("Failed to create ChatHistory")
     }
 
-    fn send_message(&self) {
-        if let Some(chat) = self.chat() {
-            let self_ = imp::ChatHistory::from_instance(self);
-            let buffer = self_.message_entry.buffer();
-            let text = types::FormattedText {
-                text: buffer
-                    .text(&buffer.start_iter(), &buffer.end_iter(), true)
-                    .to_string(),
-                ..Default::default()
-            };
-            let content = types::InputMessageText {
-                text,
-                clear_draft: true,
-                ..Default::default()
-            };
-            let message = enums::InputMessageContent::InputMessageText(content);
-
-            let client_id = chat.session().client_id();
-            let chat_id = chat.id();
-
-            RUNTIME.spawn(async move {
-                functions::SendMessage::new()
-                    .chat_id(chat_id)
-                    .input_message_content(message)
-                    .send(client_id)
-                    .await
-                    .unwrap();
-            });
-
-            buffer.set_text("");
-        }
-    }
-
-    fn save_draft_message(&self) {
-        if let Some(chat) = self.chat() {
-            let self_ = imp::ChatHistory::from_instance(self);
-            let buffer = self_.message_entry.buffer();
-            let draft = buffer
-                .text(&buffer.start_iter(), &buffer.end_iter(), true)
-                .to_string();
-
-            if chat.draft_message() != draft {
-                let text = types::FormattedText {
-                    text: draft,
-                    ..Default::default()
-                };
-                let content = types::InputMessageText {
-                    text,
-                    ..Default::default()
-                };
-                let draft_message = types::DraftMessage {
-                    input_message_text: enums::InputMessageContent::InputMessageText(content),
-                    ..Default::default()
-                };
-
-                let client_id = chat.session().client_id();
-                let chat_id = chat.id();
-
-                RUNTIME.spawn(async move {
-                    functions::SetChatDraftMessage::new()
-                        .chat_id(chat_id)
-                        .draft_message(draft_message)
-                        .send(client_id)
-                        .await
-                        .unwrap();
-                });
-            }
-        }
-    }
-
     fn load_older_messages(&self, adj: &gtk::Adjustment) {
         if adj.value() < adj.page_size() * 2.0 || adj.upper() <= adj.page_size() * 2.0 {
             if let Some(chat) = self.chat() {
@@ -246,20 +137,16 @@ impl ChatHistory {
             return;
         }
 
-        self.save_draft_message();
-
         let self_ = imp::ChatHistory::from_instance(self);
         if let Some(ref chat) = chat {
-            self_.message_entry.buffer().set_text(&chat.draft_message());
-
             let selection = gtk::NoSelection::new(Some(&chat.history()));
-            self_.history_list_view.set_model(Some(&selection));
+            self_.list_view.set_model(Some(&selection));
         }
 
         self_.chat.replace(chat);
         self.notify("chat");
 
-        let adj = self_.history_list_view.vadjustment().unwrap();
+        let adj = self_.list_view.vadjustment().unwrap();
         self.load_older_messages(&adj);
     }
 }

--- a/src/session/content/mod.rs
+++ b/src/session/content/mod.rs
@@ -4,6 +4,7 @@ mod item_row;
 mod message_bubble;
 mod message_row;
 mod message_sticker;
+mod send_message_area;
 
 use self::chat_history::ChatHistory;
 use self::event_row::EventRow;
@@ -11,6 +12,7 @@ use self::item_row::ItemRow;
 use self::message_bubble::MessageBubble;
 use self::message_row::MessageRow;
 use self::message_sticker::MessageSticker;
+use self::send_message_area::SendMessageArea;
 
 use gtk::glib;
 use gtk::prelude::*;

--- a/src/session/content/send_message_area.rs
+++ b/src/session/content/send_message_area.rs
@@ -1,0 +1,229 @@
+use glib::{clone, signal::Inhibit};
+use gtk::{gdk, glib, prelude::*, subclass::prelude::*, CompositeTemplate};
+use tdgrand::{enums::InputMessageContent, functions, types};
+
+use crate::session::Chat;
+use crate::RUNTIME;
+
+mod imp {
+    use super::*;
+    use adw::subclass::prelude::BinImpl;
+    use once_cell::sync::Lazy;
+    use std::cell::RefCell;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(resource = "/com/github/melix99/telegrand/ui/content-send-message-area.ui")]
+    pub struct SendMessageArea {
+        pub chat: RefCell<Option<Chat>>,
+        #[template_child]
+        pub message_entry: TemplateChild<gtk::TextView>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for SendMessageArea {
+        const NAME: &'static str = "ContentSendMessageArea";
+        type Type = super::SendMessageArea;
+        type ParentType = adw::Bin;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+
+            klass.install_action(
+                "send-message-area.send-text-message",
+                None,
+                move |widget, _, _| {
+                    widget.send_text_message();
+                },
+            );
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for SendMessageArea {
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![glib::ParamSpec::new_object(
+                    "chat",
+                    "Chat",
+                    "The chat associated with this widget",
+                    Chat::static_type(),
+                    glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                )]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(
+            &self,
+            obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "chat" => {
+                    let chat = value.get().unwrap();
+                    obj.set_chat(chat);
+                }
+                _ => unimplemented!(),
+            }
+        }
+
+        fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "chat" => obj.chat().to_value(),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn constructed(&self, obj: &Self::Type) {
+            self.parent_constructed(obj);
+
+            // Enable the send-text-message action only when the message entry contains text
+            let message_buffer = self.message_entry.buffer();
+            message_buffer.connect_text_notify(clone!(@weak obj => move |_| {
+                let should_enable = !obj.message_entry_text().is_empty();
+                obj.action_set_enabled("send-message-area.send-text-message", should_enable);
+            }));
+
+            // The message entry is always empty at this point, so disable the
+            // send-text-message action
+            obj.action_set_enabled("send-message-area.send-text-message", false);
+
+            // Handle the enter key to send the message and also the combination of if with the
+            // right modifier keys to add new lines to the entry
+            let key_events = gtk::EventControllerKey::new();
+            self.message_entry.add_controller(&key_events);
+            key_events.connect_key_pressed(
+                clone!(@weak obj => @default-return Inhibit(false), move |_, key, _, modifier| {
+                    if !modifier.contains(gdk::ModifierType::SHIFT_MASK)
+                        && (key == gdk::keys::constants::Return
+                            || key == gdk::keys::constants::KP_Enter)
+                    {
+                        obj.activate_action("send-message-area.send-text-message", None);
+                        Inhibit(true)
+                    } else {
+                        Inhibit(false)
+                    }
+                }),
+            );
+        }
+    }
+
+    impl WidgetImpl for SendMessageArea {}
+    impl BinImpl for SendMessageArea {}
+}
+
+glib::wrapper! {
+    pub struct SendMessageArea(ObjectSubclass<imp::SendMessageArea>)
+        @extends gtk::Widget, adw::Bin;
+}
+
+impl Default for SendMessageArea {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SendMessageArea {
+    pub fn new() -> Self {
+        glib::Object::new(&[]).expect("Failed to create SendMessageArea")
+    }
+
+    fn message_entry_text(&self) -> String {
+        let self_ = imp::SendMessageArea::from_instance(self);
+        let buffer = self_.message_entry.buffer();
+        buffer
+            .text(&buffer.start_iter(), &buffer.end_iter(), true)
+            .trim()
+            .to_string()
+    }
+
+    fn compose_text_message(&self) -> InputMessageContent {
+        let text = types::FormattedText {
+            text: self.message_entry_text(),
+            ..Default::default()
+        };
+        let content = types::InputMessageText {
+            text,
+            clear_draft: true,
+            ..Default::default()
+        };
+
+        InputMessageContent::InputMessageText(content)
+    }
+
+    fn send_text_message(&self) {
+        if let Some(chat) = self.chat() {
+            let message = self.compose_text_message();
+            let client_id = chat.session().client_id();
+            let chat_id = chat.id();
+
+            // Send the message
+            RUNTIME.spawn(async move {
+                functions::SendMessage::new()
+                    .chat_id(chat_id)
+                    .input_message_content(message)
+                    .send(client_id)
+                    .await
+                    .unwrap();
+            });
+
+            // Reset message entry
+            let self_ = imp::SendMessageArea::from_instance(self);
+            let buffer = self_.message_entry.buffer();
+            buffer.set_text("");
+        }
+    }
+
+    fn save_message_as_draft(&self) {
+        if let Some(chat) = self.chat() {
+            let message = self.compose_text_message();
+            let draft_message = types::DraftMessage {
+                input_message_text: message,
+                ..Default::default()
+            };
+            let client_id = chat.session().client_id();
+            let chat_id = chat.id();
+
+            // Save draft message
+            RUNTIME.spawn(async move {
+                functions::SetChatDraftMessage::new()
+                    .chat_id(chat_id)
+                    .draft_message(draft_message)
+                    .send(client_id)
+                    .await
+                    .unwrap();
+            });
+        }
+    }
+
+    fn load_draft_message(&self, message: String) {
+        let self_ = imp::SendMessageArea::from_instance(self);
+        self_.message_entry.buffer().set_text(&message);
+    }
+
+    pub fn chat(&self) -> Option<Chat> {
+        let self_ = imp::SendMessageArea::from_instance(self);
+        self_.chat.borrow().clone()
+    }
+
+    fn set_chat(&self, chat: Option<Chat>) {
+        if self.chat() == chat {
+            return;
+        }
+
+        self.save_message_as_draft();
+
+        if let Some(ref chat) = chat {
+            self.load_draft_message(chat.draft_message());
+        }
+
+        let self_ = imp::SendMessageArea::from_instance(self);
+        self_.chat.replace(chat);
+        self.notify("chat");
+    }
+}


### PR DESCRIPTION
Fixes #84.

This PR separates the send-message-area widget from the chat-history to improve the manageability of the code and reports to TDLib when the user is typing a new message.

~This is marked as draft because I noticed that making a request for every pressed key will cause FLOOD_WAIT responses very fast, so we need to add a sort of cool-down for the requests before merging this.~ Done.