### PR TITLE
Prevent flashing/glitching in several places

### DIFF
--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -2,392 +2,415 @@
 <interface>
   <template class="Login" parent="AdwBin">
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
+      <object class="GtkStack" id="main_stack">
+        <property name="transition-type">crossfade</property>
         <child>
-          <object class="GtkHeaderBar">
-            <child type="start">
-              <object class="GtkButton" id="previous_button">
-                <property name="visible">False</property>
-                <property name="action-name">login.previous</property>
-                <property name="use-underline">True</property>
-                <property name="label" translatable="yes">_Previous</property>
-              </object>
-            </child>
-            <child type="end">
-              <object class="GtkButton">
-                <property name="action-name">login.next</property>
-                <property name="child">
-                  <object class="GtkStack" id="next_stack">
-                    <child>
-                      <object class="GtkLabel" id="next_label">
-                        <property name="use-underline">True</property>
-                        <property name="label" translatable="yes">_Next</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSpinner" id="next_spinner">
-                        <property name="spinning">True</property>
-                        <property name="valign">center</property>
-                        <property name="halign">center</property>
-                      </object>
-                    </child>
-                  </object>
+          <object class="GtkStackPage">
+            <property name="name">empty-page</property>
+            <property name="child">
+              <object class="GtkHeaderBar">
+                <property name="valign">start</property>
+                <property name="title-widget">
+                  <object class="AdwBin"/>
                 </property>
-                <style>
-                  <class name="suggested-action"/>
-                </style>
               </object>
-            </child>
+            </property>
           </object>
         </child>
         <child>
-          <object class="AdwLeaflet" id="content">
-            <property name="can-unfold">False</property>
-            <property name="vexpand">True</property>
-            <child>
-              <object class="AdwLeafletPage">
-                <property name="name">phone-number-page</property>
-                <property name="child">
-                  <object class="AdwStatusPage">
-                    <property name="icon-name">user-available-symbolic</property>
-                    <property name="title" translatable="yes">Welcome to Telegrand</property>
-                    <child>
-                      <object class="AdwClamp">
-                        <property name="maximum-size">300</property>
-                        <property name="tightening-threshold">200</property>
+          <object class="GtkStackPage">
+            <property name="name">login-flow-page</property>
+            <property name="child">
+              <object class="GtkBox">
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkHeaderBar">
+                    <child type="start">
+                      <object class="GtkButton" id="previous_button">
+                        <property name="visible">False</property>
+                        <property name="action-name">login.previous</property>
+                        <property name="use-underline">True</property>
+                        <property name="label" translatable="yes">_Previous</property>
+                      </object>
+                    </child>
+                    <child type="end">
+                      <object class="GtkButton">
+                        <property name="action-name">login.next</property>
                         <property name="child">
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="spacing">12</property>
+                          <object class="GtkStack" id="next_stack">
                             <child>
-                              <object class="GtkListBox">
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="focusable">False</property>
-                                    <property name="selectable">False</property>
-                                    <property name="activatable">False</property>
-                                    <property name="child">
-                                      <object class="GtkEntry" id="phone_number_entry">
-                                        <property name="activates-default">True</property>
-                                        <property name="placeholder-text" translatable="yes">Phone Number</property>
-                                        <property name="margin-top">6</property>
-                                        <property name="margin-bottom">6</property>
-                                        <property name="margin-start">6</property>
-                                        <property name="margin-end">6</property>
-                                      </object>
-                                    </property>
-                                  </object>
-                                </child>
-                                <style>
-                                  <class name="content"/>
-                                </style>
+                              <object class="GtkLabel" id="next_label">
+                                <property name="use-underline">True</property>
+                                <property name="label" translatable="yes">_Next</property>
                               </object>
                             </child>
                             <child>
-                              <object class="GtkListBox">
-                                <child>
-                                  <object class="AdwExpanderRow">
-                                    <property name="focusable">False</property>
-                                    <property name="selectable">False</property>
-                                    <property name="activatable">False</property>
-                                    <property name="title" translatable="yes">Advanced</property>
+                              <object class="GtkSpinner" id="next_spinner">
+                                <property name="spinning">True</property>
+                                <property name="valign">center</property>
+                                <property name="halign">center</property>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                        <style>
+                          <class name="suggested-action"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwLeaflet" id="content">
+                    <property name="can-unfold">False</property>
+                    <property name="vexpand">True</property>
+                    <child>
+                      <object class="AdwLeafletPage">
+                        <property name="name">phone-number-page</property>
+                        <property name="child">
+                          <object class="AdwStatusPage">
+                            <property name="icon-name">user-available-symbolic</property>
+                            <property name="title" translatable="yes">Welcome to Telegrand</property>
+                            <child>
+                              <object class="AdwClamp">
+                                <property name="maximum-size">300</property>
+                                <property name="tightening-threshold">200</property>
+                                <property name="child">
+                                  <object class="GtkBox">
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">12</property>
                                     <child>
-                                      <object class="AdwActionRow">
-                                        <property name="title" translatable="yes">Encryption Key</property>
+                                      <object class="GtkListBox">
                                         <child>
-                                          <object class="GtkPasswordEntry" id="custom_encryption_key_entry">
-                                            <property name="activates-default">True</property>
-                                            <property name="valign">center</property>
+                                          <object class="GtkListBoxRow">
+                                            <property name="focusable">False</property>
+                                            <property name="selectable">False</property>
+                                            <property name="activatable">False</property>
+                                            <property name="child">
+                                              <object class="GtkEntry" id="phone_number_entry">
+                                                <property name="activates-default">True</property>
+                                                <property name="placeholder-text" translatable="yes">Phone Number</property>
+                                                <property name="margin-top">6</property>
+                                                <property name="margin-bottom">6</property>
+                                                <property name="margin-start">6</property>
+                                                <property name="margin-end">6</property>
+                                              </object>
+                                            </property>
                                           </object>
                                         </child>
+                                        <style>
+                                          <class name="content"/>
+                                        </style>
                                       </object>
                                     </child>
                                     <child>
-                                      <object class="AdwActionRow">
-                                        <property name="activatable_widget">use_test_dc_switch</property>
-                                        <property name="title" translatable="yes">Use Test Data Center</property>
-                                        <property name="subtitle" translatable="yes">This requires a restart to apply</property>
+                                      <object class="GtkListBox">
                                         <child>
-                                          <object class="GtkSwitch" id="use_test_dc_switch">
-                                            <property name="valign">center</property>
+                                          <object class="AdwExpanderRow">
+                                            <property name="focusable">False</property>
+                                            <property name="selectable">False</property>
+                                            <property name="activatable">False</property>
+                                            <property name="title" translatable="yes">Advanced</property>
+                                            <child>
+                                              <object class="AdwActionRow">
+                                                <property name="title" translatable="yes">Encryption Key</property>
+                                                <child>
+                                                  <object class="GtkPasswordEntry" id="custom_encryption_key_entry">
+                                                    <property name="activates-default">True</property>
+                                                    <property name="valign">center</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="AdwActionRow">
+                                                <property name="activatable_widget">use_test_dc_switch</property>
+                                                <property name="title" translatable="yes">Use Test Data Center</property>
+                                                <property name="subtitle" translatable="yes">This requires a restart to apply</property>
+                                                <child>
+                                                  <object class="GtkSwitch" id="use_test_dc_switch">
+                                                    <property name="valign">center</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                            </child>
                                           </object>
                                         </child>
+                                        <style>
+                                          <class name="content"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="welcome_page_error_label">
+                                        <property name="visible">False</property>
+                                        <style>
+                                          <class name="error"/>
+                                        </style>
                                       </object>
                                     </child>
                                   </object>
-                                </child>
-                                <style>
-                                  <class name="content"/>
-                                </style>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="welcome_page_error_label">
-                                <property name="visible">False</property>
-                                <style>
-                                  <class name="error"/>
-                                </style>
+                                </property>
                               </object>
                             </child>
                           </object>
                         </property>
                       </object>
                     </child>
-                  </object>
-                </property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwLeafletPage">
-                <property name="name">code-page</property>
-                <property name="child">
-                  <object class="AdwStatusPage">
-                    <property name="icon-name">mail-send-symbolic</property>
-                    <property name="title" translatable="yes">Enter the Verification Code</property>
                     <child>
-                      <object class="AdwClamp">
-                        <property name="maximum-size">300</property>
-                        <property name="tightening-threshold">200</property>
+                      <object class="AdwLeafletPage">
+                        <property name="name">code-page</property>
                         <property name="child">
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="spacing">12</property>
+                          <object class="AdwStatusPage">
+                            <property name="icon-name">mail-send-symbolic</property>
+                            <property name="title" translatable="yes">Enter the Verification Code</property>
                             <child>
-                              <object class="GtkListBox">
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="focusable">False</property>
-                                    <property name="selectable">False</property>
-                                    <property name="activatable">False</property>
-                                    <property name="child">
-                                      <object class="GtkEntry" id="code_entry">
-                                        <property name="activates-default">True</property>
-                                        <property name="placeholder-text" translatable="yes">Code</property>
-                                        <property name="margin-top">6</property>
-                                        <property name="margin-bottom">6</property>
-                                        <property name="margin-start">6</property>
-                                        <property name="margin-end">6</property>
+                              <object class="AdwClamp">
+                                <property name="maximum-size">300</property>
+                                <property name="tightening-threshold">200</property>
+                                <property name="child">
+                                  <object class="GtkBox">
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkListBox">
+                                        <child>
+                                          <object class="GtkListBoxRow">
+                                            <property name="focusable">False</property>
+                                            <property name="selectable">False</property>
+                                            <property name="activatable">False</property>
+                                            <property name="child">
+                                              <object class="GtkEntry" id="code_entry">
+                                                <property name="activates-default">True</property>
+                                                <property name="placeholder-text" translatable="yes">Code</property>
+                                                <property name="margin-top">6</property>
+                                                <property name="margin-bottom">6</property>
+                                                <property name="margin-start">6</property>
+                                                <property name="margin-end">6</property>
+                                              </object>
+                                            </property>
+                                          </object>
+                                        </child>
+                                        <style>
+                                          <class name="content"/>
+                                        </style>
                                       </object>
-                                    </property>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="code_error_label">
+                                        <property name="visible">False</property>
+                                        <style>
+                                          <class name="error"/>
+                                        </style>
+                                      </object>
+                                    </child>
                                   </object>
-                                </child>
-                                <style>
-                                  <class name="content"/>
-                                </style>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="code_error_label">
-                                <property name="visible">False</property>
-                                <style>
-                                  <class name="error"/>
-                                </style>
+                                </property>
                               </object>
                             </child>
                           </object>
                         </property>
                       </object>
                     </child>
-                  </object>
-                </property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwLeafletPage">
-                <property name="name">registration-page</property>
-                <property name="child">
-                  <object class="GtkBox">
-                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="AdwStatusPage">
-                        <property name="icon-name">contact-new-symbolic</property>
-                        <property name="title" translatable="yes">Register New Account</property>
-                        <property name="vexpand">True</property>
-                        <child>
-                          <object class="AdwClamp">
-                            <property name="maximum-size">300</property>
-                            <property name="tightening-threshold">200</property>
-                            <property name="child">
-                              <object class="GtkBox">
-                                <property name="orientation">vertical</property>
-                                <property name="spacing">12</property>
+                      <object class="AdwLeafletPage">
+                        <property name="name">registration-page</property>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="AdwStatusPage">
+                                <property name="icon-name">contact-new-symbolic</property>
+                                <property name="title" translatable="yes">Register New Account</property>
+                                <property name="vexpand">True</property>
                                 <child>
-                                  <object class="GtkListBox">
-                                    <child>
-                                      <object class="GtkListBoxRow">
-                                        <property name="focusable">False</property>
-                                        <property name="selectable">False</property>
-                                        <property name="activatable">False</property>
-                                        <property name="child">
-                                          <object class="GtkEntry" id="registration_first_name_entry">
-                                            <property name="activates-default">True</property>
-                                            <property name="placeholder-text" translatable="yes">First Name</property>
-                                            <property name="margin-top">6</property>
-                                            <property name="margin-bottom">6</property>
-                                            <property name="margin-start">6</property>
-                                            <property name="margin-end">6</property>
+                                  <object class="AdwClamp">
+                                    <property name="maximum-size">300</property>
+                                    <property name="tightening-threshold">200</property>
+                                    <property name="child">
+                                      <object class="GtkBox">
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">12</property>
+                                        <child>
+                                          <object class="GtkListBox">
+                                            <child>
+                                              <object class="GtkListBoxRow">
+                                                <property name="focusable">False</property>
+                                                <property name="selectable">False</property>
+                                                <property name="activatable">False</property>
+                                                <property name="child">
+                                                  <object class="GtkEntry" id="registration_first_name_entry">
+                                                    <property name="activates-default">True</property>
+                                                    <property name="placeholder-text" translatable="yes">First Name</property>
+                                                    <property name="margin-top">6</property>
+                                                    <property name="margin-bottom">6</property>
+                                                    <property name="margin-start">6</property>
+                                                    <property name="margin-end">6</property>
+                                                  </object>
+                                                </property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkListBoxRow">
+                                                <property name="focusable">False</property>
+                                                <property name="selectable">False</property>
+                                                <property name="activatable">False</property>
+                                                <property name="child">
+                                                  <object class="GtkEntry" id="registration_last_name_entry">
+                                                    <property name="activates-default">True</property>
+                                                    <property name="placeholder-text" translatable="yes">Last Name</property>
+                                                    <property name="margin-top">6</property>
+                                                    <property name="margin-bottom">6</property>
+                                                    <property name="margin-start">6</property>
+                                                    <property name="margin-end">6</property>
+                                                  </object>
+                                                </property>
+                                              </object>
+                                            </child>
+                                            <style>
+                                              <class name="content"/>
+                                            </style>
                                           </object>
-                                        </property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkListBoxRow">
-                                        <property name="focusable">False</property>
-                                        <property name="selectable">False</property>
-                                        <property name="activatable">False</property>
-                                        <property name="child">
-                                          <object class="GtkEntry" id="registration_last_name_entry">
-                                            <property name="activates-default">True</property>
-                                            <property name="placeholder-text" translatable="yes">Last Name</property>
-                                            <property name="margin-top">6</property>
-                                            <property name="margin-bottom">6</property>
-                                            <property name="margin-start">6</property>
-                                            <property name="margin-end">6</property>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="registration_error_label">
+                                            <property name="visible">False</property>
+                                            <style>
+                                              <class name="error"/>
+                                            </style>
                                           </object>
-                                        </property>
+                                        </child>
                                       </object>
-                                    </child>
-                                    <style>
-                                      <class name="content"/>
-                                    </style>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="registration_error_label">
-                                    <property name="visible">False</property>
-                                    <style>
-                                      <class name="error"/>
-                                    </style>
+                                    </property>
                                   </object>
                                 </child>
                               </object>
-                            </property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="AdwClamp">
-                        <property name="maximum-size">300</property>
-                        <property name="tightening-threshold">200</property>
-                        <property name="child">
-                          <object class="GtkLabel" id="tos_label">
-                            <property name="ellipsize">middle</property>
-                            <property name="justify">center</property>
-                            <property name="margin-bottom">18</property>
-                            <property name="use-markup">True</property>
-                            <property name="valign">end</property>
-                            <property name="label" translatable="yes">By signing up,
+                            </child>
+                            <child>
+                              <object class="AdwClamp">
+                                <property name="maximum-size">300</property>
+                                <property name="tightening-threshold">200</property>
+                                <property name="child">
+                                  <object class="GtkLabel" id="tos_label">
+                                    <property name="ellipsize">middle</property>
+                                    <property name="justify">center</property>
+                                    <property name="margin-bottom">18</property>
+                                    <property name="use-markup">True</property>
+                                    <property name="valign">end</property>
+                                    <property name="label" translatable="yes">By signing up,
 you agree to the &lt;a href=&quot;&quot;&gt;Terms of Service&lt;/a&gt;.</property>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
-                  </object>
-                </property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwLeafletPage">
-                <property name="name">password-page</property>
-                <property name="child">
-                  <object class="AdwStatusPage">
-                    <property name="icon-name">dialog-password-symbolic</property>
-                    <property name="title" translatable="yes">Enter Your Password</property>
-                    <child>
-                      <object class="AdwClamp">
-                        <property name="maximum-size">300</property>
-                        <property name="tightening-threshold">200</property>
-                        <property name="child">
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="spacing">12</property>
-                            <child>
-                              <object class="GtkListBox">
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="focusable">False</property>
-                                    <property name="selectable">False</property>
-                                    <property name="activatable">False</property>
-                                    <property name="child">
-                                      <object class="GtkPasswordEntry" id="password_entry">
-                                        <property name="activates-default">True</property>
-                                        <property name="placeholder-text" translatable="yes">Password</property>
-                                        <property name="margin-top">6</property>
-                                        <property name="margin-bottom">6</property>
-                                        <property name="margin-start">6</property>
-                                        <property name="margin-end">6</property>
-                                      </object>
-                                    </property>
                                   </object>
-                                </child>
-                                <style>
-                                  <class name="content"/>
-                                </style>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="password_error_label">
-                                <property name="visible">False</property>
-                                <style>
-                                  <class name="error"/>
-                                </style>
+                                </property>
                               </object>
                             </child>
                           </object>
                         </property>
                       </object>
                     </child>
-                  </object>
-                </property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwLeafletPage">
-                <property name="name">encryption-key-page</property>
-                <property name="child">
-                  <object class="AdwStatusPage">
-                    <property name="icon-name">system-lock-screen-symbolic</property>
-                    <property name="title" translatable="yes">Enter the Encryption Key</property>
                     <child>
-                      <object class="AdwClamp">
-                        <property name="maximum-size">300</property>
-                        <property name="tightening-threshold">200</property>
+                      <object class="AdwLeafletPage">
+                        <property name="name">password-page</property>
                         <property name="child">
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="spacing">12</property>
+                          <object class="AdwStatusPage">
+                            <property name="icon-name">dialog-password-symbolic</property>
+                            <property name="title" translatable="yes">Enter Your Password</property>
                             <child>
-                              <object class="GtkListBox">
-                                <child>
-                                  <object class="GtkListBoxRow">
-                                    <property name="focusable">False</property>
-                                    <property name="selectable">False</property>
-                                    <property name="activatable">False</property>
-                                    <property name="child">
-                                      <object class="GtkPasswordEntry" id="encryption_key_entry">
-                                        <property name="activates-default">True</property>
-                                        <property name="placeholder-text" translatable="yes">Encryption Key</property>
-                                        <property name="margin-top">6</property>
-                                        <property name="margin-bottom">6</property>
-                                        <property name="margin-start">6</property>
-                                        <property name="margin-end">6</property>
+                              <object class="AdwClamp">
+                                <property name="maximum-size">300</property>
+                                <property name="tightening-threshold">200</property>
+                                <property name="child">
+                                  <object class="GtkBox">
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkListBox">
+                                        <child>
+                                          <object class="GtkListBoxRow">
+                                            <property name="focusable">False</property>
+                                            <property name="selectable">False</property>
+                                            <property name="activatable">False</property>
+                                            <property name="child">
+                                              <object class="GtkPasswordEntry" id="password_entry">
+                                                <property name="activates-default">True</property>
+                                                <property name="placeholder-text" translatable="yes">Password</property>
+                                                <property name="margin-top">6</property>
+                                                <property name="margin-bottom">6</property>
+                                                <property name="margin-start">6</property>
+                                                <property name="margin-end">6</property>
+                                              </object>
+                                            </property>
+                                          </object>
+                                        </child>
+                                        <style>
+                                          <class name="content"/>
+                                        </style>
                                       </object>
-                                    </property>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="password_error_label">
+                                        <property name="visible">False</property>
+                                        <style>
+                                          <class name="error"/>
+                                        </style>
+                                      </object>
+                                    </child>
                                   </object>
-                                </child>
-                                <style>
-                                  <class name="content"/>
-                                </style>
+                                </property>
                               </object>
                             </child>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwLeafletPage">
+                        <property name="name">encryption-key-page</property>
+                        <property name="child">
+                          <object class="AdwStatusPage">
+                            <property name="icon-name">system-lock-screen-symbolic</property>
+                            <property name="title" translatable="yes">Enter the Encryption Key</property>
                             <child>
-                              <object class="GtkLabel" id="encryption_key_error_label">
-                                <property name="visible">False</property>
-                                <style>
-                                  <class name="error"/>
-                                </style>
+                              <object class="AdwClamp">
+                                <property name="maximum-size">300</property>
+                                <property name="tightening-threshold">200</property>
+                                <property name="child">
+                                  <object class="GtkBox">
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkListBox">
+                                        <child>
+                                          <object class="GtkListBoxRow">
+                                            <property name="focusable">False</property>
+                                            <property name="selectable">False</property>
+                                            <property name="activatable">False</property>
+                                            <property name="child">
+                                              <object class="GtkPasswordEntry" id="encryption_key_entry">
+                                                <property name="activates-default">True</property>
+                                                <property name="placeholder-text" translatable="yes">Encryption Key</property>
+                                                <property name="margin-top">6</property>
+                                                <property name="margin-bottom">6</property>
+                                                <property name="margin-start">6</property>
+                                                <property name="margin-end">6</property>
+                                              </object>
+                                            </property>
+                                          </object>
+                                        </child>
+                                        <style>
+                                          <class name="content"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="encryption_key_error_label">
+                                        <property name="visible">False</property>
+                                        <style>
+                                          <class name="error"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
                               </object>
                             </child>
                           </object>
@@ -395,9 +418,9 @@ you agree to the &lt;a href=&quot;&quot;&gt;Terms of Service&lt;/a&gt;.</propert
                       </object>
                     </child>
                   </object>
-                </property>
+                </child>
               </object>
-            </child>
+            </property>
           </object>
         </child>
       </object>


### PR DESCRIPTION
# From the Commit Message
This commit eliminates flashing and glitching in three places.
Before this commit, this happened when:

1. a previously logged-in user started the app she/he could see the
   phone number page for a blink.

2. a user closes the app during the login process and has processed
   beyond the phone number page, she/he saw a transition from the
   phone number page after starting the app again.

3. a user starts the app, does the login procedure, and logs out
   again, she/he saw a back transition to the phone number page.

To solve this, the login template has gotten a stack on top with a
header bar without title that is doing crossfade animations to prevent
these cases of flashing and glitching.

# Additional Info
Initial discussion in can be found in #97. I decided not to put the
"loading" page into the top level `window.ui` but rather in `login.ui`
as I did in the original PR. In this way, I could get rid of the signals. 

I am not sure whether this also fixes #71 as I haven't experienced 
these glitches for more than short moments!

# Demonstration
## Case 1 Before (Screenshot)
![1_old](https://user-images.githubusercontent.com/3630213/135177289-55209b14-fbd8-40e0-b5d9-97b622b4f72d.png)

## Case 1 After (Screenshot)
![1 _new](https://user-images.githubusercontent.com/3630213/135177472-fc425c0a-7109-45f5-b9e0-2a3bf203c766.png)

## Case 1 Before (Video)
https://user-images.githubusercontent.com/3630213/135177560-39c1aab4-ca6e-4179-9ef2-52785d6777b4.mp4

## Case 1 After (Video)
https://user-images.githubusercontent.com/3630213/135177597-7fd98e68-ea4f-4ac9-877d-dfbf1b3a0924.mp4

## Case 2 Before (Screenshot)
![2_old](https://user-images.githubusercontent.com/3630213/135177645-bce26281-ac34-40de-979a-d33404b9a894.png)

## Case 2 After (Screenshot)
![2_new](https://user-images.githubusercontent.com/3630213/135177671-31db3252-f48d-47fa-bc7e-da8da679a4e7.png)

## Case 2 Before (Video)
https://user-images.githubusercontent.com/3630213/135177704-dc30e24c-1bda-450d-a21d-50466726813f.mp4

## Case 2 After (Video)
https://user-images.githubusercontent.com/3630213/135177730-d1b2fe69-0a3d-4efb-be8a-dfba769bdb1e.mp4

## Case 3 Before (Screenshot)
![3_old](https://user-images.githubusercontent.com/3630213/135177772-088ecdb1-dce7-45b0-9d09-93d12a37254d.png)

## Case 3 After (Screenshot)
![3_new](https://user-images.githubusercontent.com/3630213/135177779-637051fd-2972-488e-91a5-1e7bbe80cc34.png)

## Case 3 Before (Video)
https://user-images.githubusercontent.com/3630213/135177783-0781d73c-0963-4d43-8bee-a2064010a963.mp4

## Case 3 After (Video)
https://user-images.githubusercontent.com/3630213/135177789-e2b4cafd-346e-4630-bc7f-565ca89e4c80.mp4



