### PR TITLE
WIP: Polish logout behaviour

### DIFF
--- a/data/resources/ui/content-chat-history.ui
+++ b/data/resources/ui/content-chat-history.ui
@@ -26,45 +26,52 @@
           </object>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
-            <property name="vexpand">True</property>
-            <property name="hscrollbar-policy">never</property>
-            <style>
-              <class name="view"/>
-              <class name="chat-history"/>
-            </style>
-            <property name="child">
-              <object class="AdwClampScrollable">
+          <object class="GtkBox" id="scrolled_window">
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="vexpand">True</property>
+                <property name="hscrollbar-policy">never</property>
+                <style>
+                  <class name="view" />
+                  <class name="chat-history" />
+                </style>
                 <property name="child">
-                  <object class="GtkListView" id="list_view">
-                    <property name="factory">
-                      <object class="GtkBuilderListItemFactory">
-                        <property name="bytes"><![CDATA[
-<?xml version="1.0" encoding="UTF-8"?>
-<interface>
-  <template class="GtkListItem">
-    <property name="child">
-      <object class="ContentItemRow">
-        <property name="margin-top">3</property>
-        <property name="margin-bottom">3</property>
-        <binding name="item">
-          <lookup name="item">GtkListItem</lookup>
-        </binding>
-      </object>
-    </property>
-  </template>
-</interface>
-                        ]]></property>
+                  <object class="AdwClampScrollable">
+                    <property name="child">
+                      <object class="GtkListView" id="list_view">
+                        <property name="factory">
+                          <object class="GtkBuilderListItemFactory">
+                            <property name="bytes">
+                              <![CDATA[
+  <?xml version="1.0" encoding="UTF-8"?>
+  <interface>
+    <template class="GtkListItem">
+      <property name="child">
+        <object class="ContentItemRow">
+          <property name="margin-top">3</property>
+          <property name="margin-bottom">3</property>
+          <binding name="item">
+            <lookup name="item">GtkListItem</lookup>
+          </binding>
+        </object>
+      </property>
+    </template>
+  </interface>
+                            ]]>
+                            </property>
+                          </object>
+                        </property>
                       </object>
                     </property>
                   </object>
                 </property>
               </object>
-            </property>
+            </child>
           </object>
         </child>
         <child>
-          <object class="GtkSeparator"/>
+          <object class="GtkSeparator" />
         </child>
         <child>
           <object class="AdwClamp">

--- a/data/resources/ui/content.ui
+++ b/data/resources/ui/content.ui
@@ -16,7 +16,7 @@
               </object>
             </child>
             <child>
-              <object class="AdwStatusPage">
+              <object class="AdwStatusPage" id="unselected_chat_status_page">
                 <property name="vexpand">True</property>
                 <property name="icon-name">user-available-symbolic</property>
                 <property name="title" translatable="yes">No Chat Selected</property>

--- a/data/resources/ui/session.ui
+++ b/data/resources/ui/session.ui
@@ -5,7 +5,7 @@
     <child>
       <object class="AdwLeaflet" id="leaflet">
         <child>
-          <object class="Sidebar">
+          <object class="Sidebar" id="sidebar">
             <property name="compact" bind-source="leaflet" bind-property="folded" bind-flags="sync-create"/>
             <property name="chat-list" bind-source="Session" bind-property="chat-list" bind-flags="sync-create"/>
             <property name="selected-chat" bind-source="Session" bind-property="selected-chat" bind-flags="sync-create | bidirectional"/>
@@ -25,7 +25,7 @@
           </object>
         </child>
         <child>
-          <object class="Content">
+          <object class="Content" id="content">
             <property name="compact" bind-source="leaflet" bind-property="folded" bind-flags="sync-create"/>
             <property name="chat" bind-source="Session" bind-property="selected-chat" bind-flags="sync-create | bidirectional"/>
           </object>

--- a/data/resources/ui/session.ui
+++ b/data/resources/ui/session.ui
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <template class="Session" parent="AdwBin">
+  <template class="Session" parent="GtkBox">
+    <property name="orientation">vertical</property>
     <child>
       <object class="AdwLeaflet" id="leaflet">
         <child>
@@ -27,6 +28,26 @@
           <object class="Content">
             <property name="compact" bind-source="leaflet" bind-property="folded" bind-flags="sync-create"/>
             <property name="chat" bind-source="Session" bind-property="selected-chat" bind-flags="sync-create | bidirectional"/>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkInfoBar" id="info_bar">
+        <property name="revealed">False</property>
+        <child>
+          <object class="GtkBox">
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkSpinner">
+                <property name="spinning">True</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">You are currently being logged out.</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/data/resources/ui/sidebar.ui
+++ b/data/resources/ui/sidebar.ui
@@ -27,7 +27,7 @@
           <object class="AdwHeaderBar">
             <property name="show-end-title-buttons" bind-source="Sidebar" bind-property="compact" bind-flags="sync-create"/>
             <child type="end">
-              <object class="GtkMenuButton">
+              <object class="GtkMenuButton" id="main_menu_button">
                 <property name="icon-name">open-menu-symbolic</property>
                 <property name="menu-model">primary_menu</property>
               </object>
@@ -35,7 +35,7 @@
           </object>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
+          <object class="GtkScrolledWindow" id="scrolled_window">
             <property name="vexpand">True</property>
             <property name="hscrollbar-policy">never</property>
             <child>

--- a/src/session/content/chat_history.rs
+++ b/src/session/content/chat_history.rs
@@ -19,6 +19,8 @@ mod imp {
         pub chat: RefCell<Option<Chat>>,
         #[template_child]
         pub list_view: TemplateChild<gtk::ListView>,
+        #[template_child]
+        pub scrolled_window: TemplateChild<gtk::Box>,
     }
 
     #[glib::object_subclass]
@@ -117,6 +119,12 @@ impl Default for ChatHistory {
 impl ChatHistory {
     pub fn new() -> Self {
         glib::Object::new(&[]).expect("Failed to create ChatHistory")
+    }
+
+    pub fn freeze(&self) {
+        imp::ChatHistory::from_instance(self)
+            .scrolled_window
+            .set_sensitive(false);
     }
 
     fn load_older_messages(&self, adj: &gtk::Adjustment) {

--- a/src/session/content/mod.rs
+++ b/src/session/content/mod.rs
@@ -37,6 +37,8 @@ mod imp {
         #[template_child]
         pub unselected_chat: TemplateChild<gtk::Box>,
         #[template_child]
+        pub unselected_chat_status_page: TemplateChild<adw::StatusPage>,
+        #[template_child]
         pub chat_history: TemplateChild<ChatHistory>,
     }
 
@@ -131,6 +133,12 @@ impl Default for Content {
 impl Content {
     pub fn new() -> Self {
         glib::Object::new(&[]).expect("Failed to create Content")
+    }
+
+    pub fn freeze(&self) {
+        let self_ = imp::Content::from_instance(self);
+        self_.unselected_chat_status_page.set_sensitive(false);
+        self_.chat_history.freeze();
     }
 
     pub fn chat(&self) -> Option<Chat> {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -43,6 +43,10 @@ mod imp {
         #[template_child]
         pub leaflet: TemplateChild<adw::Leaflet>,
         #[template_child]
+        pub sidebar: TemplateChild<Sidebar>,
+        #[template_child]
+        pub content: TemplateChild<Content>,
+        #[template_child]
         pub info_bar: TemplateChild<gtk::InfoBar>,
     }
 
@@ -158,6 +162,12 @@ impl Session {
         glib::Object::new(&[("client-id", &client_id)]).expect("Failed to create Session")
     }
 
+    fn freeze(&self) {
+        let self_ = imp::Session::from_instance(self);
+        self_.sidebar.freeze();
+        self_.content.freeze();
+    }
+
     pub fn handle_update(&self, update: Update) {
         match update {
             Update::NewMessage(_)
@@ -225,6 +235,7 @@ impl Session {
     fn log_out(&self) {
         let self_ = imp::Session::from_instance(self);
 
+        self.freeze();
         self.action_set_enabled("session.log-out", false);
         self_.info_bar.set_revealed(true);
 

--- a/src/session/sidebar/mod.rs
+++ b/src/session/sidebar/mod.rs
@@ -25,6 +25,10 @@ mod imp {
         pub filter: OnceCell<gtk::CustomFilter>,
         pub sorter: OnceCell<gtk::CustomSorter>,
         #[template_child]
+        pub main_menu_button: TemplateChild<gtk::MenuButton>,
+        #[template_child]
+        pub scrolled_window: TemplateChild<gtk::ScrolledWindow>,
+        #[template_child]
         pub chat_list_view: TemplateChild<gtk::ListView>,
     }
 
@@ -126,6 +130,12 @@ impl Default for Sidebar {
 impl Sidebar {
     pub fn new() -> Self {
         glib::Object::new(&[]).expect("Failed to create Sidebar")
+    }
+
+    pub fn freeze(&self) {
+        let self_ = imp::Sidebar::from_instance(self);
+        self_.main_menu_button.set_sensitive(false);
+        self_.scrolled_window.set_sensitive(false);
     }
 
     pub fn set_chat_list(&self, chat_list: ChatList) {


### PR DESCRIPTION
# From the commit message
Provide the user with more feedback by showing an info bar at the
bottom of the window. This infobar contains a spinner and a label
telling the user that she/he is currently being logged out.

Also, to prevent the user to enable the logout action again, set
it disabled after it has been activated for the first time.

# Additional Info
https://user-images.githubusercontent.com/3630213/135357298-553d68fa-1d37-4c8c-a3cb-b06b731fea8a.mp4

Technically, this is a very simple solution and also looks good, I think.
In #97 there was an approach to set the UI insensitive. The question is whether this in necessary: The user could just keep interacting with the app as shown here:

https://user-images.githubusercontent.com/3630213/135357912-c3eb80a2-b21b-4068-b5bd-921d22ed756b.mp4

We would just need to do better error handling in general by not just blindly unwrapping everything. For example, as seen in the video, the tokio runtime worker crashes in  `src/session/content/send_message_area.rs:180:22` when the user sends a message.

I want to use PR for discussion. :-)

By the way, if you test this, be aware that there is a bug that is independent of this PR also in `main`: If the application goes back to the first login page while the main menu was open, then the application does not accept any input and the window cannot be moved anymore.
