### PR TITLE
message-sticker: Make the stickers fit inside a fixed container

### DIFF
--- a/data/resources/ui/content-message-sticker.ui
+++ b/data/resources/ui/content-message-sticker.ui
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <template class="ContentMessageSticker" parent="AdwBin">
-    <property name="child">
-      <object class="GtkPicture" id="sticker_picture"/>
-    </property>
+  <template class="ContentMessageSticker" parent="GtkWidget">
+    <child>
+      <object class="GtkPicture" id="picture"/>
+    </child>
   </template>
 </interface>

--- a/src/session/content/message_sticker.rs
+++ b/src/session/content/message_sticker.rs
@@ -6,20 +6,22 @@ use crate::session::chat::Message;
 
 mod imp {
     use super::*;
-    use adw::subclass::prelude::BinImpl;
+    use std::cell::Cell;
 
     #[derive(Debug, Default, CompositeTemplate)]
     #[template(resource = "/com/github/melix99/telegrand/ui/content-message-sticker.ui")]
     pub struct MessageSticker {
+        pub width: Cell<i32>,
+        pub height: Cell<i32>,
         #[template_child]
-        pub sticker_picture: TemplateChild<gtk::Picture>,
+        pub picture: TemplateChild<gtk::Picture>,
     }
 
     #[glib::object_subclass]
     impl ObjectSubclass for MessageSticker {
         const NAME: &'static str = "ContentMessageSticker";
         type Type = super::MessageSticker;
-        type ParentType = adw::Bin;
+        type ParentType = gtk::Widget;
 
         fn class_init(klass: &mut Self::Class) {
             Self::bind_template(klass);
@@ -30,14 +32,37 @@ mod imp {
         }
     }
 
-    impl ObjectImpl for MessageSticker {}
-    impl WidgetImpl for MessageSticker {}
-    impl BinImpl for MessageSticker {}
+    impl ObjectImpl for MessageSticker {
+        fn dispose(&self, _obj: &Self::Type) {
+            self.picture.unparent();
+        }
+    }
+
+    impl WidgetImpl for MessageSticker {
+        fn measure(
+            &self,
+            _widget: &Self::Type,
+            orientation: gtk::Orientation,
+            _for_size: i32,
+        ) -> (i32, i32, i32, i32) {
+            let size = if let gtk::Orientation::Horizontal = orientation {
+                self.width.get()
+            } else {
+                self.height.get()
+            };
+
+            (size, size, -1, -1)
+        }
+
+        fn size_allocate(&self, _widget: &Self::Type, width: i32, height: i32, baseline: i32) {
+            self.picture.allocate(width, height, baseline, None);
+        }
+    }
 }
 
 glib::wrapper! {
     pub struct MessageSticker(ObjectSubclass<imp::MessageSticker>)
-        @extends gtk::Widget, adw::Bin;
+        @extends gtk::Widget;
 }
 
 impl Default for MessageSticker {
@@ -54,9 +79,21 @@ impl MessageSticker {
     pub fn set_message(&self, message: &Message) {
         if let MessageContent::MessageSticker(data) = message.content().0 {
             let self_ = imp::MessageSticker::from_instance(self);
-            self_
-                .sticker_picture
-                .set_height_request((data.sticker.height as f32 / 2.3) as i32);
+
+            // Scale the sticker to fit it in a small container, but keeping its
+            // original aspect ratio
+            let max_size = 200;
+            if data.sticker.width > data.sticker.height {
+                self_.width.set(max_size);
+                self_
+                    .height
+                    .set(data.sticker.height * max_size / data.sticker.width);
+            } else {
+                self_.height.set(max_size);
+                self_
+                    .width
+                    .set(data.sticker.width * max_size / data.sticker.height);
+            }
 
             if data.sticker.sticker.local.is_downloading_completed {
                 self.load_sticker(&data.sticker.sticker.local.path);
@@ -86,6 +123,6 @@ impl MessageSticker {
     fn load_sticker(&self, path: &str) {
         let self_ = imp::MessageSticker::from_instance(self);
         let media = gtk::MediaFile::for_filename(path);
-        self_.sticker_picture.set_paintable(Some(&media));
+        self_.picture.set_paintable(Some(&media));
     }
 }


### PR DESCRIPTION
This way custom stickers (manually uploaded webp images) will not appear at their original size. For making this, the message-sticker widget is now a direct subclass of GtkWidget.

Previously:
![image](https://user-images.githubusercontent.com/23530586/135537176-c932d13c-ab7e-4f93-84c7-99d537510fb2.png)


Now:
![image](https://user-images.githubusercontent.com/23530586/135537069-071757c4-2dc7-4ee1-a037-e95afbb1a0fb.png)

Thanks @alissonlauffer for providing this custom stickers to test with!