### PR TITLE
login: Password enhancements

### DIFF
--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -34,7 +34,7 @@
                       </object>
                     </child>
                     <child type="end">
-                      <object class="GtkButton">
+                      <object class="GtkButton" id="next_button">
                         <property name="action-name">login.next</property>
                         <property name="child">
                           <object class="GtkStack" id="next_stack">

--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -331,6 +331,21 @@ you agree to the &lt;a href=&quot;&quot;&gt;Terms of Service&lt;/a&gt;.</propert
                                             </property>
                                           </object>
                                         </child>
+                                        <child>
+                                          <object class="AdwActionRow" id="password_hint_action_row">
+                                            <property name="focusable">False</property>
+                                            <property name="selectable">False</property>
+                                            <property name="activatable">False</property>
+                                            <property name="title" translatable="yes">Hint</property>
+                                            <child>
+                                              <object class="GtkLabel" id="password_hint_label">
+                                                <style>
+                                                  <class name="dim-label"/>
+                                                </style>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </child>
                                         <style>
                                           <class name="content"/>
                                         </style>

--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -352,7 +352,278 @@ you agree to the &lt;a href=&quot;&quot;&gt;Terms of Service&lt;/a&gt;.</propert
                                       </object>
                                     </child>
                                     <child>
+                                      <object class="GtkListBox">
+                                        <child>
+                                          <object class="AdwActionRow">
+                                            <property name="selectable">False</property>
+                                            <property name="activatable">True</property>
+                                            <property name="action-name">login.go-to-forgot-password-page</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="title" translatable="yes">_Forgot password?</property>
+                                            <child>
+                                              <object class="GtkImage">
+                                                <property name="icon_name">go-next-symbolic</property>
+                                                <style>
+                                                  <class name="dim-label"/>
+                                                </style>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </child>
+                                        <style>
+                                          <class name="content"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
                                       <object class="GtkLabel" id="password_error_label">
+                                        <property name="visible">False</property>
+                                        <style>
+                                          <class name="error"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwLeafletPage">
+                        <property name="name">password-forgot-page</property>
+                        <property name="child">
+                          <object class="GtkScrolledWindow">
+                            <property name="child">
+                              <object class="GtkBox">
+                                <property name="orientation">vertical</property>
+                                <property name="valign">center</property>
+                                <!--  Mimick the status page margins. -->
+                                <property name="margin-top">36</property>
+                                <property name="margin-bottom">36</property>
+                                <property name="margin-start">12</property>
+                                <property name="margin-end">12</property>
+                                <property name="spacing">36</property>
+                                <child>
+                                  <object class="GtkBox" id="password_recovery_code_send_box">
+                                    <property name="orientation">vertical</property>
+                                    <child>
+                                      <object class="AdwClamp">
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="orientation">vertical</property>
+                                            <property name="valign">center</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="wrap">True</property>
+                                                <property name="wrap-mode">word-char</property>
+                                                <property name="justify">center</property>
+                                                <!--  Mimick the status page title margins. -->
+                                                <property name="margin-bottom">12</property>
+                                                <property name="label" translatable="yes">Use Recovery Code</property>
+                                                <style>
+                                                  <class name="title-1"/>
+                                                </style>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="wrap">True</property>
+                                                <property name="wrap-mode">word-char</property>
+                                                <property name="justify">center</property>
+                                                <!--  Mimick the status page description margins. -->
+                                                <property name="margin-bottom">36</property>
+                                                <property name="label" translatable="yes">When you set your cloud password, you provided a recovery email address. We can send you a code to this email address that you can use to reset your password.</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="AdwClamp">
+                                        <property name="maximum-size">300</property>
+                                        <property name="tightening-threshold">200</property>
+                                        <property name="child">
+                                          <object class="GtkListBox">
+                                            <child>
+                                              <object class="AdwActionRow">
+                                                <property name="selectable">False</property>
+                                                <property name="activatable">True</property>
+                                                <property name="action-name">login.recover-password</property>
+                                                <property name="use-underline">True</property>
+                                                <property name="title" translatable="yes">_Send recovery code</property>
+                                                <child>
+                                                  <object class="GtkStack" id="password_send_code_stack">
+                                                    <child>
+                                                      <object class="GtkStackPage">
+                                                        <property name="name">image</property>
+                                                        <property name="child">
+                                                          <object class="GtkImage">
+                                                            <property name="icon_name">go-next-symbolic</property>
+                                                            <style>
+                                                              <class name="dim-label"/>
+                                                            </style>
+                                                          </object>
+                                                        </property>
+                                                      </object>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkStackPage">
+                                                        <property name="name">spinner</property>
+                                                        <property name="child">
+                                                          <object class="GtkSpinner">
+                                                            <property name="spinning">True</property>
+                                                            <property name="valign">center</property>
+                                                            <property name="halign">center</property>
+                                                          </object>
+                                                        </property>
+                                                      </object>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <style>
+                                              <class name="content"/>
+                                            </style>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <!--  Mimick the status page margins. -->
+                                        <property name="margin-top">36</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="orientation">vertical</property>
+                                    <child>
+                                      <object class="AdwClamp">
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="orientation">vertical</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="wrap">True</property>
+                                                <property name="wrap-mode">word-char</property>
+                                                <property name="justify">center</property>
+                                                <!--  Mimick the status page title margins. -->
+                                                <property name="margin-bottom">12</property>
+                                                <property name="label" translatable="yes">Account Deletion</property>
+                                                <style>
+                                                  <class name="title-1"/>
+                                                </style>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="account_deletion_description_label">
+                                                <property name="wrap">True</property>
+                                                <property name="wrap-mode">word-char</property>
+                                                <property name="justify">center</property>
+                                                <!--  Mimick the status page description margins. -->
+                                                <property name="margin-bottom">36</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="AdwClamp">
+                                        <property name="maximum-size">300</property>
+                                        <property name="tightening-threshold">200</property>
+                                        <property name="child">
+                                          <object class="GtkButton">
+                                            <property name="action-name">login.show-delete-account-dialog</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="label" translatable="yes">_Delete Account</property>
+                                            <style>
+                                              <class name="destructive-action"/>
+                                            </style>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </property>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwLeafletPage">
+                        <property name="name">password-recovery-page</property>
+                        <property name="child">
+                          <object class="AdwStatusPage" id="password_recovery_status_page">
+                            <property name="icon-name">mail-unread-symbolic</property>
+                            <property name="title" translatable="yes">Enter the Code Sent by Mail</property>
+                            <child>
+                              <object class="AdwClamp">
+                                <property name="maximum-size">300</property>
+                                <property name="tightening-threshold">200</property>
+                                <property name="child">
+                                  <object class="GtkBox">
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkListBox">
+                                        <child>
+                                          <object class="GtkListBoxRow">
+                                            <property name="focusable">False</property>
+                                            <property name="selectable">False</property>
+                                            <property name="activatable">False</property>
+                                            <property name="child">
+                                              <object class="GtkEntry" id="password_recovery_code_entry">
+                                                <property name="activates-default">True</property>
+                                                <property name="placeholder-text" translatable="yes">Code</property>
+                                                <property name="margin-top">6</property>
+                                                <property name="margin-bottom">6</property>
+                                                <property name="margin-start">6</property>
+                                                <property name="margin-end">6</property>
+                                              </object>
+                                            </property>
+                                          </object>
+                                        </child>
+                                        <style>
+                                          <class name="content"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBox">
+                                        <child>
+                                          <object class="AdwActionRow">
+                                            <property name="selectable">False</property>
+                                            <property name="activatable">True</property>
+                                            <property name="action-name">login.show-no-email-access-dialog</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="title" translatable="yes">_Unable to access your email?</property>
+                                            <child>
+                                              <object class="GtkImage">
+                                                <property name="icon_name">go-next-symbolic</property>
+                                                <style>
+                                                  <class name="dim-label"/>
+                                                </style>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </child>
+                                        <style>
+                                          <class name="content"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="password_recovery_error_label">
                                         <property name="visible">False</property>
                                         <style>
                                           <class name="error"/>

--- a/src/login.rs
+++ b/src/login.rs
@@ -435,7 +435,7 @@ impl Login {
                     result,
                     &self_.welcome_page_error_label,
                     &*self_.phone_number_entry
-                )
+                );
             }),
         );
     }
@@ -457,7 +457,7 @@ impl Login {
             },
             clone!(@weak self as obj => move |result| async move {
                 let self_ = imp::Login::from_instance(&obj);
-                obj.handle_user_result(result, &self_.code_error_label, &*self_.code_entry)
+                obj.handle_user_result(result, &self_.code_error_label, &*self_.code_entry);
             }),
         );
     }
@@ -485,7 +485,7 @@ impl Login {
                     result,
                     &self_.registration_error_label,
                     &*self_.registration_first_name_entry
-                )
+                );
             }),
         );
     }
@@ -511,25 +511,36 @@ impl Login {
                     result,
                     &self_.password_error_label,
                     &*self_.password_entry
-                )
+                );
             }),
         );
     }
 
-    fn handle_user_result<T, W>(
+    fn handle_user_result<T, W: IsA<gtk::Widget>>(
         &self,
         result: Result<T, types::Error>,
         error_label: &gtk::Label,
         widget_to_focus: &W,
-    ) where
-        W: WidgetExt,
-    {
-        if let Err(err) = result {
-            show_error_label(error_label, &err.message);
-            self.unfreeze();
-            // Grab focus for entry again after error.
-            widget_to_focus.grab_focus();
+    ) -> Option<T> {
+        match result {
+            Err(err) => {
+                self.handle_user_error(&err, error_label, widget_to_focus);
+                None
+            }
+            Ok(t) => Some(t),
         }
+    }
+
+    fn handle_user_error<W: IsA<gtk::Widget>>(
+        &self,
+        err: &types::Error,
+        error_label: &gtk::Label,
+        widget_to_focus: &W,
+    ) {
+        show_error_label(error_label, &err.message);
+        self.unfreeze();
+        // Grab focus for entry again after error.
+        widget_to_focus.grab_focus();
     }
 
     pub fn client_id(&self) -> i32 {

--- a/src/login.rs
+++ b/src/login.rs
@@ -56,6 +56,10 @@ mod imp {
         #[template_child]
         pub password_entry: TemplateChild<gtk::PasswordEntry>,
         #[template_child]
+        pub password_hint_action_row: TemplateChild<adw::ActionRow>,
+        #[template_child]
+        pub password_hint_label: TemplateChild<gtk::Label>,
+        #[template_child]
         pub password_error_label: TemplateChild<gtk::Label>,
     }
 
@@ -203,11 +207,16 @@ impl Login {
                     Some(&*self_.registration_first_name_entry),
                 );
             }
-            AuthorizationState::WaitPassword(_) => {
+            AuthorizationState::WaitPassword(data) => {
                 // When we enter the password page, the password to be entered should be masked by
                 // default, so the peek icon is turned off and on again.
                 self_.password_entry.set_show_peek_icon(false);
                 self_.password_entry.set_show_peek_icon(true);
+
+                self_
+                    .password_hint_action_row
+                    .set_visible(!data.password_hint.is_empty());
+                self_.password_hint_label.set_text(&data.password_hint);
 
                 self.navigate_to_page(
                     "password-page",


### PR DESCRIPTION
This is a work in progress. Would like to hear what you like and don't like.

In the first commit, I implemented the function of showing the user's password hint.
The second commit adds a new password recovery page that is fully working.

# Demonstration
## Video
https://user-images.githubusercontent.com/3630213/135657731-dd68360d-c4b9-4085-b650-c2a454598c5c.mp4

## Screenshot
If the user has no hint and no mail set (I would still need to dim the arrow):

![no_hint_no_mail](https://user-images.githubusercontent.com/3630213/135657853-db13da0b-b427-4216-939d-d1e091cb1294.png)

