### PR TITLE
login: Implement functionality to resend auth code

### DIFF
--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -205,7 +205,7 @@
               <object class="AdwLeafletPage">
                 <property name="name">code-page</property>
                 <property name="child">
-                  <object class="AdwStatusPage">
+                  <object class="AdwStatusPage" id="code_page">
                     <property name="icon-name">mail-send-symbolic</property>
                     <property name="title" translatable="yes">Enter the Verification Code</property>
                     <child>
@@ -238,6 +238,53 @@
                                 <style>
                                   <class name="boxed-list"/>
                                 </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="orientation">vertical</property>
+                                <property name="spacing">9</property>
+                                <child>
+                                  <object class="GtkStack" id="code_resend_stack">
+                                    <child>
+                                      <object class="GtkButton" id="code_resend_button">
+                                        <property name="action-name">login.resend-auth-code</property>
+                                        <property name="margin-end">12</property>
+                                        <property name="margin-start">12</property>
+                                        <property name="use-underline">True</property>
+                                        <style>
+                                          <class name="pill"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkStackPage">
+                                        <property name="name">disabled</property>
+                                        <property name="child">
+                                          <object class="GtkLabel">
+                                            <property name="justify">center</property>
+                                            <property name="label" translatable="true">Code cannot be sent anymore.</property>
+                                            <property name="valign">center</property>
+                                            <property name="wrap">True</property>
+                                            <property name="wrap-mode">word</property>
+                                            <style>
+                                              <class name="dim-label"/>
+                                            </style>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="code_timeout_label">
+                                    <property name="wrap">True</property>
+                                    <property name="wrap-mode">word</property>
+                                    <style>
+                                      <class name="dim-label"/>
+                                    </style>
+                                  </object>
+                                </child>
                               </object>
                             </child>
                             <child>


### PR DESCRIPTION
# Commit Message
With this commit, the user can have the authorization code sent to him
in another form (SMS, Call, Flash Call). The user is asked to wait for
the time period suggested by tdlib, but can also resend the code be-
fore it expires.

There is a small workaround:

Sometimes the user may get a FLOOD_WAIT when he/she wants to resend the
authorization code. But then tdlib blocks the resend function for the
user, but does not inform us about it by sending an
'AuthorizationState::WaitCode'. Consequently, the user interface would
still indicate that we are allowed to resend the code. However, we al-
ways get code 8 when we try, indicating that resending does not work.
In this case, we automatically disable the resend feature.

# Demonstration
Here is a demonstration. Keep in mind that for the demonstration, I used a PasswordEntry for the phone number to hide it from you. :-)
Additionally, in the newest commit, I changed the StatusPage description from `The code has been sent to you via ...` to `The code will be sent to you via ...` (too lazy to record again).

## Normal
Pay attention to the notification of an incoming call:

https://user-images.githubusercontent.com/3630213/137212691-84edc2ac-9b43-49f0-b35e-09823494da0b.mp4

## Flood Wait Workaround
This is the workaround described in the commit message:

https://user-images.githubusercontent.com/3630213/137213641-93fee585-2823-4841-9c97-bea804a27a7e.mp4


