### PR TITLE
message-row: Introduce MessageIndicators

### DIFF
--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -124,7 +124,6 @@
 .message-bubble {
   background-color: alpha(black, 0.07);
   border-radius: 12px;
-  padding: 6px 12px;
 }
 
 .message-bubble.outgoing {
@@ -140,15 +139,13 @@
   color: @accent_fg_color;
 }
 
-.message-media {
-  padding: 2px;
-}
-
 .message-media .media-picture {
+  margin: 2px;
   border-radius: 10px;
 }
 
 .message-media.with-caption .media-picture {
+  margin-bottom: 0;
   border-radius: 10px 10px 4px 4px;
 }
 
@@ -163,8 +160,13 @@
 }
 
 .sender-text {
+  margin: 6px 12px 0 12px;
   font-size: 0.85em;
   font-weight: bold;
+}
+
+.sender-text + .message-text {
+  margin-top: 0;
 }
 
 .sender-text-red {
@@ -196,6 +198,7 @@
 }
 
 .message-text {
+  margin: 6px 12px;
   font-size: 0.95em;
 }
 

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -154,6 +154,27 @@
   min-width: 100px;
 }
 
+messageindicators {
+  font-size: x-small;
+  font-feature-settings: "tnum";
+}
+
+messagelabel {
+  margin: 6px 12px;
+  font-size: 0.95em;
+}
+
+messagelabel > messageindicators {
+  opacity: 0.7;
+}
+
+.message-media overlay > messageindicators, messagesticker messageindicators {
+  background-color: alpha(@view_bg_color, 0.8);
+  border-radius: 9999px;
+  padding: 2px 6px;
+  margin: 6px;
+}
+
 .event-row {
   font-size: 0.8em;
   padding: 3px;
@@ -165,7 +186,7 @@
   font-weight: bold;
 }
 
-.sender-text + .message-text {
+.sender-text + messagelabel {
   margin-top: 0;
 }
 
@@ -195,11 +216,6 @@
 
 .sender-text-pink {
   color: #cd4073;
-}
-
-.message-text {
-  margin: 6px 12px;
-  font-size: 0.95em;
 }
 
 /* Placeholder */

--- a/data/resources/ui/content-message-media.ui
+++ b/data/resources/ui/content-message-media.ui
@@ -9,7 +9,7 @@
       <object class="GtkBox" id="content">
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkOverlay">
+          <object class="GtkOverlay" id="overlay">
             <child type="overlay">
               <object class="GtkProgressBar" id="progress_bar">
                 <property name="halign">center</property>

--- a/data/resources/ui/content-message-media.ui
+++ b/data/resources/ui/content-message-media.ui
@@ -32,10 +32,6 @@
             <property name="wrap">True</property>
             <property name="wrap-mode">word-char</property>
             <property name="xalign">0</property>
-            <property name="margin-top">6</property>
-            <property name="margin-bottom">4</property>
-            <property name="margin-start">10</property>
-            <property name="margin-end">10</property>
             <property name="visible">False</property>
             <style>
               <class name="message-text"/>

--- a/data/resources/ui/content-message-media.ui
+++ b/data/resources/ui/content-message-media.ui
@@ -26,18 +26,6 @@
             </child>
           </object>
         </child>
-        <child>
-          <object class="GtkLabel" id="caption_label">
-            <property name="use-markup">True</property>
-            <property name="wrap">True</property>
-            <property name="wrap-mode">word-char</property>
-            <property name="xalign">0</property>
-            <property name="visible">False</property>
-            <style>
-              <class name="message-text"/>
-            </style>
-          </object>
-        </child>
       </object>
     </child>
   </template>

--- a/data/resources/ui/content-message-photo.ui
+++ b/data/resources/ui/content-message-photo.ui
@@ -5,7 +5,14 @@
       <object class="GtkBinLayout"/>
     </property>
     <child>
-      <object class="ContentMessageMedia" id="media"/>
+      <object class="ContentMessageMedia" id="media">
+        <property name="indicators">
+          <object class="MessageIndicators" id="indicators">
+            <property name="halign">end</property>
+            <property name="valign">end</property>
+          </object>
+        </property>
+      </object>
     </child>
   </template>
 </interface>

--- a/data/resources/ui/content-message-sticker.ui
+++ b/data/resources/ui/content-message-sticker.ui
@@ -5,7 +5,17 @@
       <object class="GtkBinLayout"/>
     </property>
     <child>
-      <object class="ContentStickerPicture" id="picture"/>
+      <object class="GtkOverlay">
+        <child>
+          <object class="ContentStickerPicture" id="picture"/>
+        </child>
+        <child type="overlay">
+          <object class="MessageIndicators" id="indicators">
+            <property name="halign">end</property>
+            <property name="valign">end</property>
+          </object>
+        </child>
+      </object>
     </child>
   </template>
 </interface>

--- a/data/resources/ui/content-message-text.ui
+++ b/data/resources/ui/content-message-text.ui
@@ -21,14 +21,13 @@
       </object>
     </child>
     <child>
-      <object class="GtkLabel" id="content_label">
-        <property name="use-markup">True</property>
-        <property name="wrap">True</property>
-        <property name="wrap-mode">word-char</property>
-        <property name="xalign">0</property>
-        <style>
-          <class name="message-text"/>
-        </style>
+      <object class="MessageLabel" id="content_label">
+        <property name="indicators">
+          <object class="MessageIndicators" id="indicators">
+            <property name="halign">end</property>
+            <property name="valign">end</property>
+          </object>
+        </property>
       </object>
     </child>
   </template>

--- a/src/session/content/message_row/indicators.rs
+++ b/src/session/content/message_row/indicators.rs
@@ -1,0 +1,133 @@
+use super::indicators_model::MessageIndicatorsModel;
+
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use gtk::{glib, CompositeTemplate};
+
+mod imp {
+    use super::*;
+    use glib::clone;
+    use once_cell::sync::Lazy;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(string = r#"
+    <interface>
+      <template class="MessageIndicators" parent="GtkWidget">
+        <property name="layout-manager">
+          <object class="GtkBinLayout"/>
+        </property>
+        <child>
+          <object class="GtkLabel">
+            <binding name="label">
+              <lookup name="message-info">
+                <lookup name="model">MessageIndicators</lookup>
+              </lookup>
+            </binding>
+          </object>
+        </child>
+      </template>
+    </interface>
+    "#)]
+    pub(crate) struct MessageIndicators(pub(super) MessageIndicatorsModel);
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MessageIndicators {
+        const NAME: &'static str = "MessageIndicators";
+        type Type = super::MessageIndicators;
+        type ParentType = gtk::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+            klass.set_css_name("messageindicators");
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for MessageIndicators {
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![
+                    glib::ParamSpecObject::new(
+                        "message",
+                        "Message",
+                        "The message of the widget",
+                        glib::Object::static_type(),
+                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                    ),
+                    glib::ParamSpecObject::new(
+                        "model",
+                        "Model",
+                        "The model of the widget",
+                        MessageIndicatorsModel::static_type(),
+                        glib::ParamFlags::READABLE,
+                    ),
+                ]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(
+            &self,
+            obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "message" => obj.set_message(value.get().unwrap()),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "message" => obj.message().to_value(),
+                "model" => obj.model().to_value(),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn constructed(&self, obj: &Self::Type) {
+            self.parent_constructed(obj);
+
+            self.0.connect_notify_local(
+                Some("message"),
+                clone!(@weak obj => move |_, _| {
+                    obj.notify("message");
+                }),
+            );
+        }
+
+        fn dispose(&self, obj: &Self::Type) {
+            let mut child = obj.first_child();
+            while let Some(child_) = child {
+                child = child_.next_sibling();
+                child_.unparent();
+            }
+        }
+    }
+
+    impl WidgetImpl for MessageIndicators {}
+}
+
+glib::wrapper! {
+    pub(crate) struct MessageIndicators(ObjectSubclass<imp::MessageIndicators>)
+        @extends gtk::Widget;
+}
+
+impl MessageIndicators {
+    pub(crate) fn message(&self) -> glib::Object {
+        self.imp().0.message()
+    }
+
+    pub(crate) fn set_message(&self, message: glib::Object) {
+        self.imp().0.set_message(message);
+    }
+
+    pub(crate) fn model(&self) -> &MessageIndicatorsModel {
+        &self.imp().0
+    }
+}

--- a/src/session/content/message_row/indicators_model.rs
+++ b/src/session/content/message_row/indicators_model.rs
@@ -1,0 +1,114 @@
+use gettextrs::gettext;
+use gtk::glib;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+
+use crate::tdlib::{Message, SponsoredMessage};
+
+mod imp {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use std::cell::RefCell;
+
+    #[derive(Debug, Default)]
+    pub(crate) struct MessageIndicatorsModel {
+        pub(super) message: RefCell<Option<glib::Object>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MessageIndicatorsModel {
+        const NAME: &'static str = "MessageIndicatorsModel";
+        type Type = super::MessageIndicatorsModel;
+    }
+
+    impl ObjectImpl for MessageIndicatorsModel {
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![
+                    glib::ParamSpecObject::new(
+                        "message",
+                        "Message",
+                        "The message of the model",
+                        glib::Object::static_type(),
+                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                    ),
+                    glib::ParamSpecString::new(
+                        "message-info",
+                        "Message info",
+                        "The message info of the model",
+                        None,
+                        glib::ParamFlags::READABLE,
+                    ),
+                ]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(
+            &self,
+            obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "message" => obj.set_message(value.get().unwrap()),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "message" => obj.message().to_value(),
+                "message-info" => obj.message_info().to_value(),
+                _ => unimplemented!(),
+            }
+        }
+    }
+}
+
+glib::wrapper! {
+    pub(crate) struct MessageIndicatorsModel(ObjectSubclass<imp::MessageIndicatorsModel>);
+}
+
+impl Default for MessageIndicatorsModel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MessageIndicatorsModel {
+    pub(crate) fn new() -> Self {
+        glib::Object::new(&[]).expect("Failed to create MessageIndicatorsModel")
+    }
+
+    pub(crate) fn message(&self) -> glib::Object {
+        self.imp().message.borrow().clone().unwrap()
+    }
+
+    pub(crate) fn set_message(&self, message: glib::Object) {
+        let imp = self.imp();
+        let old = imp.message.replace(Some(message));
+        if old != *imp.message.borrow() {
+            self.notify("message");
+            self.notify("message-info");
+        }
+    }
+
+    pub(crate) fn message_info(&self) -> String {
+        if let Some(message) = self.imp().message.borrow().as_ref() {
+            if let Some(message) = message.downcast_ref::<Message>() {
+                let datetime = glib::DateTime::from_unix_utc(message.date() as i64)
+                    .and_then(|t| t.to_local())
+                    .unwrap();
+
+                // Translators: This is a time format for the message timestamp without seconds
+                return datetime.format(&gettext("%l:%M %p")).unwrap().into();
+            } else if message.downcast_ref::<SponsoredMessage>().is_some() {
+                return gettext("sponsored");
+            }
+        }
+
+        String::new()
+    }
+}

--- a/src/session/content/message_row/label.rs
+++ b/src/session/content/message_row/label.rs
@@ -1,0 +1,239 @@
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use gtk::{glib, pango, CompositeTemplate};
+
+use crate::session::content::message_row::MessageIndicators;
+
+const OBJECT_REPLACEMENT_CHARACTER: char = '\u{FFFC}';
+const INDICATORS_SPACING: i32 = 6;
+
+mod imp {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use once_cell::unsync::OnceCell;
+    use std::cell::RefCell;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(string = r#"
+    <interface>
+      <template class="MessageLabel" parent="GtkWidget">
+        <child>
+          <object class="GtkLabel" id="label">
+            <property name="use-markup">True</property>
+            <property name="wrap">True</property>
+            <property name="wrap-mode">word-char</property>
+            <property name="xalign">0</property>
+            <property name="yalign">0</property>
+          </object>
+        </child>
+      </template>
+    </interface>
+    "#)]
+    pub(crate) struct MessageLabel {
+        pub(super) text: RefCell<String>,
+        pub(super) indicators: OnceCell<MessageIndicators>,
+        pub(super) indicators_size: RefCell<Option<(i32, i32)>>,
+        #[template_child]
+        pub(super) label: TemplateChild<gtk::Label>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MessageLabel {
+        const NAME: &'static str = "MessageLabel";
+        type Type = super::MessageLabel;
+        type ParentType = gtk::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+            klass.set_css_name("messagelabel");
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for MessageLabel {
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![
+                    glib::ParamSpecString::new(
+                        "label",
+                        "Label",
+                        "The label of the widget",
+                        None,
+                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                    ),
+                    glib::ParamSpecObject::new(
+                        "indicators",
+                        "Indicators",
+                        "The message indicators of the widget",
+                        MessageIndicators::static_type(),
+                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                    ),
+                ]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(
+            &self,
+            obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "label" => obj.set_label(value.get().unwrap()),
+                "indicators" => {
+                    let indicators: MessageIndicators = value.get().unwrap();
+                    indicators.set_parent(obj);
+                    self.indicators.set(indicators).unwrap();
+                }
+                _ => unimplemented!(),
+            }
+        }
+
+        fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "label" => obj.label().to_value(),
+                "indicators" => obj.indicators().to_value(),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn dispose(&self, obj: &Self::Type) {
+            self.label.unparent();
+            obj.indicators().unparent();
+        }
+    }
+
+    impl WidgetImpl for MessageLabel {
+        fn measure(
+            &self,
+            widget: &Self::Type,
+            orientation: gtk::Orientation,
+            for_size: i32,
+        ) -> (i32, i32, i32, i32) {
+            let indicators = widget.indicators();
+            let (_, indicators_size) = indicators.preferred_size();
+            let old = self
+                .indicators_size
+                .replace(Some((indicators_size.width(), indicators_size.height())));
+
+            if let Some(old_indicators_size) = old {
+                if indicators_size.width() != old_indicators_size.0
+                    || indicators_size.height() != old_indicators_size.1
+                {
+                    widget.update_label_attributes(&indicators_size);
+                }
+            } else {
+                widget.update_label_attributes(&indicators_size);
+            }
+
+            let (mut minimum, mut natural, minimum_baseline, natural_baseline) =
+                self.label.measure(orientation, for_size);
+            let (indicators_min, indicators_nat, _, _) = indicators.measure(orientation, for_size);
+
+            minimum = minimum.max(indicators_min);
+            natural = natural.max(indicators_nat);
+
+            if orientation == gtk::Orientation::Vertical && widget.is_opposite_text_direction() {
+                minimum += indicators_min;
+                natural += indicators_nat;
+            }
+
+            (minimum, natural, minimum_baseline, natural_baseline)
+        }
+
+        fn size_allocate(&self, widget: &Self::Type, width: i32, height: i32, baseline: i32) {
+            self.label.allocate(width, height, baseline, None);
+            widget.indicators().allocate(width, height, baseline, None);
+        }
+
+        fn request_mode(&self, _widget: &Self::Type) -> gtk::SizeRequestMode {
+            self.label.request_mode()
+        }
+
+        fn direction_changed(&self, widget: &Self::Type, _previous_direction: gtk::TextDirection) {
+            widget.update_label();
+        }
+    }
+}
+
+glib::wrapper! {
+    pub(crate) struct MessageLabel(ObjectSubclass<imp::MessageLabel>)
+        @extends gtk::Widget;
+}
+
+impl MessageLabel {
+    pub(crate) fn new(label: &str, indicators: &MessageIndicators) -> Self {
+        glib::Object::new(&[("label", &label), ("indicators", indicators)])
+            .expect("Failed to create MessageLabel")
+    }
+
+    fn update_label_attributes(&self, indicators_size: &gtk::Requisition) {
+        let imp = self.imp();
+        if let Some(start_index) = imp.label.text().find(OBJECT_REPLACEMENT_CHARACTER) {
+            let attrs = pango::AttrList::new();
+            let width = indicators_size.width() + INDICATORS_SPACING;
+            let height = indicators_size.height();
+            let logical_rect = pango::Rectangle::new(
+                0,
+                -(height - (height / 4)) * pango::SCALE,
+                width * pango::SCALE,
+                height * pango::SCALE,
+            );
+            let mut shape = pango::AttrShape::new(&logical_rect, &logical_rect);
+
+            shape.set_start_index(start_index as u32);
+            shape.set_end_index((start_index + OBJECT_REPLACEMENT_CHARACTER.len_utf8()) as u32);
+            attrs.insert(shape);
+
+            imp.label.set_attributes(Some(&attrs));
+        } else {
+            imp.label.set_attributes(None);
+        }
+    }
+
+    fn is_opposite_text_direction(&self) -> bool {
+        let text = self.imp().text.borrow();
+        let text_direction = pango::find_base_dir(&text);
+        let widget_direction = self.direction();
+
+        (text_direction == pango::Direction::Rtl && widget_direction == gtk::TextDirection::Ltr)
+            || text_direction == pango::Direction::Ltr
+                && widget_direction == gtk::TextDirection::Rtl
+    }
+
+    fn update_label(&self) {
+        let imp = self.imp();
+        let text = imp.text.borrow();
+        if !self.is_opposite_text_direction() {
+            imp.label
+                .set_label(&format!("{}{}", text, OBJECT_REPLACEMENT_CHARACTER));
+        } else {
+            imp.label.set_label(&text);
+        }
+
+        let (_, indicators_size) = self.indicators().preferred_size();
+        self.update_label_attributes(&indicators_size);
+    }
+
+    pub(crate) fn label(&self) -> String {
+        self.imp().text.borrow().clone()
+    }
+
+    pub(crate) fn set_label(&self, label: String) {
+        let imp = self.imp();
+        let old = imp.text.replace(label);
+        if old != *imp.text.borrow() {
+            self.update_label();
+            self.notify("label");
+        }
+    }
+
+    pub(crate) fn indicators(&self) -> &MessageIndicators {
+        self.imp().indicators.get().unwrap()
+    }
+}

--- a/src/session/content/message_row/mod.rs
+++ b/src/session/content/message_row/mod.rs
@@ -1,4 +1,7 @@
 mod base;
+mod indicators;
+mod indicators_model;
+mod label;
 mod media;
 mod media_picture;
 mod photo;
@@ -7,6 +10,8 @@ mod sticker_picture;
 mod text;
 
 use self::base::{MessageBase, MessageBaseImpl};
+use self::indicators::MessageIndicators;
+use self::label::MessageLabel;
 use self::media::Media;
 use self::media_picture::MediaPicture;
 use self::photo::MessagePhoto;

--- a/src/session/content/message_row/photo.rs
+++ b/src/session/content/message_row/photo.rs
@@ -5,7 +5,9 @@ use gtk::{gdk, glib, CompositeTemplate};
 use tdlib::enums::MessageContent;
 use tdlib::types::File;
 
-use crate::session::content::message_row::{Media, MessageBase, MessageBaseImpl};
+use crate::session::content::message_row::{
+    Media, MessageBase, MessageBaseImpl, MessageIndicators,
+};
 use crate::tdlib::{BoxedMessageContent, Message};
 use crate::utils::parse_formatted_text;
 use crate::Session;
@@ -23,6 +25,8 @@ mod imp {
         pub(super) message: RefCell<Option<Message>>,
         #[template_child]
         pub(super) media: TemplateChild<Media>,
+        #[template_child]
+        pub(super) indicators: TemplateChild<MessageIndicators>,
     }
 
     #[glib::object_subclass]
@@ -108,6 +112,8 @@ impl MessagePhoto {
             let handler_id = imp.handler_id.take().unwrap();
             old_message.disconnect(handler_id);
         }
+
+        imp.indicators.set_message(message.clone().upcast());
 
         // Setup caption expression
         let caption_binding = Message::this_expression("content")

--- a/src/session/content/message_row/sticker.rs
+++ b/src/session/content/message_row/sticker.rs
@@ -8,7 +8,9 @@ use std::io::Cursor;
 use tdlib::enums::MessageContent;
 use tdlib::types::File;
 
-use crate::session::content::message_row::{MessageBase, MessageBaseImpl, StickerPicture};
+use crate::session::content::message_row::{
+    MessageBase, MessageBaseImpl, MessageIndicators, StickerPicture,
+};
 use crate::tdlib::Message;
 use crate::utils::spawn;
 
@@ -23,6 +25,8 @@ mod imp {
         pub(super) message: RefCell<Option<Message>>,
         #[template_child]
         pub(super) picture: TemplateChild<StickerPicture>,
+        #[template_child]
+        pub(super) indicators: TemplateChild<MessageIndicators>,
     }
 
     #[glib::object_subclass]
@@ -33,6 +37,7 @@ mod imp {
 
         fn class_init(klass: &mut Self::Class) {
             Self::bind_template(klass);
+            klass.set_css_name("messagesticker");
         }
 
         fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
@@ -99,6 +104,8 @@ impl MessageSticker {
         if imp.message.borrow().as_ref() == Some(&message) {
             return;
         }
+
+        imp.indicators.set_message(message.clone().upcast());
 
         imp.picture.set_texture(None);
 

--- a/src/session/content/message_row/text.rs
+++ b/src/session/content/message_row/text.rs
@@ -7,7 +7,9 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use tdlib::enums::MessageContent;
 
-use crate::session::content::message_row::{MessageBase, MessageBaseImpl};
+use crate::session::content::message_row::{
+    MessageBase, MessageBaseImpl, MessageIndicators, MessageLabel,
+};
 use crate::tdlib::{BoxedMessageContent, Chat, ChatType, Message, MessageSender, SponsoredMessage};
 use crate::utils::parse_formatted_text;
 
@@ -25,7 +27,9 @@ mod imp {
         #[template_child]
         pub(super) sender_label: TemplateChild<gtk::Label>,
         #[template_child]
-        pub(super) content_label: TemplateChild<gtk::Label>,
+        pub(super) content_label: TemplateChild<MessageLabel>,
+        #[template_child]
+        pub(super) indicators: TemplateChild<MessageIndicators>,
     }
 
     #[glib::object_subclass]
@@ -108,6 +112,8 @@ impl MessageText {
         while let Some(binding) = bindings.pop() {
             binding.unwatch();
         }
+
+        imp.indicators.set_message(message.clone());
 
         // Remove the previous color css class
         let mut sender_color_class = imp.sender_color_class.borrow_mut();


### PR DESCRIPTION
Fixes #28.

The PR introduces a new MessageIndicators widget that will contain all the icons and labels that are related to the status of the message (sent/unread icons, timestamp label, edited label, etc), currently only the timestamp and sponsored message text is included. ~This also introduces the MessageLabel which is a widget that contains the label of the related message and also the MessageIndicators widget, which is always placed at the bottom right of the label (the label will always leave a space for it to fit).~

~What's missing is a way of updating the label attributes when the MessageIndicators size changes.~

~EDIT: the MessageIndicators also needs to be included in the MessageSticker widget.~ Done.

~EDIT: see https://github.com/melix99/telegrand/pull/121#issuecomment-1006799962.~