### PR TITLE
sidebar-chat-row: Fix gettext panic

### DIFF
--- a/src/session/sidebar/chat_row.rs
+++ b/src/session/sidebar/chat_row.rs
@@ -230,13 +230,9 @@ fn stringify_message(message: Message) -> String {
 
     let text_content = match message.content().0 {
         MessageContent::MessageText(data) => dim_and_escape(&data.text.text),
-        MessageContent::MessageBasicGroupChatCreate(data) => {
+        MessageContent::MessageBasicGroupChatCreate(_) => {
             show_sender = false;
-            gettext!(
-                "{} created the group",
-                sender_name(message.sender(), true),
-                data.title
-            )
+            gettext!("{} created the group", sender_name(message.sender(), true))
         }
         MessageContent::MessageSticker(data) => {
             format!("{} {}", data.sticker.emoji, gettext("Sticker"))


### PR DESCRIPTION
This error crept into PR #129: Argument count doesn't match the number
of format directives in gettext macro call.