### PR TITLE
misc: Simplify usage of IndexMap in some places

### DIFF
--- a/src/session/chat_list.rs
+++ b/src/session/chat_list.rs
@@ -179,12 +179,7 @@ impl ChatList {
 
     pub fn get_chat(&self, chat_id: i64) -> Option<Chat> {
         let self_ = imp::ChatList::from_instance(self);
-        if let Some(index) = self_.list.borrow().get_index_of(&chat_id) {
-            if let Some(item) = self.item(index as u32) {
-                return Some(item.downcast().unwrap());
-            }
-        }
-        None
+        self_.list.borrow().get(&chat_id).cloned()
     }
 
     fn insert_chat(&self, chat: TelegramChat) {


### PR DESCRIPTION
# Commit Description
The use of the IndexMap can be simplified in the 'ChatList::get_chat'
and 'UserList::get_or_create_user' functions by not determining the in-
dex of the element to be found, but finding the element directly.

Additionally, in the 'UserList::get_or_create_user' function the number
of lookups can be reduced from 3 (user is not initially existing) to 1
by using the Entry API and omitting recursion.