### PR TITLE
chat: Set 'unread-count' during construction

### DIFF
--- a/src/session/chat/mod.rs
+++ b/src/session/chat/mod.rs
@@ -233,6 +233,7 @@ impl Chat {
             ("type", &type_),
             ("title", &chat.title),
             ("avatar", &avatar),
+            ("unread-count", &chat.unread_count),
             ("session", &session),
         ])
         .expect("Failed to create Chat")


### PR DESCRIPTION
# Commit Description
Our glib-based chat instance must take the unread count from the
TelegramChat during construction. Otherwise, the unread label is not
initially displayed until a new message arrives.