### PR TITLE
Introduce PreferencesWindow with dark theme preference

### DIFF
--- a/data/com.github.melix99.telegrand.gschema.xml.in
+++ b/data/com.github.melix99.telegrand.gschema.xml.in
@@ -14,12 +14,22 @@
     <key name="is-maximized" type="b">
       <default>false</default>
       <summary>Default window maximized behaviour</summary>
-      <description></description>
+      <description>Default window maximized behaviour</description>
     </key>
     <key name="use-test-dc" type="b">
       <default>false</default>
       <summary>Use Telegram's test data center</summary>
       <description>Use Telegram's test data center</description>
+    </key>
+    <key name="color-scheme" type="s">
+      <choices>
+        <choice value="default"/>
+        <choice value="light"/>
+        <choice value="dark"/>
+      </choices>
+      <default>'default'</default>
+      <summary>Color Scheme</summary>
+      <description>The color scheme to be used in the app</description>
     </key>
   </schema>
 </schemalist>

--- a/data/resources/resources.gresource.xml
+++ b/data/resources/resources.gresource.xml
@@ -13,6 +13,7 @@
     <file compressed="true" preprocess="xml-stripblanks">ui/content-send-message-area.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content-user-dialog.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/login.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/preferences-window.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/session.ui</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="gtk/help-overlay.ui">ui/shortcuts.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/sidebar.ui</file>

--- a/data/resources/ui/preferences-window.ui
+++ b/data/resources/ui/preferences-window.ui
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="PreferencesWindow" parent="AdwPreferencesWindow">
+    <child>
+      <object class="AdwPreferencesPage">
+        <property name="title" translatable="yes">Appearance</property>
+        <child>
+          <object class="AdwPreferencesGroup">
+            <property name="title" translatable="yes">Color Scheme</property>
+            <child>
+              <object class="AdwActionRow" id="follow_system_colors_row">
+                <property name="title" translatable="yes">Follow System Colors</property>
+                <property name="activatable_widget">follow_system_colors_switch</property>
+                <child>
+                  <object class="GtkSwitch" id="follow_system_colors_switch">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="AdwActionRow">
+                <property name="title" translatable="yes">Dark Theme</property>
+                <property name="activatable_widget">dark_theme_switch</property>
+                <child>
+                  <object class="GtkSwitch" id="dark_theme_switch">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/resources/ui/sidebar.ui
+++ b/data/resources/ui/sidebar.ui
@@ -9,6 +9,10 @@
     </section>
     <section>
       <item>
+        <attribute name="label" translatable="yes">_Preferences</attribute>
+        <attribute name="action">app.preferences</attribute>
+      </item>
+      <item>
         <attribute name="label" translatable="yes">_Keyboard Shortcuts</attribute>
         <attribute name="action">win.show-help-overlay</attribute>
       </item>

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,14 @@ mod application;
 #[rustfmt::skip]
 mod config;
 mod login;
+mod preferences_window;
 mod session;
 mod utils;
 mod window;
 
 use self::application::Application;
 use self::login::Login;
+use self::preferences_window::PreferencesWindow;
 use self::session::Session;
 use self::window::Window;
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -25,6 +25,7 @@ rust_sources = files(
   'config.rs',
   'login.rs',
   'main.rs',
+  'preferences_window.rs',
   'utils.rs',
   'window.rs',
   'session/avatar.rs',

--- a/src/preferences_window.rs
+++ b/src/preferences_window.rs
@@ -1,0 +1,135 @@
+use glib::clone;
+use gtk::{gio, glib, prelude::*, subclass::prelude::*, CompositeTemplate};
+
+use crate::config::APP_ID;
+
+mod imp {
+    use super::*;
+    use adw::subclass::prelude::*;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(resource = "/com/github/melix99/telegrand/ui/preferences-window.ui")]
+    pub struct PreferencesWindow {
+        #[template_child]
+        pub follow_system_colors_row: TemplateChild<adw::ActionRow>,
+        #[template_child]
+        pub follow_system_colors_switch: TemplateChild<gtk::Switch>,
+        #[template_child]
+        pub dark_theme_switch: TemplateChild<gtk::Switch>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for PreferencesWindow {
+        const NAME: &'static str = "PreferencesWindow";
+        type Type = super::PreferencesWindow;
+        type ParentType = adw::PreferencesWindow;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for PreferencesWindow {
+        fn constructed(&self, obj: &Self::Type) {
+            self.parent_constructed(obj);
+
+            // If the system supports color schemes, load the 'Follow system colors'
+            // switch state, otherwise hide that row completely
+            let style_manager = adw::StyleManager::default();
+            if let Some(style_manager) = style_manager {
+                if style_manager.system_supports_color_schemes() {
+                    let settings = gio::Settings::new(APP_ID);
+                    let follow_system_colors = settings.string("color-scheme") == "default";
+                    self.follow_system_colors_switch
+                        .set_active(follow_system_colors);
+                } else {
+                    self.follow_system_colors_row.set_visible(false);
+                }
+            }
+
+            obj.setup_bindings();
+        }
+    }
+
+    impl WidgetImpl for PreferencesWindow {}
+    impl WindowImpl for PreferencesWindow {}
+    impl AdwWindowImpl for PreferencesWindow {}
+    impl PreferencesWindowImpl for PreferencesWindow {}
+}
+
+glib::wrapper! {
+    pub struct PreferencesWindow(ObjectSubclass<imp::PreferencesWindow>)
+        @extends gtk::Widget, gtk::Window, adw::Window, adw::PreferencesWindow;
+}
+
+impl PreferencesWindow {
+    pub fn new() -> Self {
+        glib::Object::new(&[]).expect("Failed to create PreferencesWindow")
+    }
+
+    fn setup_bindings(&self) {
+        let self_ = imp::PreferencesWindow::from_instance(self);
+
+        // 'Follow system colors' switch state handling
+        self_
+            .follow_system_colors_switch
+            .connect_active_notify(|switch| {
+                let style_manager = adw::StyleManager::default();
+                if let Some(style_manager) = style_manager {
+                    let settings = gio::Settings::new(APP_ID);
+                    if switch.is_active() {
+                        // Prefer light theme unless the system prefers dark colors
+                        style_manager.set_color_scheme(adw::ColorScheme::PreferLight);
+                        settings.set_string("color-scheme", "default").unwrap();
+                    } else {
+                        // Set default state for the dark theme switch
+                        style_manager.set_color_scheme(adw::ColorScheme::ForceLight);
+                        settings.set_string("color-scheme", "light").unwrap();
+                    }
+                }
+            });
+
+        // 'Dark theme' switch state handling
+        let follow_system_colors_switch = &*self_.follow_system_colors_switch;
+        self_.dark_theme_switch.connect_active_notify(
+            clone!(@weak follow_system_colors_switch => move |switch| {
+                if !follow_system_colors_switch.is_active() {
+                let style_manager = adw::StyleManager::default();
+                if let Some(style_manager) = style_manager {
+                    let settings = gio::Settings::new(APP_ID);
+                    if switch.is_active() {
+                        // Dark mode
+                        style_manager.set_color_scheme(adw::ColorScheme::ForceDark);
+                        settings.set_string("color-scheme", "dark").unwrap();
+                    } else {
+                        // Light mode
+                        style_manager.set_color_scheme(adw::ColorScheme::ForceLight);
+                        settings.set_string("color-scheme", "light").unwrap();
+                    }
+                }
+                }
+            }),
+        );
+
+        // Make the 'Dark theme' switch insensitive if the 'Follow system colors'
+        // switch is active
+        self_
+            .follow_system_colors_switch
+            .bind_property("active", &*self_.dark_theme_switch, "sensitive")
+            .flags(glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::INVERT_BOOLEAN)
+            .build();
+
+        // Have the 'Dark theme' switch state always updated with the dark state
+        let style_manager = adw::StyleManager::default();
+        if let Some(style_manager) = style_manager {
+            style_manager
+                .bind_property("dark", &*self_.dark_theme_switch, "active")
+                .flags(glib::BindingFlags::SYNC_CREATE)
+                .build();
+        }
+    }
+}


### PR DESCRIPTION
~This needs testing in systems where there's support for system color schemes. A guide + app to do that is [here](https://gitlab.gnome.org/exalm/color-scheme-simulator) (information for future me).~

Edit: this supersedes #139. 

Edit 2: ~forgot to mention that this is still incomplete as there's no way to save the dark theme state.~ Done

Edit 3: I confirm that the 'Follow system colors' works in systems where there's the support for it.