### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@
 
 ## Installation Instructions
 
-Telegrand is an in-development project and it isn't considered stable software yet. But if you still want to try it out, there's a [CI](https://github.com/melix99/telegrand/actions?query=branch%3Amain) that automatically generates the latest flatpak build. Just download the artifact of the latest build and install it locally using `flatpak install telegrand.flatpak`.
+Telegrand is an in-development project and it isn't considered stable software yet. Also, the included API credentials are very limited and, in some cases, your account may end up banned by Telegram (check the `Telegram API Credentials` section below). You can avoid that by using a custom built version of Telegrand with provided API credentials via meson options, like [this AUR package](https://aur.archlinux.org/packages/telegrand-git) which you may prefer using if you use Arch Linux. But, if you still feel brave enough, there's a CI that automatically generates the latest flatpak build with the test API credentials: just download the [latest artifact](https://nightly.link/melix99/telegrand/workflows/ci/main/telegrand-x86_64.zip) and install it locally using `flatpak install telegrand.flatpak`.
+
+## Telegram API Credentials
+
+Telegram requires custom clients to set some credentials for using their API. Telegrand doesn't provide official API credentials, so the packagers are expected to set their own credentials for distributing the app. However, Telegrand includes the Telegram's test credentials by default, which are very limited, but usable (especially for development). However, it's known that Telegram sometimes decides to ban accounts that use such credentials (especially newer accounts). For that reason, it's suggested to use your own API credentials, which can be set by using meson options (see the `Build Instructions` section below).
 
 ## Build Instructions
 
@@ -34,17 +38,23 @@ Using Gnome Builder is the easiest way to get the app built without even using t
 
 ### Meson
 
-We use TDLib as the backend for the Telegram API, so you'll need to have TDLib already installed in your system (together with GTK4 and libadwaita). Then, you'll need Meson and Rust to actually build the app.
+#### Prerequisites
+
+The following packages are required to build Telegrand:
+
+- meson
+- cargo
+- GTK4
+- libadwaita (latest git revision)
+- TDLib 1.7.0
+
+#### Instructions
 
 ```shell
-meson . _build --prefix=/usr/local
+meson . _build -Dtg_api_id=ID -Dtg_api_hash=HASH
 ninja -C _build
 sudo ninja -C _build install
 ```
-
-## Telegram API Credentials
-
-Telegram requires custom clients to set some credentials for using their API. Telegrand doesn't provide official credentials, so the packagers are expected to set their own credentials for distributing the app. Anyway, Telegrand does include by default the official credentials that Telegram provides for testing purposes, which are very limited, but usable (expecially for development).
 
 ## Acknowledgment
 


### PR DESCRIPTION
It includes more information about the included Telegram's test API credentials and improves the meson section with a list of prerequisites.

Hopefully this is a bit more complete than before.

@marhkb do you mind giving me an ACK just to be sure I didn't miss anything?