### PR TITLE
gschema: Set default window size

### DIFF
--- a/data/com.github.melix99.telegrand.gschema.xml.in
+++ b/data/com.github.melix99.telegrand.gschema.xml.in
@@ -2,12 +2,12 @@
 <schemalist>
   <schema path="/com/github/melix99/telegrand/" id="@app-id@" gettext-domain="@gettext-package@">
     <key name="window-width" type="i">
-      <default>-1</default>
+      <default>900</default>
       <summary>Default window width</summary>
       <description>Default window width</description>
     </key>
     <key name="window-height" type="i">
-      <default>-1</default>
+      <default>600</default>
       <summary>Default window height</summary>
       <description>Default window height</description>
     </key>


### PR DESCRIPTION
The default window size wasn't even set before.