### PR TITLE
flatpak: Remove vapi from libadwaita

### DIFF
--- a/build-aux/com.github.melix99.telegrand.Devel.json
+++ b/build-aux/com.github.melix99.telegrand.Devel.json
@@ -60,6 +60,7 @@
             "name": "libadwaita",
             "buildsystem": "meson",
             "config-opts": [
+                "-Dvapi=false",
                 "-Dexamples=false",
                 "-Dtests=false"
             ],


### PR DESCRIPTION
I think we don't need the vala bindings.