### PR TITLE
Implement Multi Account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,12 +201,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -233,6 +248,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
 
 [[package]]
+name = "futures-sink"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+
+[[package]]
 name = "futures-task"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -1013,18 +1035,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1033,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
  "itoa",
  "ryu",
@@ -1179,6 +1201,8 @@ dependencies = [
 name = "telegrand"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "futures",
  "gettext-rs",
  "gtk4",
  "indexmap",
@@ -1191,6 +1215,7 @@ dependencies = [
  "regex",
  "tdgrand",
  "tokio",
+ "tokio-stream",
  "webp",
 ]
 
@@ -1237,6 +1262,17 @@ checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
  "num_cpus",
  "pin-project-lite",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 [dependencies]
 adw = { version = "0.1.0-alpha-6", package = "libadwaita" }
+anyhow = "1.0"
+futures = { version = "0.3", default-features = false }
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
 gtk = { version = "0.3", package = "gtk4" }
 indexmap = "1.7"
@@ -17,4 +19,5 @@ qrcode-generator = { version = "4.1", default-features = false }
 regex = "1.5"
 tdgrand = { git = "https://github.com/melix99/tdgrand", branch = "main" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio-stream = { version = "0.1", features = ["fs"] }
 webp = "0.2"

--- a/data/com.github.melix99.telegrand.gschema.xml.in
+++ b/data/com.github.melix99.telegrand.gschema.xml.in
@@ -16,10 +16,10 @@
       <summary>Default window maximized behaviour</summary>
       <description>Default window maximized behaviour</description>
     </key>
-    <key name="use-test-dc" type="b">
-      <default>false</default>
-      <summary>Use Telegram's test data center</summary>
-      <description>Use Telegram's test data center</description>
+    <key name="recently-used-sessions" type="as">
+      <default>[]</default>
+      <summary>Recently used sessions</summary>
+      <description>The ordered list of recently used sessions by their database directory name</description>
     </key>
     <key name="color-scheme" type="s">
       <choices>

--- a/data/resources/resources.gresource.xml
+++ b/data/resources/resources.gresource.xml
@@ -3,6 +3,8 @@
   <gresource prefix="/com/github/melix99/telegrand/">
     <file preprocess="xml-stripblanks">icons/scalable/actions/phone-oldschool-symbolic.svg</file>
 
+    <file compressed="true" preprocess="xml-stripblanks">ui/add-account-row.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/avatar-with-selection.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/components-avatar.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content-chat-action-bar.ui</file>
@@ -15,11 +17,14 @@
     <file compressed="true" preprocess="xml-stripblanks">ui/content-user-dialog.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/login.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/preferences-window.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/session-entry-row.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/session-manager.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/session.ui</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="gtk/help-overlay.ui">ui/shortcuts.ui</file>
-    <file compressed="true" preprocess="xml-stripblanks">ui/sidebar.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/sidebar-avatar.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/sidebar-row.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/sidebar-session-switcher.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/sidebar.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/window.ui</file>
 
     <file compressed="true">style.css</file>

--- a/data/resources/style-dark.css
+++ b/data/resources/style-dark.css
@@ -1,3 +1,7 @@
+#new-login-icon {
+  background-color: @dark_2;
+}
+
 .chat-list row .unread-count-muted {
   background-color: @dark_2;
 }

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -1,3 +1,54 @@
+.bold {
+  font-weight: bold;
+}
+
+.italic {
+  font-size: 0.8em;
+}
+
+/* Account switcher */
+#account-switcher row {
+  border-radius: 10px;
+  margin-top: 2px;
+  margin-bottom: 2px;
+  padding-top: 7px;
+  padding-bottom: 7px;
+}
+
+#account-switcher .user-id {
+  font-size: 12px;
+}
+
+#new-login-icon {
+  /*
+   *  2 * padding + pixel-size = size (of avatar)
+   */
+  padding: 12px;
+  background-color: @light_4;
+  border-radius: 9999px;
+}
+
+.unread-count {
+  background-color: @accent_bg_color;
+  color: @accent_fg_color;
+  font-weight: bold;
+  min-width: 0.7em;
+  border-radius: 9999px;
+  font-size: 0.95em;
+  padding: 2px 5px 1px;
+}
+
+.selected-avatar avatar {
+  border: 2px solid @accent_bg_color;
+}
+
+.blue-checkmark {
+  color: @light_1;
+  border-radius: 9999px;
+  border: solid @accent_bg_color 2px;
+  background-color: @accent_bg_color;
+}
+
 .chat-list {
   background: @window_bg_color;
 }

--- a/data/resources/ui/add-account-row.ui
+++ b/data/resources/ui/add-account-row.ui
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <menu id="menu_model">
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">_Production Server</attribute>
+        <attribute name="action">app.new-login-production-server</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">_Test Server</attribute>
+        <attribute name="action">app.new-login-test-server</attribute>
+      </item>
+    </section>
+  </menu>
+  <template class="AddAccountRow" parent="GtkWidget">
+    <property name="layout-manager">
+      <object class="GtkBoxLayout">
+        <property name="spacing">10</property>
+      </object>
+    </property>
+    <property name="margin-start">3</property>
+    <property name="margin-end">3</property>
+    <child>
+      <object class="GtkImage" id="image">
+        <property name="name">new-login-icon</property>
+        <property name="icon-name">list-add-symbolic</property>
+        <property name="pixel-size">16</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label">
+        <property name="use-underline">true</property>
+        <property name="label" translatable="yes">_Add Account</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkPopoverMenu" id="menu">
+        <property name="menu-model">menu_model</property>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/resources/ui/avatar-with-selection.ui
+++ b/data/resources/ui/avatar-with-selection.ui
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="AvatarWithSelection" parent="AdwBin">
+    <property name="child">
+      <object class="GtkOverlay">
+        <child>
+          <object class="ComponentsAvatar" id="child_avatar"/>
+        </child>
+        <child type="overlay">
+          <object class="GtkImage" id="checkmark">
+            <style>
+              <class name="blue-checkmark" />
+            </style>
+            <property name="visible">false</property>
+            <property name="halign">end</property>
+            <property name="valign">end</property>
+            <property name="icon-name">emblem-ok-symbolic</property>
+          </object>
+        </child>
+      </object>
+    </property>
+  </template>
+</interface>

--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -169,26 +169,6 @@
                                             </child>
                                           </object>
                                         </child>
-                                        <child>
-                                          <object class="AdwExpanderRow">
-                                            <property name="focusable">False</property>
-                                            <property name="selectable">False</property>
-                                            <property name="activatable">False</property>
-                                            <property name="title" translatable="yes">Advanced</property>
-                                            <child>
-                                              <object class="AdwActionRow">
-                                                <property name="activatable_widget">use_test_dc_switch</property>
-                                                <property name="title" translatable="yes">Use Test Data Center</property>
-                                                <property name="subtitle" translatable="yes">This requires a restart to apply</property>
-                                                <child>
-                                                  <object class="GtkSwitch" id="use_test_dc_switch">
-                                                    <property name="valign">center</property>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                            </child>
-                                          </object>
-                                        </child>
                                         <style>
                                           <class name="boxed-list"/>
                                         </style>

--- a/data/resources/ui/session-entry-row.ui
+++ b/data/resources/ui/session-entry-row.ui
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="SessionEntryRow" parent="GtkWidget">
+    <property name="layout-manager">
+      <object class="GtkBoxLayout">
+        <property name="spacing">10</property>
+      </object>
+    </property>
+    <property name="margin-start">3</property>
+    <property name="margin-end">3</property>
+    <child>
+      <object class="AvatarWithSelection" id="account_avatar">
+        <property name="size">40</property>
+        <binding name="item">
+          <lookup name="avatar" type="User">
+            <lookup name="me" type="Session">
+              <lookup name="session">SessionEntryRow</lookup>
+            </lookup>
+          </lookup>
+        </binding>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox" id="center_box">
+        <property name="orientation">vertical</property>
+        <property name="spacing">3</property>
+        <child>
+          <object class="GtkLabel" id="display_name_label">
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="xalign">0.0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="username_label">
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="xalign">0.0</property>
+            <style>
+              <class name="dim-label"/>
+              <class name="user-id"/>
+            </style>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel" id="unread_count_label">
+        <property name="valign">center</property>
+        <property name="halign">end</property>
+        <property name="ellipsize">end</property>
+        <property name="justify">center</property>
+        <binding name="label">
+          <lookup name="unread-count" type="ChatList">
+            <lookup name="chat-list" type="Session">
+              <lookup name="session">SessionEntryRow</lookup>
+            </lookup>
+          </lookup>
+        </binding>
+        <binding name="visible">
+          <lookup name="unread-count" type="ChatList">
+            <lookup name="chat-list" type="Session">
+              <lookup name="session">SessionEntryRow</lookup>
+            </lookup>
+          </lookup>
+        </binding>
+        <style>
+          <class name="unread-count"/>
+        </style>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/resources/ui/session-manager.ui
+++ b/data/resources/ui/session-manager.ui
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="SessionManager" parent="GtkWidget">
+    <property name="layout-manager">
+      <object class="GtkBinLayout"/>
+    </property>
+    <child>
+      <object class="GtkStack" id="main_stack">
+        <property name="visible-child">login</property>
+        <property name="transition-type">crossfade</property>
+        <child>
+          <object class="Login" id="login"/>
+        </child>
+        <child>
+          <object class="GtkStack" id="sessions"/>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/resources/ui/sidebar-session-switcher.ui
+++ b/data/resources/ui/sidebar-session-switcher.ui
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="SessionSwitcher" parent="GtkPopover">
+    <property name="name">account-switcher</property>
+    <child>
+      <object class="GtkListView" id="entries">
+        <property name="single-click-activate">true</property>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/resources/ui/sidebar.ui
+++ b/data/resources/ui/sidebar.ui
@@ -33,15 +33,37 @@
       <object class="AdwHeaderBar" id="header_bar">
         <property name="show-end-title-buttons" bind-source="Sidebar" bind-property="compact" bind-flags="sync-create"/>
         <child type="start">
-          <object class="GtkToggleButton">
-            <property name="icon-name">system-search-symbolic</property>
-            <property name="active" bind-source="search_bar" bind-property="search-mode-enabled" bind-flags="bidirectional|sync-create"/>
+          <object class="GtkMenuButton">
+            <property name="popover">
+              <object class="SessionSwitcher" id="session_switcher"/>
+            </property>
+            <style>
+              <class name="image-button"/>
+            </style>
+            <property name="child">
+              <object class="ComponentsAvatar">
+                <property name="size">24</property>
+                <binding name="item">
+                  <lookup name="avatar" type="User">
+                    <lookup name="me" type="Session">
+                      <lookup name="session">Sidebar</lookup>
+                    </lookup>
+                  </lookup>
+                </binding>
+              </object>
+            </property>
           </object>
         </child>
         <child type="end">
           <object class="GtkMenuButton">
             <property name="icon-name">open-menu-symbolic</property>
             <property name="menu-model">primary_menu</property>
+          </object>
+        </child>
+        <child type="end">
+          <object class="GtkToggleButton">
+            <property name="icon-name">system-search-symbolic</property>
+            <property name="active" bind-source="search_bar" bind-property="search-mode-enabled" bind-flags="bidirectional|sync-create"/>
           </object>
         </child>
       </object>

--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -4,13 +4,7 @@
     <property name="default-width">900</property>
     <property name="default-height">600</property>
     <property name="content">
-      <object class="GtkStack" id="main_stack">
-        <property name="visible-child">login</property>
-        <property name="transition-type">crossfade</property>
-        <child>
-          <object class="Login" id="login"/>
-        </child>
-      </object>
+      <object class="SessionManager" id="session_manager"/>
     </property>
   </template>
 </interface>

--- a/src/application.rs
+++ b/src/application.rs
@@ -122,6 +122,23 @@ impl Application {
             app.show_about_dialog();
         }));
         self.add_action(&action_about);
+
+        // New login on production server
+        let action_new_login_production_server =
+            gio::SimpleAction::new("new-login-production-server", None);
+        action_new_login_production_server.connect_activate(
+            clone!(@weak self as app => move |_, _| {
+                app.main_window().session_manager().add_new_session(false);
+            }),
+        );
+        self.add_action(&action_new_login_production_server);
+
+        // New login on test server
+        let action_new_login_test_server = gio::SimpleAction::new("new-login-test-server", None);
+        action_new_login_test_server.connect_activate(clone!(@weak self as app => move |_, _| {
+            app.main_window().session_manager().add_new_session(true);
+        }));
+        self.add_action(&action_new_login_test_server);
     }
 
     // Sets up keyboard shortcuts

--- a/src/login.rs
+++ b/src/login.rs
@@ -5,25 +5,26 @@ use gtk::{
     prelude::*,
     subclass::prelude::*,
 };
-use locale_config::Locale;
 use tdgrand::{enums::AuthorizationState, functions, types};
 
-use crate::config;
-use crate::utils::{do_async, parse_formatted_text};
-use crate::DATA_DIR;
+use crate::{
+    session_manager::{DatabaseInfo, SessionManager},
+    utils::{do_async, log_out, parse_formatted_text, send_tdlib_parameters},
+};
 
 mod imp {
     use super::*;
     use adw::subclass::prelude::BinImpl;
-    use glib::subclass::Signal;
-    use gtk::{gio, CompositeTemplate};
-    use once_cell::sync::Lazy;
+    use gtk::CompositeTemplate;
+    use once_cell::sync::OnceCell;
     use std::cell::{Cell, RefCell};
 
     #[derive(Debug, Default, CompositeTemplate)]
     #[template(resource = "/com/github/melix99/telegrand/ui/login.ui")]
     pub struct Login {
+        pub session_manager: OnceCell<SessionManager>,
         pub client_id: Cell<i32>,
+        pub database_info: RefCell<Option<DatabaseInfo>>,
         pub tos_text: RefCell<String>,
         pub show_tos_popup: Cell<bool>,
         pub has_recovery_email_address: Cell<bool>,
@@ -50,8 +51,6 @@ mod imp {
         pub phone_number_use_qr_code_stack: TemplateChild<gtk::Stack>,
         #[template_child]
         pub welcome_page_error_label: TemplateChild<gtk::Label>,
-        #[template_child]
-        pub use_test_dc_switch: TemplateChild<gtk::Switch>,
         #[template_child]
         pub qr_code_image: TemplateChild<gtk::Image>,
         #[template_child]
@@ -143,13 +142,6 @@ mod imp {
     }
 
     impl ObjectImpl for Login {
-        fn signals() -> &'static [Signal] {
-            static SIGNALS: Lazy<Vec<Signal>> = Lazy::new(|| {
-                vec![Signal::builder("new-session", &[], <()>::static_type().into()).build()]
-            });
-            SIGNALS.as_ref()
-        }
-
         fn constructed(&self, obj: &Self::Type) {
             self.parent_constructed(obj);
 
@@ -161,13 +153,6 @@ mod imp {
                 .connect_visible_child_name_notify(clone!(@weak obj => move |_| {
                     obj.update_actions_for_visible_page()
                 }));
-
-            // Bind the use-test-dc setting to the relative switch
-            let use_test_dc_switch = &*self_.use_test_dc_switch;
-            let settings = gio::Settings::new(config::APP_ID);
-            settings
-                .bind("use-test-dc", use_test_dc_switch, "state")
-                .build();
 
             self_.tos_label.connect_activate_link(|label, _| {
                 label.activate_action("login.show-tos-dialog", None);
@@ -199,9 +184,18 @@ impl Login {
         glib::Object::new(&[]).expect("Failed to create Login")
     }
 
-    pub fn login_client(&self, client_id: i32) {
+    pub fn set_session_manager(&self, session_manager: SessionManager) {
+        imp::Login::from_instance(self)
+            .session_manager
+            .set(session_manager)
+            .unwrap();
+    }
+
+    pub fn login_client(&self, client_id: i32, database_info: DatabaseInfo) {
         let self_ = imp::Login::from_instance(self);
         self_.client_id.set(client_id);
+
+        self_.database_info.replace(Some(database_info));
 
         // We don't know what login page to show at this point, so we show an empty page until we
         // receive an AuthenticationState that will eventually show the related login page.
@@ -219,7 +213,20 @@ impl Login {
 
         match state {
             AuthorizationState::WaitTdlibParameters => {
-                self.send_tdlib_parameters();
+                let client_id = self_.client_id.get();
+                let database_info = self_.database_info.borrow().clone().unwrap();
+                do_async(
+                    glib::PRIORITY_DEFAULT_IDLE,
+                    async move { send_tdlib_parameters(client_id, &database_info).await },
+                    clone!(@weak self as obj => move |result| async move {
+                        if let Err(err) = result {
+                            show_error_label(
+                                &imp::Login::from_instance(&obj).welcome_page_error_label,
+                                &err.message
+                            );
+                        }
+                    }),
+                );
             }
             AuthorizationState::WaitEncryptionKey(_) => {
                 self.send_encryption_key();
@@ -366,11 +373,17 @@ impl Login {
             }
             AuthorizationState::Ready => {
                 self.disable_actions();
+
                 // Clear the qr code image save some potential memory.
                 self_
                     .qr_code_image
                     .set_paintable(None as Option<&gdk::Paintable>);
-                self.emit_by_name("new-session", &[]).unwrap();
+
+                self_.session_manager.get().unwrap().add_logged_in_session(
+                    self_.client_id.get(),
+                    self_.database_info.take().unwrap(),
+                    true,
+                );
             }
             _ => {}
         }
@@ -390,7 +403,7 @@ impl Login {
         let self_ = imp::Login::from_instance(self);
 
         // Before transition to the page, be sure to reset the error label because it still might
-        // conatain an error message from the time when it was previously visited.
+        // contain an error message from the time when it was previously visited.
         if let Some(error_label_to_clear) = error_label_to_clear {
             error_label_to_clear.set_label("");
         }
@@ -416,7 +429,13 @@ impl Login {
 
         let visible_page = self_.content.visible_child_name().unwrap();
 
-        let is_previous_valid = visible_page.as_str() != "phone-number-page";
+        let is_previous_valid = self_
+            .session_manager
+            .get()
+            .map(|session_manager| session_manager.sessions().n_items() > 0)
+            .unwrap_or_default()
+            || visible_page.as_str() != "phone-number-page";
+
         let is_next_valid = visible_page.as_str() != "password-forgot-page"
             && visible_page.as_str() != "qr-code-page";
 
@@ -449,6 +468,17 @@ impl Login {
         let self_ = imp::Login::from_instance(self);
 
         match self_.content.visible_child_name().unwrap().as_str() {
+            "phone-number-page" => {
+                self.freeze_with_previous_spinner();
+
+                // Logout the client when login is aborted.
+                log_out(self_.client_id.get());
+                self_
+                    .session_manager
+                    .get()
+                    .unwrap()
+                    .switch_to_sessions(None);
+            }
             "qr-code-page" => self.leave_qr_code_page(),
             "password-forgot-page" => self.navigate_to_page::<gtk::Editable, _, _>(
                 "password-page",
@@ -497,15 +527,26 @@ impl Login {
 
     fn request_qr_code(&self) {
         self.freeze();
-        imp::Login::from_instance(self)
+
+        let self_ = imp::Login::from_instance(self);
+        self_
             .phone_number_use_qr_code_stack
             .set_visible_child_name("spinner");
 
-        let client_id = self.client_id();
+        let other_user_ids = self_
+            .session_manager
+            .get()
+            .unwrap()
+            .logged_in_users()
+            .into_iter()
+            .map(|user| user.id())
+            .collect();
+        let client_id = self_.client_id.get();
         do_async(
             glib::PRIORITY_DEFAULT_IDLE,
             async move {
                 functions::RequestQrCodeAuthentication::new()
+                    .other_user_ids(other_user_ids)
                     .send(client_id)
                     .await
             },
@@ -521,24 +562,17 @@ impl Login {
     }
 
     fn leave_qr_code_page(&self) {
-        self.freeze_with_previous_spinner();
+        // We actually need to logout to stop tdlib sending us new links.
+        // https://github.com/tdlib/td/issues/1645
+        let self_ = imp::Login::from_instance(self);
+        let use_test_dc = self_.database_info.borrow().as_ref().unwrap().use_test_dc;
 
-        let client_id = self.client_id();
-        do_async(
-            glib::PRIORITY_DEFAULT_IDLE,
-            async move {
-                // We actually need to logout to stop tdlib sending us new links.
-                // https://github.com/tdlib/td/issues/1645
-                functions::LogOut::new().send(client_id).await
-            },
-            clone!(@weak self as obj => move |result| async move {
-                if result.is_err() {
-                    obj.unfreeze();
-                    // TODO: We also need to handle potential errors here and inform the user that
-                    // the change to phone number identification failed (Toast?).
-                }
-            }),
-        );
+        log_out(self_.client_id.get());
+        self_
+            .session_manager
+            .get()
+            .unwrap()
+            .add_new_session(use_test_dc);
     }
 
     fn show_tos_dialog(&self, user_needs_to_accept: bool) {
@@ -614,58 +648,6 @@ impl Login {
         self_.content.set_sensitive(true);
     }
 
-    fn send_tdlib_parameters(&self) {
-        let self_ = imp::Login::from_instance(self);
-        let client_id = self_.client_id.get();
-        let use_test_dc = self_.use_test_dc_switch.state();
-
-        let database_directory = DATA_DIR
-            .get()
-            .unwrap()
-            .to_str()
-            .expect("Data directory path is not a valid unicode string")
-            .to_owned();
-
-        let system_language_code = {
-            let locale = Locale::current().to_string();
-            if !locale.is_empty() {
-                locale
-            } else {
-                "en_US".to_string()
-            }
-        };
-        let parameters = types::TdlibParameters {
-            use_test_dc,
-            database_directory,
-            use_message_database: true,
-            use_secret_chats: true,
-            api_id: config::TG_API_ID,
-            api_hash: config::TG_API_HASH.to_string(),
-            system_language_code,
-            device_model: "Desktop".to_string(),
-            application_version: config::VERSION.to_string(),
-            enable_storage_optimizer: true,
-            ..types::TdlibParameters::default()
-        };
-        do_async(
-            glib::PRIORITY_DEFAULT_IDLE,
-            async move {
-                functions::SetTdlibParameters::new()
-                    .parameters(parameters)
-                    .send(client_id)
-                    .await
-            },
-            clone!(@weak self as obj => move |result| async move {
-                if let Err(err) = result {
-                    show_error_label(
-                        &imp::Login::from_instance(&obj).welcome_page_error_label,
-                        &err.message
-                    );
-                }
-            }),
-        );
-    }
-
     fn send_encryption_key(&self) {
         let self_ = imp::Login::from_instance(self);
         let client_id = self_.client_id.get();
@@ -695,24 +677,51 @@ impl Login {
         reset_error_label(&self_.welcome_page_error_label);
 
         let client_id = self_.client_id.get();
-        let phone_number = self_.phone_number_entry.text().to_string();
-        do_async(
-            glib::PRIORITY_DEFAULT_IDLE,
-            async move {
-                functions::SetAuthenticationPhoneNumber::new()
-                    .phone_number(phone_number)
-                    .send(client_id)
-                    .await
-            },
-            clone!(@weak self as obj => move |result| async move {
-                let self_ = imp::Login::from_instance(&obj);
-                obj.handle_user_result(
-                    result,
-                    &self_.welcome_page_error_label,
-                    &*self_.phone_number_entry
+        let phone_number = self_.phone_number_entry.text();
+
+        // Check if we are already have an account logged in with that phone_number.
+        let phone_number_digits = phone_number
+            .chars()
+            .filter(|c| c.is_digit(10))
+            .collect::<String>();
+
+        let session_manager = self_.session_manager.get().unwrap();
+
+        match session_manager.session_index_for(
+            self_.database_info.borrow().as_ref().unwrap().use_test_dc,
+            &phone_number_digits,
+        ) {
+            Some(pos) => {
+                // We just figured out that we already have an open session for that account.
+                // Therefore we logout the client, with which we wanted to log in and delete its
+                // just created database directory.
+                log_out(self_.client_id.get());
+                self_
+                    .session_manager
+                    .get()
+                    .unwrap()
+                    .switch_to_sessions(Some(pos));
+            }
+            None => {
+                do_async(
+                    glib::PRIORITY_DEFAULT_IDLE,
+                    async move {
+                        functions::SetAuthenticationPhoneNumber::new()
+                            .phone_number(phone_number.into())
+                            .send(client_id)
+                            .await
+                    },
+                    clone!(@weak self as obj => move |result| async move {
+                        let self_ = imp::Login::from_instance(&obj);
+                        obj.handle_user_result(
+                            result,
+                            &self_.welcome_page_error_label,
+                            &*self_.phone_number_entry
+                        );
+                    }),
                 );
-            }),
-        );
+            }
+        }
     }
 
     fn send_code(&self) {
@@ -995,21 +1004,6 @@ impl Login {
         self.unfreeze();
         // Grab focus for entry again after error.
         widget_to_focus.grab_focus();
-    }
-
-    pub fn client_id(&self) -> i32 {
-        let self_ = imp::Login::from_instance(self);
-        self_.client_id.get()
-    }
-
-    pub fn connect_new_session<F: Fn(&Self) + 'static>(&self, f: F) -> glib::SignalHandlerId {
-        self.connect_local("new-session", true, move |values| {
-            let obj = values[0].get::<Self>().unwrap();
-            f(&obj);
-
-            None
-        })
-        .unwrap()
     }
 }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,6 +26,7 @@ rust_sources = files(
   'login.rs',
   'main.rs',
   'preferences_window.rs',
+  'session_manager.rs',
   'utils.rs',
   'window.rs',
   'session/avatar.rs',
@@ -62,6 +63,11 @@ rust_sources = files(
   'session/sidebar/avatar.rs',
   'session/sidebar/mod.rs',
   'session/sidebar/row.rs',
+  'session/sidebar/session_switcher/add_account.rs',
+  'session/sidebar/session_switcher/avatar_with_selection.rs',
+  'session/sidebar/session_switcher/item.rs',
+  'session/sidebar/session_switcher/mod.rs',
+  'session/sidebar/session_switcher/session_entry_row.rs',
 )
 
 sources = [rust_sources, cargo_sources]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -290,6 +290,12 @@ impl Session {
             | Update::DeleteMessages(_) => {
                 self.chat_list().handle_update(update);
             }
+            Update::UnreadMessageCount(ref update_) => {
+                // TODO: Also handle archived chats
+                if let tdgrand::enums::ChatList::Main = update_.chat_list {
+                    self.chat_list().handle_update(update)
+                }
+            }
             Update::ScopeNotificationSettings(update) => {
                 let settings = BoxedScopeNotificationSettings(Some(update.notification_settings));
                 match update.scope {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -484,9 +484,12 @@ impl Session {
             clone!(@weak self as obj => move |result| async move {
                 let TelegramUser::User(me) = result.unwrap();
 
+                let me = User::from_td_object(me, &obj);
+                obj.user_list().insert_user(me.clone());
+
                 imp::Session::from_instance(&obj)
                     .me
-                    .replace(obj.user_list().get_or_create_user(me.id).into());
+                    .replace(Some(me));
 
                 obj.notify("me");
             }),

--- a/src/session/sidebar/mod.rs
+++ b/src/session/sidebar/mod.rs
@@ -1,7 +1,9 @@
 mod avatar;
 mod row;
+mod session_switcher;
 
 use self::row::Row;
+use self::session_switcher::SessionSwitcher;
 
 use glib::clone;
 use gtk::{gio, glib, prelude::*, subclass::prelude::*, CompositeTemplate};
@@ -18,6 +20,8 @@ mod imp {
     use once_cell::sync::Lazy;
     use std::cell::{Cell, RefCell};
 
+    use crate::session::components::Avatar as ComponentsAvatar;
+
     #[derive(Debug, Default, CompositeTemplate)]
     #[template(resource = "/com/github/melix99/telegrand/ui/sidebar.ui")]
     pub struct Sidebar {
@@ -31,6 +35,8 @@ mod imp {
         pub already_searched_users: RefCell<Vec<i64>>,
         #[template_child]
         pub header_bar: TemplateChild<adw::HeaderBar>,
+        #[template_child]
+        pub session_switcher: TemplateChild<SessionSwitcher>,
         #[template_child]
         pub search_bar: TemplateChild<gtk::SearchBar>,
         #[template_child]
@@ -48,6 +54,7 @@ mod imp {
         type ParentType = gtk::Widget;
 
         fn class_init(klass: &mut Self::Class) {
+            ComponentsAvatar::static_type();
             Row::static_type();
             Self::bind_template(klass);
         }
@@ -375,5 +382,11 @@ impl Sidebar {
     pub fn session(&self) -> Option<Session> {
         let self_ = imp::Sidebar::from_instance(self);
         self_.session.borrow().to_owned()
+    }
+
+    pub fn set_sessions(&self, sessions: &gtk::SelectionModel, this_session: &Session) {
+        imp::Sidebar::from_instance(self)
+            .session_switcher
+            .set_sessions(sessions, this_session);
     }
 }

--- a/src/session/sidebar/session_switcher/add_account.rs
+++ b/src/session/sidebar/session_switcher/add_account.rs
@@ -1,0 +1,78 @@
+use gtk::glib;
+use gtk::{prelude::*, subclass::prelude::*};
+
+mod imp {
+    use super::*;
+
+    use glib::subclass::InitializingObject;
+    use gtk::glib::clone;
+    use gtk::{self, CompositeTemplate};
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(resource = "/com/github/melix99/telegrand/ui/add-account-row.ui")]
+    pub struct AddAccountRow {
+        #[template_child]
+        pub image: TemplateChild<gtk::Image>,
+        #[template_child]
+        pub label: TemplateChild<gtk::Label>,
+        #[template_child]
+        pub menu: TemplateChild<gtk::PopoverMenu>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for AddAccountRow {
+        const NAME: &'static str = "AddAccountRow";
+        type Type = super::AddAccountRow;
+        type ParentType = gtk::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+        }
+
+        fn instance_init(obj: &InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for AddAccountRow {
+        fn constructed(&self, obj: &Self::Type) {
+            self.parent_constructed(obj);
+
+            let long_press_events = gtk::GestureLongPress::builder().delay_factor(2.0).build();
+            long_press_events.connect_pressed(clone!(@weak obj => move |_, _, _| {
+                Self::from_instance(&obj).menu.show();
+            }));
+            // A cancelled long press event is used to emulate a normal "click" event.
+            long_press_events.connect_cancelled(clone!(@weak obj => move |_| {
+                obj.activate_action("app.new-login-production-server", None);
+            }));
+
+            obj.add_controller(&long_press_events);
+        }
+
+        fn dispose(&self, _obj: &Self::Type) {
+            self.image.unparent();
+            self.label.unparent();
+            self.menu.unparent();
+        }
+    }
+    impl WidgetImpl for AddAccountRow {}
+}
+
+glib::wrapper! {
+    pub struct AddAccountRow(ObjectSubclass<imp::AddAccountRow>)
+        @extends gtk::Widget,
+        @implements gtk::Accessible;
+}
+
+impl AddAccountRow {
+    pub fn new() -> Self {
+        glib::Object::new(&[]).expect("Failed to create AddAccountRow")
+    }
+}
+
+impl Default for AddAccountRow {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/session/sidebar/session_switcher/avatar_with_selection.rs
+++ b/src/session/sidebar/session_switcher/avatar_with_selection.rs
@@ -1,0 +1,132 @@
+use adw::subclass::prelude::*;
+use gtk::{glib, prelude::*, subclass::prelude::*};
+
+use crate::session::components::Avatar;
+use crate::session::Avatar as AvatarItem;
+
+mod imp {
+    use super::*;
+    use glib::subclass::InitializingObject;
+    use gtk::CompositeTemplate;
+    use once_cell::sync::Lazy;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(resource = "/com/github/melix99/telegrand/ui/avatar-with-selection.ui")]
+    pub struct AvatarWithSelection {
+        #[template_child]
+        pub child_avatar: TemplateChild<Avatar>,
+        #[template_child]
+        pub checkmark: TemplateChild<gtk::Image>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for AvatarWithSelection {
+        const NAME: &'static str = "AvatarWithSelection";
+        type Type = super::AvatarWithSelection;
+        type ParentType = adw::Bin;
+
+        fn class_init(klass: &mut Self::Class) {
+            Avatar::static_type();
+            Self::bind_template(klass);
+        }
+
+        fn instance_init(obj: &InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for AvatarWithSelection {
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![
+                    glib::ParamSpec::new_object(
+                        "item",
+                        "Item",
+                        "The Avatar item displayed by this widget",
+                        AvatarItem::static_type(),
+                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                    ),
+                    glib::ParamSpec::new_int(
+                        "size",
+                        "Size",
+                        "The size of the Avatar",
+                        -1,
+                        i32::MAX,
+                        -1,
+                        glib::ParamFlags::READWRITE,
+                    ),
+                    glib::ParamSpec::new_boolean(
+                        "selected",
+                        "Selected",
+                        "Style helper for the inner Avatar",
+                        false,
+                        glib::ParamFlags::WRITABLE,
+                    ),
+                ]
+            });
+
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(
+            &self,
+            obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "item" => self.child_avatar.set_item(value.get().unwrap()),
+                "size" => self.child_avatar.set_size(value.get().unwrap()),
+                "selected" => obj.set_selected(value.get().unwrap()),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn property(&self, _obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "item" => self.child_avatar.item().to_value(),
+                "size" => self.child_avatar.size().to_value(),
+                _ => unimplemented!(),
+            }
+        }
+    }
+
+    impl WidgetImpl for AvatarWithSelection {}
+    impl BinImpl for AvatarWithSelection {}
+}
+
+glib::wrapper! {
+    /// A widget displaying an `Avatar` for an `Account`.
+    pub struct AvatarWithSelection(ObjectSubclass<imp::AvatarWithSelection>)
+        @extends gtk::Widget, adw::Bin,
+        @implements gtk::Accessible;
+}
+
+impl Default for AvatarWithSelection {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AvatarWithSelection {
+    pub fn new() -> Self {
+        glib::Object::new(&[]).expect("Failed to create AvatarWithSelection")
+    }
+
+    pub fn set_selected(&self, selected: bool) {
+        let self_ = imp::AvatarWithSelection::from_instance(self);
+
+        self_.checkmark.set_visible(selected);
+
+        if selected {
+            self_.child_avatar.add_css_class("selected-avatar");
+        } else {
+            self_.child_avatar.remove_css_class("selected-avatar");
+        }
+    }
+
+    pub fn avatar(&self) -> &Avatar {
+        &imp::AvatarWithSelection::from_instance(self).child_avatar
+    }
+}

--- a/src/session/sidebar/session_switcher/item.rs
+++ b/src/session/sidebar/session_switcher/item.rs
@@ -1,0 +1,163 @@
+use super::add_account::AddAccountRow;
+use super::session_entry_row::SessionEntryRow;
+
+use gtk::{gio::ListStore, glib, prelude::*, subclass::prelude::*};
+use std::convert::TryFrom;
+
+use crate::session::Session;
+
+mod imp {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use std::cell::Cell;
+
+    #[derive(Debug, Default)]
+    pub struct ExtraItemObj(pub Cell<super::ExtraItem>);
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for ExtraItemObj {
+        const NAME: &'static str = "ExtraItemObj";
+        type Type = super::ExtraItemObj;
+        type ParentType = glib::Object;
+    }
+
+    impl ObjectImpl for ExtraItemObj {
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![glib::ParamSpec::new_enum(
+                    "inner",
+                    "Inner",
+                    "Inner value of ExtraItem",
+                    super::ExtraItem::static_type(),
+                    0,
+                    glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                )]
+            });
+
+            PROPERTIES.as_ref()
+        }
+
+        fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "inner" => obj.get().to_value(),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn set_property(
+            &self,
+            _obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "inner" => self.0.set(value.get().unwrap()),
+                _ => unimplemented!(),
+            }
+        }
+    }
+}
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone, Copy, glib::GEnum)]
+#[repr(u32)]
+#[genum(type_name = "ExtraItem")]
+pub enum ExtraItem {
+    Separator = 0,
+    AddAccount = 1,
+}
+
+impl ExtraItem {
+    const VALUES: [Self; 2] = [Self::Separator, Self::AddAccount];
+}
+
+impl Default for ExtraItem {
+    fn default() -> Self {
+        Self::Separator
+    }
+}
+
+glib::wrapper! {
+    pub struct ExtraItemObj(ObjectSubclass<imp::ExtraItemObj>);
+}
+
+impl From<&ExtraItem> for ExtraItemObj {
+    fn from(item: &ExtraItem) -> Self {
+        glib::Object::new(&[("inner", item)]).expect("Failed to create ExtraItem")
+    }
+}
+
+impl ExtraItemObj {
+    pub fn list_store() -> ListStore {
+        ExtraItem::VALUES.iter().map(ExtraItemObj::from).fold(
+            ListStore::new(ExtraItemObj::static_type()),
+            |list_items, item| {
+                list_items.append(&item);
+                list_items
+            },
+        )
+    }
+
+    pub fn get(&self) -> ExtraItem {
+        imp::ExtraItemObj::from_instance(self).0.get()
+    }
+
+    pub fn is_separator(&self) -> bool {
+        self.get() == ExtraItem::Separator
+    }
+
+    pub fn is_add_account(&self) -> bool {
+        self.get() == ExtraItem::AddAccount
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Item {
+    Session(Session, bool),
+    Separator,
+    AddAccount,
+}
+
+impl From<ExtraItem> for Item {
+    fn from(extra_item: ExtraItem) -> Self {
+        match extra_item {
+            ExtraItem::Separator => Self::Separator,
+            ExtraItem::AddAccount => Self::AddAccount,
+        }
+    }
+}
+
+impl TryFrom<glib::Object> for Item {
+    type Error = glib::Object;
+
+    fn try_from(object: glib::Object) -> Result<Self, Self::Error> {
+        object
+            .downcast::<gtk::StackPage>()
+            .map(|sp| Self::Session(sp.child().downcast::<Session>().unwrap(), false))
+            .or_else(|object| object.downcast::<ExtraItemObj>().map(|it| it.get().into()))
+    }
+}
+
+impl Item {
+    pub fn set_hint(self, this_session: Session) -> Self {
+        match self {
+            Self::Session(session, _) => {
+                let hinted = this_session == session;
+                Self::Session(session, hinted)
+            }
+            other => other,
+        }
+    }
+
+    pub fn build_widget(&self) -> gtk::Widget {
+        match self {
+            Self::Session(ref session, hinted) => {
+                let session_entry = SessionEntryRow::new(session);
+                session_entry.set_hint(*hinted);
+                session_entry.upcast()
+            }
+            Self::Separator => gtk::Separator::new(gtk::Orientation::Vertical).upcast(),
+            Self::AddAccount => AddAccountRow::new().upcast(),
+        }
+    }
+}

--- a/src/session/sidebar/session_switcher/mod.rs
+++ b/src/session/sidebar/session_switcher/mod.rs
@@ -1,0 +1,163 @@
+mod add_account;
+mod avatar_with_selection;
+mod item;
+mod session_entry_row;
+
+use super::session_switcher::item::{ExtraItemObj, Item as SessionSwitcherItem};
+
+use gtk::{
+    gio::{self, ListModel, ListStore},
+    glib::{self, clone},
+    prelude::*,
+    subclass::prelude::*,
+    CompositeTemplate, SelectionModel,
+};
+use std::convert::TryFrom;
+
+use crate::session::Session;
+
+mod imp {
+    use super::*;
+
+    use glib::subclass::InitializingObject;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(resource = "/com/github/melix99/telegrand/ui/sidebar-session-switcher.ui")]
+    pub struct SessionSwitcher {
+        #[template_child]
+        pub entries: TemplateChild<gtk::ListView>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for SessionSwitcher {
+        const NAME: &'static str = "SessionSwitcher";
+        type Type = super::SessionSwitcher;
+        type ParentType = gtk::Popover;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+            klass.set_accessible_role(gtk::AccessibleRole::Dialog);
+        }
+
+        fn instance_init(obj: &InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for SessionSwitcher {
+        fn constructed(&self, obj: &Self::Type) {
+            self.parent_constructed(obj);
+
+            self.entries.connect_activate(|list_view, index| {
+                if let Some(Ok(item)) = list_view
+                    .model()
+                    .and_then(|model| model.item(index))
+                    .map(SessionSwitcherItem::try_from)
+                {
+                    match item {
+                        SessionSwitcherItem::Session(session, _) => {
+                            session
+                                .parent()
+                                .unwrap()
+                                .downcast::<gtk::Stack>()
+                                .unwrap()
+                                .set_visible_child(&session);
+                        }
+                        SessionSwitcherItem::AddAccount => {
+                            /* ignored - as this is handled separately in the AddAccountItem */
+                        }
+                        other => unreachable!("Unexpected item: {:?}", other),
+                    }
+                }
+            });
+        }
+
+        fn dispose(&self, _obj: &Self::Type) {
+            self.entries.unparent();
+        }
+    }
+
+    impl WidgetImpl for SessionSwitcher {}
+    impl PopoverImpl for SessionSwitcher {}
+}
+
+glib::wrapper! {
+    pub struct SessionSwitcher(ObjectSubclass<imp::SessionSwitcher>)
+        @extends gtk::Widget, gtk::Popover,
+        @implements gtk::Accessible, gio::ListModel;
+}
+
+impl SessionSwitcher {
+    pub fn set_sessions(&self, sessions: &SelectionModel, this_session: &Session) {
+        let entries = imp::SessionSwitcher::from_instance(self).entries.get();
+
+        // There is no permanent stuff to take care of,
+        // so only bind and unbind are connected.
+        let factory = &gtk::SignalListItemFactory::new();
+        factory.connect_bind(clone!(@weak this_session => move |_, list_item| {
+            list_item.set_selectable(false);
+            let child = list_item
+                .item()
+                .map(SessionSwitcherItem::try_from)
+                .and_then(Result::ok)
+                .map(|item| {
+                    // Given that all the account switchers are built per-session widget
+                    // there is no need for callbacks or data bindings; just set the hint
+                    // when building the entries and they will show correctly marked in
+                    // each session widget.
+                    let item = item.set_hint(this_session);
+
+                    if item == SessionSwitcherItem::Separator {
+                        list_item.set_activatable(false);
+                    }
+
+                    item
+                })
+                .as_ref()
+                .map(SessionSwitcherItem::build_widget);
+
+            list_item.set_child(child.as_ref());
+        }));
+
+        factory.connect_unbind(|_, list_item| {
+            list_item.set_child(gtk::NONE_WIDGET);
+        });
+
+        entries.set_factory(Some(factory));
+
+        let session_sorter = gtk::CustomSorter::new(move |obj1, obj2| {
+            let session1 = obj1
+                .downcast_ref::<gtk::StackPage>()
+                .unwrap()
+                .child()
+                .downcast::<Session>()
+                .unwrap();
+            let session2 = obj2
+                .downcast_ref::<gtk::StackPage>()
+                .unwrap()
+                .child()
+                .downcast::<Session>()
+                .unwrap();
+
+            session1
+                .database_info()
+                .0
+                .directory_base_name
+                .cmp(&session2.database_info().0.directory_base_name)
+                .into()
+        });
+
+        let sessions_sort_model = gtk::SortListModel::new(Some(sessions), Some(&session_sorter));
+
+        let end_items = ExtraItemObj::list_store();
+
+        let items_split = ListStore::new(ListModel::static_type());
+        items_split.append(&sessions_sort_model);
+        items_split.append(&end_items);
+
+        let items = gtk::FlattenListModel::new(Some(&items_split));
+        let selectable_items = &gtk::NoSelection::new(Some(&items));
+
+        entries.set_model(Some(selectable_items));
+    }
+}

--- a/src/session/sidebar/session_switcher/session_entry_row.rs
+++ b/src/session/sidebar/session_switcher/session_entry_row.rs
@@ -1,0 +1,204 @@
+use super::avatar_with_selection::AvatarWithSelection;
+
+use gtk::{glib, prelude::*, subclass::prelude::*};
+
+use crate::session::{Session, User};
+
+mod imp {
+    use super::*;
+    use glib::subclass::InitializingObject;
+    use gtk::CompositeTemplate;
+    use once_cell::sync::Lazy;
+    use std::cell::RefCell;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(resource = "/com/github/melix99/telegrand/ui/session-entry-row.ui")]
+    pub struct SessionEntryRow {
+        pub session: RefCell<Option<Session>>,
+        pub bindings: RefCell<Vec<gtk::ExpressionWatch>>,
+        #[template_child]
+        pub account_avatar: TemplateChild<AvatarWithSelection>,
+        #[template_child]
+        pub center_box: TemplateChild<gtk::Box>,
+        #[template_child]
+        pub display_name_label: TemplateChild<gtk::Label>,
+        #[template_child]
+        pub username_label: TemplateChild<gtk::Label>,
+        #[template_child]
+        pub unread_count_label: TemplateChild<gtk::Label>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for SessionEntryRow {
+        const NAME: &'static str = "SessionEntryRow";
+        type Type = super::SessionEntryRow;
+        type ParentType = gtk::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            AvatarWithSelection::static_type();
+            Self::bind_template(klass);
+        }
+
+        fn instance_init(obj: &InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for SessionEntryRow {
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![
+                    glib::ParamSpec::new_object(
+                        "session",
+                        "Session",
+                        "The session that this entry represents",
+                        Session::static_type(),
+                        glib::ParamFlags::READWRITE
+                            | glib::ParamFlags::CONSTRUCT_ONLY
+                            | glib::ParamFlags::EXPLICIT_NOTIFY,
+                    ),
+                    glib::ParamSpec::new_boolean(
+                        "hint",
+                        "Selection hint",
+                        "The hint of the session that owns the account switcher which this entry belongs to",
+                        false,
+                        glib::ParamFlags::WRITABLE | glib::ParamFlags::CONSTRUCT_ONLY,
+                    ),
+                ]
+            });
+
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(
+            &self,
+            obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "session" => {
+                    let session_page = value.get().unwrap();
+                    obj.set_session(session_page);
+                }
+                "hint" => obj.set_hint(value.get().unwrap()),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "session" => obj.session().to_value(),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn dispose(&self, _obj: &Self::Type) {
+            self.account_avatar.unparent();
+            self.center_box.unparent();
+            self.unread_count_label.unparent();
+        }
+    }
+
+    impl WidgetImpl for SessionEntryRow {}
+}
+
+glib::wrapper! {
+    pub struct SessionEntryRow(ObjectSubclass<imp::SessionEntryRow>)
+        @extends gtk::Widget, @implements gtk::Accessible;
+}
+
+impl SessionEntryRow {
+    pub fn new(session: &Session) -> Self {
+        glib::Object::new(&[("session", session)]).expect("Failed to create SessionEntryRow")
+    }
+
+    fn session(&self) -> Option<Session> {
+        let self_ = imp::SessionEntryRow::from_instance(self);
+        self_.session.borrow().clone()
+    }
+
+    pub fn set_session(&self, session: Option<Session>) {
+        if self.session() == session {
+            return;
+        }
+
+        let self_ = imp::SessionEntryRow::from_instance(self);
+        let mut bindings = self_.bindings.borrow_mut();
+
+        while let Some(binding) = bindings.pop() {
+            binding.unwatch();
+        }
+
+        if let Some(ref session) = session {
+            let me_expression =
+                gtk::PropertyExpression::new(Session::static_type(), gtk::NONE_EXPRESSION, "me");
+
+            let display_name_expression = gtk::ClosureExpression::new(
+                |args| {
+                    let maybe_me = args[1].get::<User>();
+                    maybe_me
+                        .ok()
+                        .map(|user| {
+                            let last_name = user.last_name();
+                            if last_name.is_empty() {
+                                user.first_name()
+                            } else {
+                                format!("{} {}", user.first_name(), last_name)
+                            }
+                        })
+                        .unwrap_or_default()
+                },
+                &[me_expression.clone().upcast()],
+            );
+            let display_name_binding =
+                display_name_expression.bind(&*self_.display_name_label, "label", Some(session));
+            bindings.push(display_name_binding);
+
+            let username_label_expression = gtk::ClosureExpression::new(
+                |args| {
+                    let maybe_me = args[1].get::<User>();
+                    maybe_me
+                        .ok()
+                        .as_ref()
+                        .map(User::username)
+                        .filter(|username| !username.is_empty())
+                        .map(|username| format!("@{}", username))
+                        .unwrap_or_default()
+                },
+                &[me_expression.upcast()],
+            );
+            let username_label_binding =
+                username_label_expression.bind(&*self_.username_label, "label", Some(session));
+            bindings.push(username_label_binding);
+
+            let username_visibility_expression = gtk::ClosureExpression::new(
+                |args| {
+                    let label = args[1].get::<&str>().unwrap();
+                    !label.is_empty()
+                },
+                &[username_label_expression.upcast()],
+            );
+            let username_visibility_binding = username_visibility_expression.bind(
+                &*self_.username_label,
+                "visible",
+                Some(session),
+            );
+            bindings.push(username_visibility_binding);
+        }
+
+        self_.session.replace(session);
+
+        self.notify("session");
+    }
+
+    pub fn set_hint(&self, hinted: bool) {
+        let self_ = imp::SessionEntryRow::from_instance(self);
+
+        self_.account_avatar.set_selected(hinted);
+        self_
+            .display_name_label
+            .set_css_classes(if hinted { &["bold"] } else { &[] });
+    }
+}

--- a/src/session/user.rs
+++ b/src/session/user.rs
@@ -1,5 +1,6 @@
 use gtk::{glib, prelude::*, subclass::prelude::*};
 use tdgrand::enums::{Update, UserStatus, UserType};
+use tdgrand::types::User as TelegramUser;
 
 use crate::session::Avatar;
 use crate::Session;
@@ -160,6 +161,23 @@ impl User {
     pub fn new(id: i64, session: &Session) -> Self {
         let avatar = Avatar::new(session);
         glib::Object::new(&[("id", &id), ("avatar", &avatar)]).expect("Failed to create User")
+    }
+
+    pub fn from_td_object(user: TelegramUser, session: &Session) -> Self {
+        let avatar = Avatar::new(session);
+        avatar.update_from_user_photo(user.profile_photo);
+
+        glib::Object::new(&[
+            ("id", &user.id),
+            ("type", &BoxedUserType(user.r#type)),
+            ("first-name", &user.first_name),
+            ("last-name", &user.last_name),
+            ("username", &user.username),
+            ("phone-number", &user.phone_number),
+            ("status", &BoxedUserStatus(user.status)),
+            ("avatar", &avatar),
+        ])
+        .expect("Failed to create User")
     }
 
     pub fn handle_update(&self, update: Update) {

--- a/src/session_manager.rs
+++ b/src/session_manager.rs
@@ -1,0 +1,888 @@
+//! Widget for managing sessions.
+//!
+//! This widget can be considered as the main view. It is directly subordinate to the application
+//! window and takes care of managing sessions. In the following sections it is described what this
+//! includes.
+//!
+//! # Adding new sessions
+//! The `SessionManager` directs it to [`Login`](struct@crate::login::Login) as soon as the user
+//! wants to add a new session within the function `add_new_session`. Login returns control to the
+//! session manager if either the new session is ready, logging into the new session is aborted by
+//! the user, or it is noticed that the phone number is already logged in. In order ro prevent
+//! logging in twice in the same account by an qr code, the function
+//! [`SessionManager::logged_in_users()`] is provided that is used by `login.rs` to extract user
+//! ids and pass them to tdlib.
+//!
+//! # Adding existing sessions
+//! The `SessionManager` analyzes the individual database directories in the Telegrand data
+//! directory to see which sessions can be logged in directly using
+//! [`SessionManager::add_existing_session()`]. To do this, it checks the presence of a `td.binlog`
+//! or a `td_test.binlog` file.
+//!
+//! # Destroying sessions
+//! This is realized by first logging out the client and then deleting the database directory once
+//! the `AuthorizationState::Closed` event has been received for that session.
+//! Destroying sessions happens in different places: When the login is canceled, When the QR code
+//! is canceled, when a logged in session is logged out, and when the session is removed from
+//! another device.
+//!
+//! # Remembering recently used sessions
+//! In order to remember the order in which the user selected the sessions, the `SessionManager`
+//! uses a gsettings key value pair.
+
+use futures::{TryFutureExt, TryStreamExt};
+use glib::clone;
+use gtk::{gio, glib, prelude::*, subclass::prelude::*, CompositeTemplate};
+use std::borrow::Borrow;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tdgrand::enums::{self, AuthorizationState, Update};
+use tdgrand::functions;
+use tdgrand::types::{self, UpdateAuthorizationState};
+use tokio::fs;
+use tokio_stream::wrappers::ReadDirStream;
+
+use crate::session::{Session, User};
+use crate::utils::{data_dir, do_async, log_out, send_tdlib_parameters};
+use crate::APPLICATION_OPTS;
+use crate::RUNTIME;
+
+/// Struct for storing information about a td client.
+#[derive(Clone, Debug)]
+pub enum ClientInfo {
+    /// The client is currently in the authorization state. Every client, even those that were
+    /// logged in during a previous run of the application will need to go through this state
+    /// again.
+    Auth {
+        /// Whether there is a chance that the client is already authorized.
+        /// This will be set to `true` for all the sessions found in the data directory at
+        /// application start because we assume that they will get the `AuthorizationState::Ready`
+        /// without user interaction as they were probably logged in before.
+        /// So, we use this information to bypass the login process (phone number -> auth code ->
+        /// ... -> ready) and to just wait for the `AuthorizationState::Ready` update.
+        maybe_authorized: bool,
+        // The information about the session's database.
+        database_info: DatabaseInfo,
+    },
+    /// The client is logged and has a `Session`.
+    LoggedIn(
+        /// The `Session` of this client.
+        Session,
+    ),
+    /// The client is currently in the process of logging out
+    LoggingOut(
+        /// The name of the database directory.
+        String,
+    ),
+}
+impl ClientInfo {
+    fn database_dir_base_name(&self) -> &str {
+        match self {
+            Self::Auth { database_info, .. } => &database_info.directory_base_name,
+            Self::LoggedIn(session) => &session.database_info().0.directory_base_name,
+            Self::LoggingOut(database_dir_base_name) => database_dir_base_name,
+        }
+    }
+}
+
+mod imp {
+    use super::*;
+
+    use std::cell::{Cell, RefCell};
+    use std::collections::HashMap;
+
+    use crate::Login;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(resource = "/com/github/melix99/telegrand/ui/session-manager.ui")]
+    pub struct SessionManager {
+        /// The order of the recently used sessions. The string stored in the `Vec` represents the
+        /// session's database directory name.
+        pub recently_used_sessions: RefCell<Vec<String>>,
+        /// The number sessions to load/handle at application start. This number will indirectly be
+        /// determined in [`analyze_data_dir()`]
+        pub initial_sessions_to_handle: Cell<u32>,
+        pub clients: RefCell<HashMap<i32, ClientInfo>>,
+        #[template_child]
+        pub main_stack: TemplateChild<gtk::Stack>,
+        #[template_child]
+        pub login: TemplateChild<Login>,
+        #[template_child]
+        pub sessions: TemplateChild<gtk::Stack>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for SessionManager {
+        const NAME: &'static str = "SessionManager";
+        type Type = super::SessionManager;
+        type ParentType = gtk::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for SessionManager {
+        fn constructed(&self, obj: &Self::Type) {
+            self.parent_constructed(obj);
+
+            self.login.set_session_manager(obj.clone());
+
+            // Take action when the active client changed.
+            self.main_stack
+                .connect_visible_child_notify(clone!(@weak obj => move |main_stack| {
+                    if main_stack.visible_child().unwrap().downcast_ref::<gtk::Stack>().is_some() {
+                        obj.on_active_session_changed();
+                    }
+                }));
+
+            // Take action when the active client changed.
+            self.sessions.connect_visible_child_notify(
+                clone!(@weak obj => move |_| obj.on_active_session_changed()),
+            );
+
+            // ####################################################################################
+            // # Load the sessions from the data directory.                                       #
+            // ####################################################################################
+            do_async(
+                glib::PRIORITY_DEFAULT_IDLE,
+                analyze_data_dir(),
+                clone!(@weak obj => move |datadir_state| async move {
+                    match datadir_state {
+                        // TODO: Should we show a dialog in this case instead of just bailing out
+                        // silently?
+                        Err(e) => panic!("Could not initialize data directory: {}", e),
+                        Ok(datadir_state) => match datadir_state {
+                            DatadirState::Empty => {
+                                obj.add_new_session(
+                                    APPLICATION_OPTS.get().unwrap().test_dc,
+                                );
+                            }
+                            DatadirState::HasSessions {
+                                recently_used_sessions,
+                                database_infos
+                            } => {
+                                let self_ = Self::from_instance(&obj);
+
+                                self_.recently_used_sessions.replace(recently_used_sessions);
+
+                                self_.initial_sessions_to_handle
+                                    .set(database_infos.len() as u32);
+
+                                database_infos.into_iter().for_each(|database_info| {
+                                    obj.add_existing_session(database_info);
+                                });
+                            }
+                        }
+                    }
+                }),
+            );
+        }
+
+        fn dispose(&self, _obj: &Self::Type) {
+            self.main_stack.unparent();
+        }
+    }
+
+    impl WidgetImpl for SessionManager {}
+}
+
+glib::wrapper! {
+    pub struct SessionManager(ObjectSubclass<imp::SessionManager>)
+        @extends gtk::Widget;
+}
+
+impl SessionManager {
+    /// Returns the active client id if it is logged in or `None` if it isn't logged in
+    /// (e.g. during authorization).
+    fn active_logged_in_client_id(&self) -> Option<i32> {
+        let self_ = imp::SessionManager::from_instance(self);
+
+        self_
+            .main_stack
+            .visible_child()
+            .filter(|widget| widget == self_.sessions.get().upcast_ref::<gtk::Widget>())
+            .map(|_| {
+                self_
+                    .sessions
+                    .visible_child()
+                    .unwrap()
+                    .downcast_ref::<Session>()
+                    .unwrap()
+                    .client_id()
+            })
+    }
+
+    /// Function that returns all currently logged in users.
+    pub fn logged_in_users(&self) -> Vec<User> {
+        let sessions = self.sessions();
+
+        (0..sessions.n_items())
+            .filter_map(|pos| {
+                sessions
+                    .item(pos)
+                    .unwrap()
+                    .downcast::<gtk::StackPage>()
+                    .unwrap()
+                    .child()
+                    .downcast::<Session>()
+                    .unwrap()
+                    .me()
+            })
+            .collect()
+    }
+
+    /// Returns the `ClientInfo` for the given client id.
+    pub fn client_info(&self, client_id: i32) -> Option<ClientInfo> {
+        imp::SessionManager::from_instance(self)
+            .clients
+            .borrow()
+            .get(&client_id)
+            .cloned()
+    }
+
+    /// Returns the index of the logged in session that matches the passed parameters or `None` if
+    /// no matching session was found.
+    ///
+    /// This function is mainly used to check if a logged in session already exists for an account
+    /// to prevent two sessions for the same account.
+    pub fn session_index_for(&self, on_test_dc: bool, phone_number_digits: &str) -> Option<u32> {
+        let sessions = self.sessions();
+
+        (0..sessions.n_items()).find_map(|pos| {
+            let session = sessions
+                .item(pos)
+                .unwrap()
+                .downcast::<gtk::StackPage>()
+                .unwrap()
+                .child()
+                .downcast::<Session>()
+                .unwrap();
+
+            session
+                .me()
+                .filter(|me| {
+                    on_test_dc == session.database_info().0.use_test_dc
+                        && me.phone_number().replace(" ", "") == phone_number_digits
+                })
+                .map(|_| pos)
+        })
+    }
+
+    /// Function for switching the main stack to the active sessions. It also will switch to the
+    /// given position if it has some value.
+    ///
+    /// This function has basically two callers both in `Login`:
+    /// First, it will be called when the `back` button is pressed on the phone number page to go
+    /// back to the last session. Secondly, it will be called with a position if the phone number
+    /// entered already has a session.
+    pub fn switch_to_sessions(&self, pos: Option<u32>) {
+        let self_ = imp::SessionManager::from_instance(self);
+        self_.main_stack.set_visible_child(&*self_.sessions);
+        if let Some(pos) = pos {
+            self_.sessions.pages().select_item(pos, true);
+        }
+    }
+
+    /// Returns sessions as selection model.
+    ///
+    /// Is mainly used by `Login` to check whether the back button should be visible on the phone
+    /// number page and to check the session' phone numbers in order to not have 2 sessions of the
+    /// same account.
+    pub fn sessions(&self) -> gtk::SelectionModel {
+        let self_ = imp::SessionManager::from_instance(self);
+        self_.sessions.pages()
+    }
+
+    /// This functions will be invoked when the active client has changed.
+    /// It does:
+    ///   1. Update the online status of the clients
+    ///   2. Update the order of the recently used sessions
+    ///
+    /// This is invoked when the visible child of the main stack or the sessions stack changes.
+    fn on_active_session_changed(&self) {
+        let self_ = imp::SessionManager::from_instance(self);
+
+        if let Some(session) = self_
+            .sessions
+            .visible_child()
+            .and_then(|widget| widget.downcast::<Session>().ok())
+        {
+            self.transfer_online_status(session.client_id());
+
+            if self_.main_stack.visible_child() == Some(self_.sessions.clone().upcast()) {
+                let database_dir_base_name = session.database_info().0.directory_base_name.clone();
+
+                {
+                    let mut recently_used_sessions = self_.recently_used_sessions.borrow_mut();
+                    remove_from_vec(&mut *recently_used_sessions, &database_dir_base_name);
+                    recently_used_sessions.push(database_dir_base_name);
+                }
+
+                self.save_recently_used_sessions();
+            }
+        }
+    }
+
+    /// Sets the online status for the active logged in client. This will be called from the
+    /// application `Window` when its active state has changed.
+    pub fn set_active_client_online(&self, value: bool) {
+        if let Some(client_id) = self.active_logged_in_client_id() {
+            RUNTIME.spawn(async move { set_online(client_id, value).await.unwrap() });
+        }
+    }
+
+    /// Transfers the online status to this given new active client id. All other clients' online
+    /// status are set to `false`.
+    fn transfer_online_status(&self, active_client_id: i32) {
+        imp::SessionManager::from_instance(self)
+            .clients
+            .borrow()
+            .values()
+            .filter_map(|client_info| match client_info {
+                ClientInfo::LoggedIn(session) => Some(session.client_id()),
+                _ => None,
+            })
+            .for_each(|client_id| {
+                RUNTIME.spawn(async move {
+                    set_online(
+                        client_id,
+                        // Session switching is only possible when the window is active.
+                        client_id == active_client_id,
+                    )
+                    .await
+                    .unwrap()
+                });
+            });
+    }
+
+    /// This function is used to add/load an existing session that already had the
+    /// `AuthorizationState::Ready` state from a previous application run.
+    pub fn add_existing_session(&self, database_info: DatabaseInfo) {
+        let client_id = tdgrand::create_client();
+
+        let self_ = imp::SessionManager::from_instance(self);
+
+        self_.clients.borrow_mut().insert(
+            client_id,
+            ClientInfo::Auth {
+                // Important: Here, we basically say that we just want to wait for
+                // `AuthorizationState::Ready` and skip the login process.
+                maybe_authorized: true,
+                database_info,
+            },
+        );
+
+        send_log_level(client_id);
+    }
+
+    /// This function is used to add a new session for a so far unknown account. This means it will
+    /// go through the login process.
+    pub fn add_new_session(&self, use_test_dc: bool) {
+        let client_id = tdgrand::create_client();
+        self.init_new_session(client_id, use_test_dc);
+        send_log_level(client_id);
+    }
+
+    /// This function initializes everything that's needed for adding a new session for the given
+    /// client id.
+    fn init_new_session(&self, client_id: i32, use_test_dc: bool) {
+        let self_ = imp::SessionManager::from_instance(self);
+
+        let database_info = DatabaseInfo {
+            directory_base_name: generate_database_dir_base_name(),
+            use_test_dc,
+        };
+
+        self_.clients.borrow_mut().insert(
+            client_id,
+            ClientInfo::Auth {
+                // Important: Here, we state that this client will have to go through the login
+                // process.
+                maybe_authorized: false,
+                database_info: database_info.clone(),
+            },
+        );
+
+        self_.login.login_client(client_id, database_info);
+
+        self_.main_stack.set_visible_child(&*self_.login);
+    }
+
+    /// This function is called when a session is in the process of logging out.
+    ///
+    /// Among other things, it switches to the last session or to the login page, if called from a
+    /// logged in session. Furthermore, the recently used sessions order file will be overwritten.
+    fn set_session_logging_out(&self, client_info: &ClientInfo) {
+        if let ClientInfo::LoggedIn(ref session) = client_info {
+            let self_ = imp::SessionManager::from_instance(self);
+
+            self_.sessions.remove(session);
+
+            let database_dir_base_name = &session.database_info().0.directory_base_name;
+
+            if !remove_from_vec(
+                &mut *self_.recently_used_sessions.borrow_mut(),
+                database_dir_base_name,
+            ) {
+                log::warn!(
+                    "Could not remove session directory base name from recently used sessions: {}",
+                    database_dir_base_name
+                );
+            }
+
+            if self_.sessions.pages().n_items() > 0 {
+                // Important: This must not put as an expression in the `select_item` method
+                // but rather stay here as a statement. Else, a borrow error will occur.
+                let active_session_index = self_
+                    .recently_used_sessions
+                    .borrow()
+                    .last()
+                    .and_then(|database_dir_base_name| {
+                        (0..self.sessions().n_items()).find_map(|pos| {
+                            let session = self
+                                .sessions()
+                                .item(pos)
+                                .unwrap()
+                                .downcast::<gtk::StackPage>()
+                                .unwrap()
+                                .child()
+                                .downcast::<Session>()
+                                .unwrap();
+
+                            if &session.database_info().0.directory_base_name
+                                == database_dir_base_name
+                            {
+                                Some(pos)
+                            } else {
+                                None
+                            }
+                        })
+                    })
+                    .unwrap_or_default();
+
+                self_
+                    .sessions
+                    .pages()
+                    .select_item(active_session_index, true);
+            } else {
+                // There are no sessions left. Thus go back to login.
+                self.add_new_session(APPLICATION_OPTS.get().unwrap().test_dc);
+            }
+
+            // save recently used sessions
+            self.save_recently_used_sessions();
+        }
+    }
+
+    /// Function cleaning up, which is called by the application windows on closing. It sets all
+    /// clients offline.
+    pub fn close_clients(&self) {
+        let self_ = imp::SessionManager::from_instance(self);
+
+        // Create a future to close the sessions.
+        let close_sessions_future = futures::future::join_all(
+            self_
+                .clients
+                .borrow()
+                .iter()
+                .filter_map(|(client_id, client_info)| match client_info {
+                    ClientInfo::Auth { .. } | ClientInfo::LoggedIn(_) => Some(client_id),
+                    _ => None,
+                })
+                .cloned()
+                .map(|client_id| {
+                    set_online(client_id, false)
+                        .and_then(move |_| functions::Close::new().send(client_id))
+                }),
+        );
+
+        // Block on that future, else the window closes before they are finished!!!
+        RUNTIME.block_on(async {
+            close_sessions_future.await.into_iter().for_each(|result| {
+                if let Err(e) = result {
+                    log::warn!("Error on closing client: {:?}", e);
+                }
+            });
+        });
+    }
+
+    pub fn handle_update(&self, update: Update, client_id: i32) {
+        let self_ = imp::SessionManager::from_instance(self);
+
+        match update {
+            Update::AuthorizationState(update) => {
+                self.handle_authorization_state(update, client_id);
+            }
+            update => {
+                if let ClientInfo::LoggedIn(session) =
+                    self_.clients.borrow().get(&client_id).unwrap()
+                {
+                    session.handle_update(update)
+                }
+            }
+        }
+    }
+
+    /// This function is used to log in an account. Within the function it is first checked if the
+    /// client needs to authorize. Then the `AuthorizationState` is delegated to the `Login`
+    /// widget. Otherwise, if the client was already authorized from previous a application run,
+    /// the session is created directly in this function.
+    fn handle_authorization_state(&self, update: UpdateAuthorizationState, client_id: i32) {
+        let self_ = imp::SessionManager::from_instance(self);
+
+        if let AuthorizationState::Closed = update.authorization_state {
+            if let ClientInfo::LoggingOut(database_dir_base_name) =
+                self_.clients.borrow_mut().remove(&client_id).unwrap()
+            {
+                RUNTIME.spawn(async move {
+                    if let Err(e) =
+                        fs::remove_dir_all(data_dir().join(database_dir_base_name)).await
+                    {
+                        log::error!("Error on on removing database directory: {}", e);
+                    }
+                });
+            }
+            return;
+        }
+
+        let client_info = self.client_info(client_id).unwrap();
+
+        if let AuthorizationState::LoggingOut = update.authorization_state {
+            self.set_session_logging_out(&client_info);
+            self_.clients.borrow_mut().insert(
+                client_id,
+                ClientInfo::LoggingOut(client_info.database_dir_base_name().to_owned()),
+            );
+
+            return;
+        }
+
+        if let ClientInfo::Auth {
+            maybe_authorized,
+            database_info,
+        } = client_info
+        {
+            if !maybe_authorized {
+                self_
+                    .login
+                    .set_authorization_state(update.authorization_state);
+            } else {
+                // Client doesn't need to authorize. So we can skip the login procedure.
+                match &update.authorization_state {
+                    AuthorizationState::WaitTdlibParameters => {
+                        do_async(
+                            glib::PRIORITY_DEFAULT_IDLE,
+                            async move { send_tdlib_parameters(client_id, &database_info).await },
+                            |result| async {
+                                if let Err(e) = result {
+                                    panic!("Error on sending tdlib parameters: {:?}", e);
+                                }
+                            },
+                        );
+                    }
+                    AuthorizationState::WaitEncryptionKey(_) => {
+                        let encryption_key = "".to_string();
+                        do_async(
+                            glib::PRIORITY_DEFAULT_IDLE,
+                            functions::CheckDatabaseEncryptionKey::new()
+                                .encryption_key(encryption_key)
+                                .send(client_id),
+                            |result| async {
+                                if let Err(e) = result {
+                                    panic!("Error on sending encryption key: {:?}", e);
+                                }
+                            },
+                        );
+                    }
+                    AuthorizationState::Ready => {
+                        let is_last_used = self_
+                            .recently_used_sessions
+                            .borrow()
+                            .iter()
+                            .rev()
+                            .next()
+                            .map(|last| &database_info.directory_base_name == last)
+                            .unwrap_or_default();
+
+                        self.add_logged_in_session(client_id, database_info, is_last_used);
+                    }
+                    _ => {
+                        // Our assumption that the database's session we found at application start
+                        // would not need to authorize was wrong. So we handle it correctly.
+                        if self_.initial_sessions_to_handle.get() == 1
+                            && APPLICATION_OPTS.get().unwrap().test_dc == database_info.use_test_dc
+                        {
+                            // Handle it over to `login.rs`.
+
+                            // Overwrite ClientInfo.
+                            self_.clients.borrow_mut().insert(
+                                client_id,
+                                ClientInfo::Auth {
+                                    maybe_authorized: false,
+                                    database_info: database_info.clone(),
+                                },
+                            );
+
+                            self_.login.login_client(client_id, database_info);
+
+                            self_
+                                .login
+                                .set_authorization_state(update.authorization_state);
+                        } else {
+                            log_out(client_id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Function that is used to overwrite the recently used sessions file.
+    fn save_recently_used_sessions(&self) {
+        let self_ = imp::SessionManager::from_instance(self);
+
+        let settings = gio::Settings::new(crate::config::APP_ID);
+        if let Err(e) = settings.set_strv(
+            "recently-used-sessions",
+            self_
+                .recently_used_sessions
+                .borrow()
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .as_slice(),
+        ) {
+            log::warn!(
+                "Failed to save value for gsettings key 'recently-used-sessions': {}",
+                e
+            );
+        }
+    }
+
+    /// Within this function a new `Session` is created based on the passed client id. This session
+    /// is then added to the session stack.
+    pub fn add_logged_in_session(
+        &self,
+        client_id: i32,
+        database_info: DatabaseInfo,
+        visible: bool,
+    ) {
+        let self_ = imp::SessionManager::from_instance(self);
+        let session = Session::new(client_id, database_info);
+
+        self_.sessions.add_child(&session);
+        session.set_sessions(&self_.sessions.pages());
+
+        self_
+            .clients
+            .borrow_mut()
+            .insert(client_id, ClientInfo::LoggedIn(session.clone()));
+
+        let auth_session_present = self_
+            .clients
+            .borrow()
+            .values()
+            .any(|client_info| matches!(client_info, ClientInfo::Auth { .. }));
+
+        if (self_.main_stack.visible_child() != Some(self_.sessions.clone().upcast())
+            && !auth_session_present)
+            || visible
+        {
+            self_.sessions.set_visible_child(&session);
+            self_.main_stack.set_visible_child(&*self_.sessions);
+        }
+
+        // Enable notifications for this client
+        RUNTIME.spawn(async move {
+            functions::SetOption::new()
+                .name("notification_group_count_max".to_string())
+                .value(enums::OptionValue::Integer(types::OptionValueInteger {
+                    value: 5,
+                }))
+                .send(client_id)
+                .await
+                .unwrap();
+        });
+    }
+
+    pub fn begin_chats_search(&self) {
+        if let Some(client_id) = self.active_logged_in_client_id() {
+            let self_ = imp::SessionManager::from_instance(self);
+            if let ClientInfo::LoggedIn(session) = self_.clients.borrow().get(&client_id).unwrap() {
+                session.begin_chats_search();
+            }
+        }
+    }
+}
+
+/// A struct for storing information about a session's database.
+#[derive(Clone, Debug)]
+pub struct DatabaseInfo {
+    // The base name of the database directory.
+    pub directory_base_name: String,
+    // Whether this database uses a test dc.
+    pub use_test_dc: bool,
+}
+
+/// A struct for representing the state of the data directory.
+#[derive(Debug)]
+pub enum DatadirState {
+    /// There are no sessions at all. This probably means that the application is started for the
+    /// first time or the data directory has been deleted by the user.
+    Empty,
+    /// There were several sessions found in the data directory.
+    HasSessions {
+        /// The `DatabaseInfos`
+        database_infos: Vec<DatabaseInfo>,
+        /// The order of the recently used sessions that will be read from a gsettings value.
+        recently_used_sessions: Vec<String>,
+    },
+}
+
+/// This function analyzes the data directory.
+///
+/// First, it checks whether the directory exists. It will create it and return immediately if
+/// it doesn't.
+///
+/// If the data directory exists, information about the sessions is gathered. This is reading the
+/// recently used sessions file and checking the individual session's database directory.
+async fn analyze_data_dir() -> Result<DatadirState, anyhow::Error> {
+    if !data_dir().exists() {
+        // Create the Telegrand data directory if it does not exist and return.
+        return fs::create_dir_all(&data_dir())
+            .map_err(anyhow::Error::from)
+            .map_ok(|_| DatadirState::Empty)
+            .await;
+    }
+
+    let read_dir = fs::read_dir(&data_dir())
+        .map_err(anyhow::Error::from)
+        .await?;
+
+    // All directories with the result of reading the session info file.
+    let database_infos = ReadDirStream::new(read_dir)
+        .map_err(anyhow::Error::from)
+        // Only consider directories.
+        .try_filter_map(|entry| async move {
+            Ok(match entry.metadata().await {
+                Ok(metadata) if metadata.is_dir() => Some(entry),
+                _ => None,
+            })
+        })
+        // Only consider directories with a "*.binlog" file
+        .try_filter_map(|entry| async move {
+            Ok(match fs::metadata(entry.path().join("td.binlog")).await {
+                Ok(metadata) if metadata.is_file() => Some((entry, false)),
+                _ => match fs::metadata(entry.path().join("td_test.binlog")).await {
+                    Ok(metadata) if metadata.is_file() => Some((entry, true)),
+                    _ => None,
+                },
+            })
+        })
+        .map_ok(|(entry, use_test_dc)| DatabaseInfo {
+            directory_base_name: entry
+                .path()
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_owned(),
+            use_test_dc,
+        })
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    if database_infos.is_empty() {
+        Ok(DatadirState::Empty)
+    } else {
+        let mut recently_used_sessions = gio::Settings::new(crate::config::APP_ID)
+            .strv("recently-used-sessions")
+            .into_iter()
+            .map(glib::GString::into)
+            .collect::<Vec<_>>();
+
+        // Remove invalid database directory base names from recently used sessions.
+        recently_used_sessions.retain(|database_dir_base_name| {
+            database_infos
+                .iter()
+                .any(|database_info| &database_info.directory_base_name == database_dir_base_name)
+        });
+
+        Ok(DatadirState::HasSessions {
+            recently_used_sessions,
+            database_infos,
+        })
+    }
+}
+
+/// This function generates a new database directory name based on the current UNIX system time
+/// (e.g. db1638487692420). In the very unlikely case that a name is already taken it tries to
+/// append a number at the end.
+fn generate_database_dir_base_name() -> String {
+    let database_dir_base_name = format!(
+        "db{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_millis()
+    );
+
+    // Just to be sure!
+    if data_dir().join(&database_dir_base_name).exists() {
+        (2..)
+            .map(|count| format!("{}_{}", database_dir_base_name, count))
+            .find(|alternative_base_name| !data_dir().join(alternative_base_name).exists())
+            .unwrap()
+    } else {
+        database_dir_base_name
+    }
+}
+
+/// Helper function for setting the online status of a client.
+async fn set_online(client_id: i32, value: bool) -> Result<enums::Ok, types::Error> {
+    functions::SetOption::new()
+        .name("online".to_string())
+        .value(enums::OptionValue::Boolean(types::OptionValueBoolean {
+            value,
+        }))
+        .send(client_id)
+        .await
+}
+
+/// Helper function for setting the tdlib log level.
+fn send_log_level(client_id: i32) {
+    RUNTIME.spawn(
+        functions::SetLogVerbosityLevel::new()
+            .new_verbosity_level(if log::log_enabled!(log::Level::Trace) {
+                5
+            } else if log::log_enabled!(log::Level::Debug) {
+                4
+            } else if log::log_enabled!(log::Level::Info) {
+                3
+            } else if log::log_enabled!(log::Level::Warn) {
+                2
+            } else {
+                0
+            })
+            .send(client_id),
+    );
+}
+
+/// Helper function for removing an element from a [`Vec`] based on an equality comparison.
+fn remove_from_vec<T, Q: ?Sized>(vec: &mut Vec<T>, to_remove: &Q) -> bool
+where
+    T: Borrow<Q>,
+    Q: Eq,
+{
+    match vec.iter().position(|elem| elem.borrow() == to_remove) {
+        Some(pos) => {
+            vec.remove(pos);
+            true
+        }
+        None => false,
+    }
+}


### PR DESCRIPTION
# Disclaimer
If you want to test this PR, you should be prepared that your local tdlib database can be destroyed. Therefore, it is important to make a backup of the database beforehand. Although this PR is as good as feature-complete in my opinion, I decided to leave it as a draft until it has been sufficiently tested.

# What does this PR?
It implements a multi-account feature. This means that the user is able to log into Telegrand with several accounts at the same time.

# Objectives
Broadly speaking, there are the following two major objectives. To meet these objectives, the modifications to the existing structure of the data directory are therefore minimally-invasive

## Backward compatibility to existing databases
I consider that to be very critical. In no case should the existing database be destroyed when the updated application is used.

## Backward compatibility of the new multi-account capable data directory to older Telegrand versions
It should also be possible to load the database with an older Telegrand version. Of course, then only the first account (db0) will be loaded. But all data should remain consistent. This is for example helpful for git bisect.

# How it works

![ma_server_chooser](https://user-images.githubusercontent.com/3630213/142788210-d7757a24-bba4-4317-af1c-71717f020dde.png)


As soon as the user is logged in, the Accounts button is located in the upper left corner. This opens a popover in which all logged in accounts can be seen. You can also add a new account. By default, the new account will be logged into a production server. But you can open a menu with a long press, in which you have the choice to use a test server.

The option on the login page to use the test DC has been removed completely, because this option was global, but the flag to use the Test DC applies to the account. It therefore no longer makes sense. By default, the production server is always used at the first login. Further accounts can then be connected on the test DC. However, to use the test DC at the first login, telegrand can be started with the command line flag `--test-dc`.

# How can you help with testing?
For example, you could test the following things

1. Does adding new accounts work?
2. Does logout of individual accounts work?
3. Does the application remember the last account used when restarting?
4. Does the order in the accounts list match the order in which the accounts were added?
5. What happens if I add an account that I am already logged in with? 
6. Is the whole thing really backward and forward compatible?
7. ... A million other edge cases you can think of.

# Todos

- [x] Make some remaining filesystem operations async/await
- [x] Cleanup the code
- [x] Split into smaller commits
- [x] More testing (bugs and performance)

# Credit
Goes to the Fractal developers, from whom I was able to take a lot.