### PR TITLE
meson: Don't require new versions of tdlib

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@ dependency('glib-2.0', version: '>= 2.66')
 dependency('gio-2.0', version: '>= 2.66')
 dependency('gtk4', version: '>= 4.4.0')
 dependency('libadwaita-1', version: '>= 1.0.0')
-dependency('tdjson', version: '>= 1.7.0')
+dependency('tdjson', version: '== 1.7.0')
 
 glib_compile_resources = find_program('glib-compile-resources', required: true)
 glib_compile_schemas = find_program('glib-compile-schemas', required: true)


### PR DESCRIPTION
Using newer versions of tdlib compared to what Telegrand uses can break stuff, so let's require the exact version.