### PR TITLE
sidebar-chat-row: Show unread-mention-count badge

### DIFF
--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -26,6 +26,16 @@
   font-size: 0.95em;
 }
 
+.chat-list row .unread-mention-count {
+  color: @accent_fg_color;
+  background-color: @accent_bg_color;
+  font-size: 0.8em;
+  font-weight: bold;
+  min-width: 1.7em;
+  border-radius: 9999px;
+  padding: 2px 0px;
+}
+
 .chat-list row .unread-count {
   color: @accent_fg_color;
   font-size: 0.8em;

--- a/data/resources/ui/sidebar-row.ui
+++ b/data/resources/ui/sidebar-row.ui
@@ -66,6 +66,16 @@
               </object>
             </child>
             <child>
+              <object class="GtkLabel" id="unread_mention_label">
+                <property name="valign">center</property>
+                <property name="justify">center</property>
+                <property name="label">@</property>
+                <style>
+                  <class name="unread-mention-count"/>
+                </style>
+              </object>
+            </child>
+            <child>
               <object class="GtkLabel" id="unread_count_label">
                 <property name="valign">center</property>
                 <property name="ellipsize">end</property>

--- a/src/session/chat_list.rs
+++ b/src/session/chat_list.rs
@@ -162,6 +162,16 @@ impl ChatList {
                     chat.handle_update(update);
                 }
             }
+            Update::ChatUnreadMentionCount(ref update_) => {
+                if let Some(chat) = self_.list.borrow().get(&update_.chat_id) {
+                    chat.handle_update(update);
+                }
+            }
+            Update::MessageMentionRead(ref update_) => {
+                if let Some(chat) = self_.list.borrow().get(&update_.chat_id) {
+                    chat.handle_update(update);
+                }
+            }
             Update::ChatReadInbox(ref update_) => {
                 if let Some(chat) = self_.list.borrow().get(&update_.chat_id) {
                     chat.handle_update(update);

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -229,6 +229,8 @@ impl Session {
             | Update::ChatLastMessage(_)
             | Update::ChatNotificationSettings(_)
             | Update::ChatPosition(_)
+            | Update::ChatUnreadMentionCount(_)
+            | Update::MessageMentionRead(_)
             | Update::ChatReadInbox(_)
             | Update::ChatDraftMessage(_)
             | Update::DeleteMessages(_) => {


### PR DESCRIPTION
# Commit Message
```
As in the official clients, a circular accent-colored label with the
text `@` is displayed in front of the `unread-count` label for this pur-
pose.

If for a chat the condition

  unread_count == 1 && unread_mention_count == 1

is true, the `unread_count` label will be hidden and only the
`unread_mention_count` label will be shown.
```
![unread_mention_count_1](https://user-images.githubusercontent.com/3630213/143153096-a0cb129e-2692-487d-a983-02e0e90d0d29.png)
![unread_mention_count_n](https://user-images.githubusercontent.com/3630213/143153100-09e19573-26c3-443f-8c42-4566b023a599.png)
