### PR TITLE
chat-list: Use LoadChats instead of GetChats

### DIFF
--- a/src/session/chat_list.rs
+++ b/src/session/chat_list.rs
@@ -107,8 +107,8 @@ impl ChatList {
 
     pub fn fetch(&self, client_id: i32) {
         RUNTIME.spawn(async move {
-            functions::GetChats::new()
-                .limit(i32::MAX)
+            functions::LoadChats::new()
+                .limit(20)
                 .send(client_id)
                 .await
                 .unwrap();

--- a/src/session/chat_list.rs
+++ b/src/session/chat_list.rs
@@ -6,7 +6,8 @@ use tdgrand::types::Chat as TelegramChat;
 use tdgrand::{enums::Update, functions};
 
 use crate::session::Chat;
-use crate::{Session, RUNTIME};
+use crate::utils::do_async;
+use crate::Session;
 
 mod imp {
     use super::*;
@@ -106,13 +107,20 @@ impl ChatList {
     }
 
     pub fn fetch(&self, client_id: i32) {
-        RUNTIME.spawn(async move {
-            functions::LoadChats::new()
-                .limit(20)
-                .send(client_id)
-                .await
-                .unwrap();
-        });
+        do_async(
+            glib::PRIORITY_DEFAULT_IDLE,
+            functions::LoadChats::new().limit(20).send(client_id),
+            clone!(@weak self as obj => move |result| async move {
+                if let Err(err) = result {
+                    // Error 404 means that all chats have been loaded
+                    if err.code != 404 {
+                        log::error!("Received an error for LoadChats: {}", err.code);
+                    }
+                } else {
+                    obj.fetch(client_id);
+                }
+            }),
+        );
     }
 
     pub fn handle_update(&self, update: Update) {


### PR DESCRIPTION
Note: this PR requires #174 merged first.

This is a new TDLib api that only relies on updates to receive the loaded chats instead of also returning them in the response.

~It should also fix #78.~ Fixes #78.