### PR TITLE
session: Allow more ways to navigate back to the chat list

### DIFF
--- a/data/resources/ui/session.ui
+++ b/data/resources/ui/session.ui
@@ -3,6 +3,7 @@
   <template class="Session" parent="AdwBin">
     <child>
       <object class="AdwLeaflet" id="leaflet">
+        <property name="can-navigate-back">True</property>
         <child>
           <object class="Sidebar" id="sidebar">
             <property name="compact" bind-source="leaflet" bind-property="folded" bind-flags="sync-create"/>

--- a/src/session/content/mod.rs
+++ b/src/session/content/mod.rs
@@ -46,10 +46,6 @@ mod imp {
         fn class_init(klass: &mut Self::Class) {
             ChatHistory::static_type();
             Self::bind_template(klass);
-
-            klass.install_action("content.go-back", None, move |widget, _, _| {
-                widget.set_chat(None);
-            });
         }
 
         fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {


### PR DESCRIPTION
# Commit Message
```
session: Allow more ways to navigate back to the chat list

The user does not necessarily have to use the back button in the header
bar to get back to the chat list in compact mode. Alternatively, the us-
er could for example use the mouse back button or a swipe gesture.

fixes #173
```

@Kekun I basically did this according to your instructions. Unfortunately I don't have a touch device to test and strangely the gestures on the touchpad as described here don't work ([link](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/property.Leaflet.can-navigate-back.html)).
However, Alt+← and mouse back button seem to work.