### PR TITLE
flatpak: Use prebuilt TDLib for certain arches

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following packages are required to build Telegrand:
 
 - meson
 - cargo
-- GTK4
+- GTK >= 4.5.0
 - libadwaita (latest git revision)
 - TDLib 1.7.9
 

--- a/build-aux/com.github.melix99.telegrand.Devel.json
+++ b/build-aux/com.github.melix99.telegrand.Devel.json
@@ -58,6 +58,17 @@
             ]
         },
         {
+            "name": "gtk",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/gtk.git",
+                    "tag": "4.5.0"
+                }
+            ]
+        },
+        {
             "name": "libadwaita",
             "buildsystem": "meson",
             "config-opts": [

--- a/build-aux/com.github.melix99.telegrand.Devel.json
+++ b/build-aux/com.github.melix99.telegrand.Devel.json
@@ -74,7 +74,34 @@
             ]
         },
         {
+            "name": "tdlib-prebuilt",
+            "only-arches": [ "x86_64", "aarch64" ],
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -D libtdjson.so.* /app/lib",
+                "ln -sf /app/lib/libtdjson.so.* /app/lib/libtdjson.so",
+                "install -D pkgconfig/* /app/lib/pkgconfig"
+            ],
+            "sources": [
+                {
+                    "only-arches": [ "x86_64" ],
+                    "type": "archive",
+                    "url": "https://github.com/melix99/tdjson-ci/releases/download/1.7.9/tdjson-x86_64.zip",
+                    "sha256": "2be3e2227d8e1dbf5265fb6e27c288300f4c78754b5802579b7221db26de6aa6",
+                    "strip-components": 0
+                },
+                {
+                    "only-arches": [ "aarch64" ],
+                    "type": "archive",
+                    "url": "https://github.com/melix99/tdjson-ci/releases/download/1.7.9/tdjson-aarch64.zip",
+                    "sha256": "d02fb846c1a2570014b177afd39047303887ee369c618971b1167e01f10e221b",
+                    "strip-components": 0
+                }
+            ]
+        },
+        {
             "name": "tdlib",
+            "skip-arches": [ "x86_64", "aarch64" ],
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ base_id = 'com.github.melix99.telegrand'
 
 dependency('glib-2.0', version: '>= 2.66')
 dependency('gio-2.0', version: '>= 2.66')
-dependency('gtk4', version: '>= 4.4.0')
+dependency('gtk4', version: '>= 4.5.0')
 dependency('libadwaita-1', version: '>= 1.0.0')
 dependency('tdjson', version: '== 1.7.9')
 


### PR DESCRIPTION
TDLib is annoying to build, period. The aarch64 CI builds can't even finish because it reaches the 6 hour maximum allowed from GitHub and it also annoys new contributors (and me) to build it.

This PR changes the flatpak manifest to include prebuilt tdjson library for certain architectures (x86_64 and aarch64 for now) and it will fallback to a full build of tdlib in case of other architectures.