### PR TITLE
message-row: Show sender name of outgoing messages if sender is not a user

### DIFF
--- a/src/session/content/message_row/text.rs
+++ b/src/session/content/message_row/text.rs
@@ -71,13 +71,13 @@ impl MessageText {
 
         // Show sender label, if needed
         let show_sender = {
-            if !message.is_outgoing() {
+            if message.is_outgoing() {
+                matches!(message.sender(), MessageSender::Chat(_))
+            } else {
                 matches!(
                     message.chat().type_(),
                     ChatType::BasicGroup(_) | ChatType::Supergroup(_)
                 )
-            } else {
-                false
             }
         };
         if show_sender {


### PR DESCRIPTION
Works for both anonymous admins (when sender is the group itself) and anonymous users (when sender is a channel):

![Anonymous sender](https://user-images.githubusercontent.com/29029632/145347960-1e237eb8-1d54-4d59-baff-953e9d172f5b.png)
