### PR TITLE
Introduce StickerPaintable and use libwebp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "bytemuck"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cairo-rs"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +87,9 @@ name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-expr"
@@ -99,6 +114,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "crc32fast"
@@ -566,6 +587,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "image"
+version = "0.23.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +624,15 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "lazy_static"
@@ -637,6 +681,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
 
 [[package]]
+name = "libwebp-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e70c064738b35a28fd6f991d27c0d9680353641d167ae3702a8228dd8272ef6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "locale_config"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +731,47 @@ name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
@@ -1112,6 +1206,7 @@ dependencies = [
  "regex",
  "tdgrand",
  "tokio",
+ "webp",
 ]
 
 [[package]]
@@ -1219,6 +1314,16 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "webp"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0041a9fcbdbf6402c3cb0ec7c2c1a1c240efd523519a0763ae07753bc95f7713"
+dependencies = [
+ "image",
+ "libwebp-sys",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ qrcode-generator = { version = "4.1", default-features = false }
 regex = "1.5"
 tdgrand = { git = "https://github.com/melix99/tdgrand", branch = "main" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
+webp = "0.2"

--- a/data/resources/ui/content-chat-history.ui
+++ b/data/resources/ui/content-chat-history.ui
@@ -41,6 +41,7 @@
             </style>
             <property name="child">
               <object class="AdwClampScrollable">
+                <property name="vscroll-policy">natural</property>
                 <property name="child">
                   <object class="GtkListView" id="list_view">
                     <property name="factory">

--- a/data/resources/ui/content-message-sticker.ui
+++ b/data/resources/ui/content-message-sticker.ui
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <template class="ContentMessageSticker" parent="GtkWidget">
+    <property name="layout-manager">
+      <object class="GtkBinLayout"/>
+    </property>
     <child>
       <object class="GtkPicture" id="picture"/>
     </child>

--- a/src/meson.build
+++ b/src/meson.build
@@ -47,6 +47,7 @@ rust_sources = files(
   'session/content/user_dialog.rs',
   'session/content/message_row/mod.rs',
   'session/content/message_row/sticker.rs',
+  'session/content/message_row/sticker_paintable.rs',
   'session/content/message_row/text.rs',
   'session/sidebar/avatar.rs',
   'session/sidebar/mod.rs',

--- a/src/session/content/message_row/mod.rs
+++ b/src/session/content/message_row/mod.rs
@@ -1,7 +1,9 @@
 mod sticker;
+mod sticker_paintable;
 mod text;
 
 use self::sticker::MessageSticker;
+use self::sticker_paintable::StickerPaintable;
 use self::text::MessageText;
 
 use adw::prelude::BinExt;

--- a/src/session/content/message_row/sticker_paintable.rs
+++ b/src/session/content/message_row/sticker_paintable.rs
@@ -1,0 +1,129 @@
+use gtk::{gdk, glib, prelude::*, subclass::prelude::*};
+
+const MAX_SIZE: i32 = 200;
+
+mod imp {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use std::cell::{Cell, RefCell};
+
+    #[derive(Debug, Default)]
+    pub struct StickerPaintable {
+        pub texture: RefCell<Option<gdk::Texture>>,
+        pub width: Cell<i32>,
+        pub height: Cell<i32>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for StickerPaintable {
+        const NAME: &'static str = "ContentStickerPaintable";
+        type Type = super::StickerPaintable;
+        type ParentType = glib::Object;
+        type Interfaces = (gdk::Paintable,);
+    }
+
+    impl ObjectImpl for StickerPaintable {
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![glib::ParamSpec::new_object(
+                    "texture",
+                    "Texture",
+                    "The texture of the sticker",
+                    gdk::Texture::static_type(),
+                    glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                )]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(
+            &self,
+            obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "texture" => obj.set_texture(value.get().unwrap()),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "texture" => obj.texture().to_value(),
+                _ => unimplemented!(),
+            }
+        }
+    }
+
+    impl PaintableImpl for StickerPaintable {
+        fn intrinsic_width(&self, _paintable: &Self::Type) -> i32 {
+            self.width.get()
+        }
+
+        fn intrinsic_height(&self, _paintable: &Self::Type) -> i32 {
+            self.height.get()
+        }
+
+        fn snapshot(
+            &self,
+            _paintable: &Self::Type,
+            snapshot: &gdk::Snapshot,
+            width: f64,
+            height: f64,
+        ) {
+            if let Some(texture) = self.texture.borrow().as_ref() {
+                texture.snapshot(snapshot, width, height);
+            }
+        }
+    }
+}
+
+glib::wrapper! {
+    pub struct StickerPaintable(ObjectSubclass<imp::StickerPaintable>) @implements gdk::Paintable;
+}
+
+impl Default for StickerPaintable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StickerPaintable {
+    pub fn new() -> Self {
+        glib::Object::new(&[]).expect("Failed to create StickerPaintable")
+    }
+
+    pub fn set_aspect_ratio(&self, aspect_ratio: f64) {
+        let self_ = imp::StickerPaintable::from_instance(self);
+
+        if aspect_ratio >= 1.0 {
+            self_.width.set(MAX_SIZE);
+            self_.height.set((MAX_SIZE as f64 / aspect_ratio) as i32);
+        } else {
+            self_.width.set((MAX_SIZE as f64 * aspect_ratio) as i32);
+            self_.height.set(MAX_SIZE);
+        }
+
+        self.invalidate_size();
+    }
+
+    pub fn texture(&self) -> Option<gdk::Texture> {
+        let self_ = imp::StickerPaintable::from_instance(self);
+        self_.texture.borrow().to_owned()
+    }
+
+    pub fn set_texture(&self, texture: Option<gdk::Texture>) {
+        if self.texture() == texture {
+            return;
+        }
+
+        let self_ = imp::StickerPaintable::from_instance(self);
+        self_.texture.replace(texture);
+
+        self.invalidate_contents();
+
+        self.notify("texture");
+    }
+}


### PR DESCRIPTION
This paintable is made to avoid creating a custom measure implementation for the MessageSticker, which was also wrong anyway. Also, now we load the sticker via libwebp instead of using gstreamer as before, this allows us to have a simpler texture instance instead of using GtkMediaFile.

It probably needs a bit of testing.