### PR TITLE
Flatpak refinements

### DIFF
--- a/build-aux/com.github.melix99.telegrand.Devel.json
+++ b/build-aux/com.github.melix99.telegrand.Devel.json
@@ -11,6 +11,7 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--share=network",
+        "--share=ipc",
         "--device=dri",
         "--talk-name=org.a11y.Bus",
         "--env=G_MESSAGES_DEBUG=none",

--- a/build-aux/com.github.melix99.telegrand.Devel.json
+++ b/build-aux/com.github.melix99.telegrand.Devel.json
@@ -21,10 +21,6 @@
         "append-path": "/usr/lib/sdk/rust-stable/bin",
         "build-args": [
             "--share=network"
-        ],
-        "test-args": [
-            "--socket=x11",
-            "--share=network"
         ]
     },
     "cleanup": [


### PR DESCRIPTION
According to this [page](https://docs.flatpak.org/de/latest/sandbox-permissions-reference.html#f1) the `--share=ipc` should improve performance in X11.