### PR TITLE
login: Use the same width for the 'Previous' and 'Next' buttons

### DIFF
--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
+  <object class="GtkSizeGroup">
+    <property name="mode">horizontal</property>
+    <widgets>
+      <widget name="previous_button"/>
+      <widget name="next_button"/>
+    </widgets>
+  </object>
   <template class="Login" parent="AdwBin">
     <child>
       <object class="GtkStack" id="main_stack">


### PR DESCRIPTION
This looks more harmonious and is also done this way in the gnome-tour
app.

# Before
![Bildschirmfoto von 2022-01-13 15-11-31](https://user-images.githubusercontent.com/3630213/149345864-6eb329c5-236c-4725-a0aa-774d88eb2bd8.png)

# After
![Bildschirmfoto von 2022-01-13 15-05-20](https://user-images.githubusercontent.com/3630213/149345896-2fe60aa0-9f53-4066-ac98-61687e8067bf.png)

# Gnome Tour
![Bildschirmfoto von 2022-01-13 15-05-48](https://user-images.githubusercontent.com/3630213/149345933-4c284290-824e-4b49-a0c5-3cc82c9719f6.png)
