### PR TITLE
session: Await functions::GetMe before proceeding

### DIFF
--- a/src/session/sidebar/avatar.rs
+++ b/src/session/sidebar/avatar.rs
@@ -175,22 +175,14 @@ impl Avatar {
 
         let user_expression = gtk::ConstantExpression::new(user);
         let interlocutor_status_expression = user_expression.chain_property::<User>("status");
-        let me_expression = Session::this_expression("me");
 
+        let my_id = session.me().id();
         let user_id = user.id();
-        // TODO: Change `me` to a non-Option value when
-        // https://github.com/melix99/telegrand/pull/208 is merged
         let is_online_binding = gtk::ClosureExpression::new::<bool, _, _>(
-            &[
-                me_expression.upcast(),
-                interlocutor_status_expression.upcast(),
-            ],
-            closure!(
-                |_: Session, me: Option<User>, interlocutor_status: BoxedUserStatus| {
-                    matches!(interlocutor_status.0, UserStatus::Online(_))
-                        && me.map(|me| me.id()).unwrap_or_default() != user_id
-                }
-            ),
+            &[interlocutor_status_expression.upcast()],
+            closure!(|_: Session, interlocutor_status: BoxedUserStatus| {
+                matches!(interlocutor_status.0, UserStatus::Online(_)) && my_id != user_id
+            }),
         )
         .bind(self, "is-online", Some(&session));
 

--- a/src/session_manager.rs
+++ b/src/session_manager.rs
@@ -217,7 +217,7 @@ impl SessionManager {
         let sessions = self.sessions();
 
         (0..sessions.n_items())
-            .filter_map(|pos| {
+            .map(|pos| {
                 sessions
                     .item(pos)
                     .unwrap()
@@ -254,13 +254,13 @@ impl SessionManager {
                 .downcast::<Session>()
                 .unwrap();
 
-            session
-                .me()
-                .filter(|me| {
-                    on_test_dc == session.database_info().0.use_test_dc
-                        && me.phone_number().replace(" ", "") == phone_number_digits
-                })
-                .map(|_| pos)
+            if on_test_dc == session.database_info().0.use_test_dc
+                && session.me().phone_number().replace(" ", "") == phone_number_digits
+            {
+                Some(pos)
+            } else {
+                None
+            }
         })
     }
 
@@ -655,47 +655,55 @@ impl SessionManager {
     /// Within this function a new `Session` is created based on the passed client id. This session
     /// is then added to the session stack.
     pub fn add_logged_in_session(&self, client_id: i32, session: Session, visible: bool) {
-        let imp = self.imp();
+        do_async(
+            glib::PRIORITY_DEFAULT_IDLE,
+            functions::GetMe::new().send(client_id),
+            clone!(@weak self as obj => move |result| async move {
+                let imp = obj.imp();
 
-        session.fetch_me();
-        session.fetch_chats();
+                imp.sessions.add_child(&session);
+                // TODO: set_me
+                let tdgrand::enums::User::User(me) = result.unwrap();
+                session.set_me(session.user_list().get(me.id));
+                session.set_sessions(&imp.sessions.pages());
+                session.fetch_chats();
 
-        imp.sessions.add_child(&session);
-        session.set_sessions(&imp.sessions.pages());
+                imp.clients.borrow_mut().insert(
+                    client_id,
+                    Client {
+                        session: session.clone(),
+                        state: ClientState::LoggedIn,
+                    },
+                );
 
-        imp.clients.borrow_mut().insert(
-            client_id,
-            Client {
-                session: session.clone(),
-                state: ClientState::LoggedIn,
-            },
+                let auth_session_present = imp
+                    .clients
+                    .borrow()
+                    .values()
+                    .any(|client| matches!(client.state, ClientState::Auth { .. }));
+
+                if (imp.main_stack.visible_child() != Some(imp.sessions.clone().upcast())
+                    && !auth_session_present)
+                    || visible
+                {
+                    imp.sessions.set_visible_child(&session);
+                    imp.main_stack.set_visible_child(&*imp.sessions);
+                }
+
+                // Enable notifications for this client
+                RUNTIME.spawn(async move {
+                    functions::SetOption::new()
+                        .name("notification_group_count_max".to_string())
+                        .value(enums::OptionValue::Integer(types::OptionValueInteger {
+                            value: 5,
+                        }))
+                        .send(client_id)
+                        .await
+                        .unwrap();
+                });
+
+            }),
         );
-
-        let auth_session_present = imp
-            .clients
-            .borrow()
-            .values()
-            .any(|client| matches!(client.state, ClientState::Auth { .. }));
-
-        if (imp.main_stack.visible_child() != Some(imp.sessions.clone().upcast())
-            && !auth_session_present)
-            || visible
-        {
-            imp.sessions.set_visible_child(&session);
-            imp.main_stack.set_visible_child(&*imp.sessions);
-        }
-
-        // Enable notifications for this client
-        RUNTIME.spawn(async move {
-            functions::SetOption::new()
-                .name("notification_group_count_max".to_string())
-                .value(enums::OptionValue::Integer(types::OptionValueInteger {
-                    value: 5,
-                }))
-                .send(client_id)
-                .await
-                .unwrap();
-        });
     }
 
     pub fn begin_chats_search(&self) {


### PR DESCRIPTION
# Commit Message
```
It's better to wait for `functions::GetMe` to return our own user be-
fore creating a new session. In this way we don't need expressions for
watching the `me` property to become `Some`. We can just use
`Session::me()`, which at this point guarantees to return our own user.

Since updates are already coming in the time that the own user is being
waited for, `WaitingForOwnUser` is introduced as the fourth variant of
the `ClientInfo` enum. Here all updates for the sessions are cached and
then applied as soon as the own user is available with which the session
can be created.
```

# Original Post
As discussed, it is better to wait for `functions::GetMe` to return our own user. In this way we don't need expressions as we can be sure that our user object is always `Some`.

There is one small flaw: 
we still need to wrap our `User` as a `RefCell<Option<User>>` instead of an `OnceCell<User>`, since a `User` and a `Session` have a cyclic dependency on each other. Therefore, the own `User` can only be created after the `GObject` for the `Session` has been created. However, the `GObject` expects a default value for all its properties and so for the `User`.

Despite this flaw, however, we can always be sure that `session.me().unwrap()` will not crash.

