### PR TITLE
Always expect types inside lists

### DIFF
--- a/src/session/basic_group_list.rs
+++ b/src/session/basic_group_list.rs
@@ -58,9 +58,18 @@ impl BasicGroupList {
         glib::Object::new(&[]).expect("Failed to create BasicGroupList")
     }
 
-    pub fn get(&self, id: i64) -> Option<BasicGroup> {
+    /// Return the `BasicGroup` of the specified `id`. Panics if the basic group is not present.
+    /// Note that TDLib guarantees that types are always returned before their ids,
+    /// so if you use an `id` returned by TDLib, it should be expected that the
+    /// relative `BasicGroup` exists in the list.
+    pub fn get(&self, id: i64) -> BasicGroup {
         let self_ = imp::BasicGroupList::from_instance(self);
-        self_.list.borrow().get(&id).cloned()
+        self_
+            .list
+            .borrow()
+            .get(&id)
+            .expect("Failed to get expected BasicGroup")
+            .to_owned()
     }
 
     pub fn handle_update(&self, update: &Update) {

--- a/src/session/basic_group_list.rs
+++ b/src/session/basic_group_list.rs
@@ -83,9 +83,9 @@ impl BasicGroupList {
                     let basic_group = BasicGroup::from_td_object(&data.basic_group);
                     entry.insert(basic_group);
 
+                    let position = (list.len() - 1) as u32;
                     drop(list);
 
-                    let position = (self_.list.borrow().len() - 1) as u32;
                     self.items_changed(position, 0, 1);
                 }
             }

--- a/src/session/chat/message.rs
+++ b/src/session/chat/message.rs
@@ -145,7 +145,7 @@ impl Message {
         let content = BoxedMessageContent(message.content);
         let sender = match message.sender_id {
             TelegramMessageSender::User(data) => {
-                let user = chat.session().user_list().get_or_create_user(data.user_id);
+                let user = chat.session().user_list().get(data.user_id);
                 MessageSender::User(user)
             }
             TelegramMessageSender::Chat(data) => {

--- a/src/session/chat/message.rs
+++ b/src/session/chat/message.rs
@@ -149,7 +149,7 @@ impl Message {
                 MessageSender::User(user)
             }
             TelegramMessageSender::Chat(data) => {
-                let chat = chat.session().chat_list().get_chat(data.chat_id).unwrap();
+                let chat = chat.session().chat_list().get(data.chat_id);
                 MessageSender::Chat(chat)
             }
         };

--- a/src/session/chat/mod.rs
+++ b/src/session/chat/mod.rs
@@ -30,7 +30,7 @@ impl ChatType {
     pub fn from_td_object(_type: &TdChatType, session: &Session) -> Self {
         match _type {
             TdChatType::Private(data) => {
-                let user = session.user_list().get_or_create_user(data.user_id);
+                let user = session.user_list().get(data.user_id);
                 Self::Private(user)
             }
             TdChatType::BasicGroup(data) => {

--- a/src/session/chat/mod.rs
+++ b/src/session/chat/mod.rs
@@ -34,10 +34,7 @@ impl ChatType {
                 Self::Private(user)
             }
             TdChatType::BasicGroup(data) => {
-                let basic_group = session
-                    .basic_group_list()
-                    .get(data.basic_group_id)
-                    .expect("Failed to get expected BasicGroup");
+                let basic_group = session.basic_group_list().get(data.basic_group_id);
                 Self::BasicGroup(basic_group)
             }
             TdChatType::Supergroup(data) => {

--- a/src/session/chat/mod.rs
+++ b/src/session/chat/mod.rs
@@ -41,10 +41,7 @@ impl ChatType {
                 Self::BasicGroup(basic_group)
             }
             TdChatType::Supergroup(data) => {
-                let supergroup = session
-                    .supergroup_list()
-                    .get(data.supergroup_id)
-                    .expect("Failed to get expected Supergroup");
+                let supergroup = session.supergroup_list().get(data.supergroup_id);
                 Self::Supergroup(supergroup)
             }
             TdChatType::Secret(data) => {

--- a/src/session/chat/mod.rs
+++ b/src/session/chat/mod.rs
@@ -42,10 +42,7 @@ impl ChatType {
                 Self::Supergroup(supergroup)
             }
             TdChatType::Secret(data) => {
-                let secret_chat = session
-                    .secret_chat_list()
-                    .get(data.secret_chat_id)
-                    .expect("Failed to get expected SecretChat");
+                let secret_chat = session.secret_chat_list().get(data.secret_chat_id);
                 Self::Secret(secret_chat)
             }
         }

--- a/src/session/chat/sponsored_message.rs
+++ b/src/session/chat/sponsored_message.rs
@@ -95,10 +95,7 @@ impl SponsoredMessage {
                 .await?;
 
         let content = BoxedMessageContent(sponsored_message.content);
-        let sponsor_chat = session
-            .chat_list()
-            .get_chat(sponsored_message.sponsor_chat_id)
-            .expect("Failed to get expected Chat");
+        let sponsor_chat = session.chat_list().get(sponsored_message.sponsor_chat_id);
 
         Ok(glib::Object::new(&[
             ("message-id", &sponsored_message.message_id),

--- a/src/session/chat_list.rs
+++ b/src/session/chat_list.rs
@@ -218,9 +218,18 @@ impl ChatList {
         }
     }
 
-    pub fn get_chat(&self, chat_id: i64) -> Option<Chat> {
+    /// Return the `Chat` of the specified `id`. Panics if the chat is not present.
+    /// Note that TDLib guarantees that types are always returned before their ids,
+    /// so if you use an `id` returned by TDLib, it should be expected that the
+    /// relative `Chat` exists in the list.
+    pub fn get(&self, id: i64) -> Chat {
         let self_ = imp::ChatList::from_instance(self);
-        self_.list.borrow().get(&chat_id).cloned()
+        self_
+            .list
+            .borrow()
+            .get(&id)
+            .expect("Failed to get expected Chat")
+            .to_owned()
     }
 
     fn insert_chat(&self, chat: TelegramChat) {

--- a/src/session/secret_chat_list.rs
+++ b/src/session/secret_chat_list.rs
@@ -116,9 +116,9 @@ impl SecretChatList {
                     let secret_chat = SecretChat::from_td_object(&data.secret_chat, &user);
                     entry.insert(secret_chat);
 
+                    let position = (list.len() - 1) as u32;
                     drop(list);
 
-                    let position = (self_.list.borrow().len() - 1) as u32;
                     self.items_changed(position, 0, 1);
                 }
             }

--- a/src/session/secret_chat_list.rs
+++ b/src/session/secret_chat_list.rs
@@ -103,10 +103,7 @@ impl SecretChatList {
             match list.entry(data.secret_chat.id) {
                 Entry::Occupied(entry) => entry.get().handle_update(update),
                 Entry::Vacant(entry) => {
-                    let user = self
-                        .session()
-                        .user_list()
-                        .get_or_create_user(data.secret_chat.user_id);
+                    let user = self.session().user_list().get(data.secret_chat.user_id);
                     let secret_chat = SecretChat::from_td_object(&data.secret_chat, &user);
                     entry.insert(secret_chat);
 

--- a/src/session/secret_chat_list.rs
+++ b/src/session/secret_chat_list.rs
@@ -90,9 +90,18 @@ impl SecretChatList {
         glib::Object::new(&[("session", session)]).expect("Failed to create SecretChatList")
     }
 
-    pub fn get(&self, id: i32) -> Option<SecretChat> {
+    /// Return the `SecretChat` of the specified `id`. Panics if the secret chat is not present.
+    /// Note that TDLib guarantees that types are always returned before their ids,
+    /// so if you use an `id` returned by TDLib, it should be expected that the
+    /// relative `SecretChat` exists in the list.
+    pub fn get(&self, id: i32) -> SecretChat {
         let self_ = imp::SecretChatList::from_instance(self);
-        self_.list.borrow().get(&id).cloned()
+        self_
+            .list
+            .borrow()
+            .get(&id)
+            .expect("Failed to get expected SecretChat")
+            .to_owned()
     }
 
     pub fn handle_update(&self, update: &Update) {

--- a/src/session/sidebar/mod.rs
+++ b/src/session/sidebar/mod.rs
@@ -205,7 +205,7 @@ impl Sidebar {
                             let chat_list = session.chat_list();
 
                             self_.already_searched_users.borrow_mut().extend(chats.chat_ids.iter()
-                                .filter_map(|id| chat_list.get_chat(*id))
+                                .map(|id| chat_list.get(*id))
                                 .filter_map(|chat| match chat.type_() {
                                     ChatType::Private(user) => Some(user.id()),
                                     _ => None
@@ -356,8 +356,8 @@ impl Sidebar {
                                 },
                                 clone!(@weak obj, @weak session => move |result| async move {
                                     if let Ok(enums::Chat::Chat(chat)) = result {
-                                        let chat = session.chat_list().get_chat(chat.id);
-                                        obj.set_selected_chat(chat);
+                                        let chat = session.chat_list().get(chat.id);
+                                        obj.set_selected_chat(Some(chat));
                                     }
                                 }),
                             );

--- a/src/session/sidebar/row.rs
+++ b/src/session/sidebar/row.rs
@@ -446,7 +446,7 @@ fn stringify_message(message: Message) -> String {
                 let members = data
                     .member_user_ids
                     .into_iter()
-                    .map(|user_id| user_list.get_or_create_user(user_id))
+                    .map(|user_id| user_list.get(user_id))
                     .map(|user| stringify_user(&user, true))
                     .collect::<Vec<_>>();
 
@@ -486,11 +486,7 @@ fn stringify_message(message: Message) -> String {
                     "{} removed {}",
                     sender_name(message.sender(), true),
                     stringify_user(
-                        &message
-                            .chat()
-                            .session()
-                            .user_list()
-                            .get_or_create_user(data.user_id),
+                        &message.chat().session().user_list().get(data.user_id),
                         true
                     )
                 )

--- a/src/session/supergroup_list.rs
+++ b/src/session/supergroup_list.rs
@@ -58,9 +58,18 @@ impl SupergroupList {
         glib::Object::new(&[]).expect("Failed to create SupergroupList")
     }
 
-    pub fn get(&self, id: i64) -> Option<Supergroup> {
+    /// Return the `Supergroup` of the specified `id`. Panics if the supergroup is not present.
+    /// Note that TDLib guarantees that types are always returned before their ids,
+    /// so if you use an `id` returned by TDLib, it should be expected that the
+    /// relative `Supergroup` exists in the list.
+    pub fn get(&self, id: i64) -> Supergroup {
         let self_ = imp::SupergroupList::from_instance(self);
-        self_.list.borrow().get(&id).cloned()
+        self_
+            .list
+            .borrow()
+            .get(&id)
+            .expect("Failed to get expected Supergroup")
+            .to_owned()
     }
 
     pub fn handle_update(&self, update: &Update) {

--- a/src/session/supergroup_list.rs
+++ b/src/session/supergroup_list.rs
@@ -83,9 +83,9 @@ impl SupergroupList {
                     let supergroup = Supergroup::from_td_object(&data.supergroup);
                     entry.insert(supergroup);
 
+                    let position = (list.len() - 1) as u32;
                     drop(list);
 
-                    let position = (self_.list.borrow().len() - 1) as u32;
                     self.items_changed(position, 0, 1);
                 }
             }

--- a/src/session/user.rs
+++ b/src/session/user.rs
@@ -1,6 +1,6 @@
 use gtk::{glib, prelude::*, subclass::prelude::*};
 use tdgrand::enums::{Update, UserStatus, UserType};
-use tdgrand::types::User as TelegramUser;
+use tdgrand::types::User as TdUser;
 
 use crate::session::Avatar;
 use crate::Session;
@@ -158,12 +158,7 @@ glib::wrapper! {
 }
 
 impl User {
-    pub fn new(id: i64, session: &Session) -> Self {
-        let avatar = Avatar::new(session);
-        glib::Object::new(&[("id", &id), ("avatar", &avatar)]).expect("Failed to create User")
-    }
-
-    pub fn from_td_object(user: TelegramUser, session: &Session) -> Self {
+    pub fn from_td_object(user: TdUser, session: &Session) -> Self {
         let avatar = Avatar::new(session);
         avatar.update_from_user_photo(user.profile_photo);
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -289,7 +289,7 @@ impl Window {
 fn sender_name(sender: &TelegramMessageSender, chat: &Chat) -> String {
     match sender {
         TelegramMessageSender::User(data) => {
-            let user = chat.session().user_list().get_or_create_user(data.user_id);
+            let user = chat.session().user_list().get(data.user_id);
             format!("{} {}", user.first_name(), user.last_name())
                 .trim()
                 .into()

--- a/src/window.rs
+++ b/src/window.rs
@@ -221,7 +221,7 @@ impl Window {
 
         if let Some(ClientInfo::LoggedIn(session)) = self_.session_manager.client_info(client_id) {
             let app = self.application().unwrap();
-            let chat = session.chat_list().get_chat(chat_id).unwrap();
+            let chat = session.chat_list().get(chat_id);
 
             for notification in notifications {
                 let notification_id = notification.id;
@@ -295,7 +295,7 @@ fn sender_name(sender: &TelegramMessageSender, chat: &Chat) -> String {
                 .into()
         }
         TelegramMessageSender::Chat(data) => {
-            let chat = chat.session().chat_list().get_chat(data.chat_id).unwrap();
+            let chat = chat.session().chat_list().get(data.chat_id);
             chat.title()
         }
     }


### PR DESCRIPTION
TDLib docs states that all the updates related to new objects (e.g. Update::NewChat, Update::User, Update::Supergroup, ...) are always returned before their related ids are returned to the application. This means that we can expect that these objects always exist in the `get(id)` function of their related lists, without forcing us to `unwrap()` or `expect()` manually all the time.

This also removes the `get_or_create_user()`, created appositely for a crash happened in an old version of the app where for some reason a requested `User` wasn't present inside the list. I can't reproduce this anymore and, anyway, if it still happens it means that there's some underlying issue to solve.