### PR TITLE
session-manager: Create the Session from the beginning

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -272,9 +272,6 @@ mod imp {
                     }
                 }),
             );
-
-            obj.fetch_me();
-            obj.fetch_chats();
         }
     }
 
@@ -500,7 +497,7 @@ impl Session {
         self.notify("channel-chats-notification-settings")
     }
 
-    fn fetch_me(&self) {
+    pub fn fetch_me(&self) {
         let client_id = self.client_id();
         do_async(
             glib::PRIORITY_DEFAULT_IDLE,
@@ -520,7 +517,7 @@ impl Session {
         );
     }
 
-    fn fetch_chats(&self) {
+    pub fn fetch_chats(&self) {
         let client_id = self.imp().client_id.get();
         self.chat_list().fetch(client_id);
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -11,7 +11,7 @@ use tokio::task;
 
 use crate::config::{APP_ID, PROFILE};
 use crate::session::{Chat, ChatType};
-use crate::session_manager::{ClientInfo, SessionManager};
+use crate::session_manager::{ClientState, SessionManager};
 use crate::Application;
 use crate::RUNTIME;
 
@@ -213,11 +213,12 @@ impl Window {
         client_id: i32,
         chat_id: i64,
     ) {
-        if let Some(ClientInfo::LoggedIn(session)) =
-            self.imp().session_manager.client_info(client_id)
+        let client = self.imp().session_manager.client(client_id);
+        if let Some(ref client) =
+            client.filter(|client| matches!(client.state, ClientState::LoggedIn))
         {
             let app = self.application().unwrap();
-            let chat = session.chat_list().get(chat_id);
+            let chat = client.session.chat_list().get(chat_id);
 
             for notification in notifications {
                 let notification_id = notification.id;


### PR DESCRIPTION
In this way, we make sure that we don't miss updates that may arrive be-
fore `AuthorizationState::Ready`. This also fixes a crash that occurs
when a new session is added because the update of the own user is always
missed in this case.