### PR TITLE
Enhance the ci.yaml file a bit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,6 @@ jobs:
       options: --privileged
     steps:
       - uses: actions/checkout@v2
-      - name: Create dummy versions of configured file
-        run: |
-          sed \
-            -e 's/str =.*;/str = "";/g' \
-            -e 's/i32 =.*;/i32 = 0;/g' \
-            src/config.rs.in \
-            > src/config.rs
       - name: Build dependencies
         run: |
           flatpak-builder \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
         arch: [x86_64, aarch64]
       # Don't fail the whole workflow if one architecture fails
       fail-fast: false
+    needs: [rustfmt, clippy]
     steps:
       - uses: actions/checkout@v2
       # Docker is required by the docker/setup-qemu-action which enables emulation


### PR DESCRIPTION
The first commit removes the `sed` step for the `clippy` job, which isn't really needed.

The second commit only builds and deploys the flatpak if the `rustfmt` and `clippy` jobs succeed. I haven't measured, but I think the time for the CI to finish won't change in case of a success, as I assume resources are shared. In case one of the first jobs fails, it should even save resources as the flatpak doesn't need to be build anymore.
But we'll see whether this hypothesis is correct.