### PR TITLE
user: Set CONSTRUCT flag for properties where appropriate

### DIFF
--- a/src/session/user.rs
+++ b/src/session/user.rs
@@ -62,7 +62,7 @@ mod imp {
                         "first-name",
                         "First Name",
                         "The first name of this user",
-                        None,
+                        Some(""),
                         glib::ParamFlags::READWRITE
                             | glib::ParamFlags::CONSTRUCT
                             | glib::ParamFlags::EXPLICIT_NOTIFY,
@@ -71,7 +71,7 @@ mod imp {
                         "last-name",
                         "Last Name",
                         "The last name of this user",
-                        None,
+                        Some(""),
                         glib::ParamFlags::READWRITE
                             | glib::ParamFlags::CONSTRUCT
                             | glib::ParamFlags::EXPLICIT_NOTIFY,
@@ -80,7 +80,7 @@ mod imp {
                         "username",
                         "Username",
                         "The username of this user",
-                        None,
+                        Some(""),
                         glib::ParamFlags::READWRITE
                             | glib::ParamFlags::CONSTRUCT
                             | glib::ParamFlags::EXPLICIT_NOTIFY,
@@ -89,7 +89,7 @@ mod imp {
                         "phone-number",
                         "Phone Number",
                         "The phone number of this user",
-                        None,
+                        Some(""),
                         glib::ParamFlags::READWRITE
                             | glib::ParamFlags::CONSTRUCT
                             | glib::ParamFlags::EXPLICIT_NOTIFY,
@@ -125,10 +125,18 @@ mod imp {
             match pspec.name() {
                 "id" => self.id.set(value.get().unwrap()),
                 "type" => obj.set_type(value.get().unwrap()),
-                "first-name" => obj.set_first_name(value.get().unwrap()),
-                "last-name" => obj.set_last_name(value.get().unwrap()),
-                "username" => obj.set_username(value.get().unwrap()),
-                "phone-number" => obj.set_phone_number(value.get().unwrap()),
+                "first-name" => {
+                    obj.set_first_name(value.get::<Option<String>>().unwrap().unwrap_or_default())
+                }
+                "last-name" => {
+                    obj.set_last_name(value.get::<Option<String>>().unwrap().unwrap_or_default())
+                }
+                "username" => {
+                    obj.set_username(value.get::<Option<String>>().unwrap().unwrap_or_default())
+                }
+                "phone-number" => {
+                    obj.set_phone_number(value.get::<Option<String>>().unwrap().unwrap_or_default())
+                }
                 "avatar" => self.avatar.set(value.get().unwrap()).unwrap(),
                 "status" => obj.set_status(value.get().unwrap()),
                 _ => unimplemented!(),

--- a/src/session/user.rs
+++ b/src/session/user.rs
@@ -54,35 +54,45 @@ mod imp {
                         "Type",
                         "The type of this user",
                         BoxedUserType::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READWRITE
+                            | glib::ParamFlags::CONSTRUCT
+                            | glib::ParamFlags::EXPLICIT_NOTIFY,
                     ),
                     glib::ParamSpecString::new(
                         "first-name",
                         "First Name",
                         "The first name of this user",
                         None,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READWRITE
+                            | glib::ParamFlags::CONSTRUCT
+                            | glib::ParamFlags::EXPLICIT_NOTIFY,
                     ),
                     glib::ParamSpecString::new(
                         "last-name",
                         "Last Name",
                         "The last name of this user",
                         None,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READWRITE
+                            | glib::ParamFlags::CONSTRUCT
+                            | glib::ParamFlags::EXPLICIT_NOTIFY,
                     ),
                     glib::ParamSpecString::new(
                         "username",
                         "Username",
                         "The username of this user",
                         None,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READWRITE
+                            | glib::ParamFlags::CONSTRUCT
+                            | glib::ParamFlags::EXPLICIT_NOTIFY,
                     ),
                     glib::ParamSpecString::new(
                         "phone-number",
                         "Phone Number",
                         "The phone number of this user",
                         None,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READWRITE
+                            | glib::ParamFlags::CONSTRUCT
+                            | glib::ParamFlags::EXPLICIT_NOTIFY,
                     ),
                     glib::ParamSpecObject::new(
                         "avatar",
@@ -96,7 +106,9 @@ mod imp {
                         "Status",
                         "The status of this user",
                         BoxedUserStatus::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READWRITE
+                            | glib::ParamFlags::CONSTRUCT
+                            | glib::ParamFlags::EXPLICIT_NOTIFY,
                     ),
                 ]
             });
@@ -182,7 +194,6 @@ impl User {
                 self.set_username(data.user.username);
                 self.set_phone_number(data.user.phone_number);
                 self.set_status(BoxedUserStatus(data.user.status));
-
                 self.avatar()
                     .update_from_user_photo(data.user.profile_photo);
             }


### PR DESCRIPTION
This way we can reliably do unwrap on properties that we don't want to be nullable.

This should probably be done in other places too, but I will do that in another PR.