### PR TITLE
session: Set own user before showing the session

### DIFF
--- a/src/session/sidebar/avatar.rs
+++ b/src/session/sidebar/avatar.rs
@@ -173,26 +173,16 @@ impl Avatar {
             .session()
             .unwrap();
 
-        let user_expression = gtk::ConstantExpression::new(user);
-        let interlocutor_status_expression = user_expression.chain_property::<User>("status");
-        let me_expression = Session::this_expression("me");
-
+        let my_id = session.me().id();
         let user_id = user.id();
-        // TODO: Change `me` to a non-Option value when
-        // https://github.com/melix99/telegrand/pull/208 is merged
-        let is_online_binding = gtk::ClosureExpression::new::<bool, _, _>(
-            &[
-                me_expression.upcast(),
-                interlocutor_status_expression.upcast(),
-            ],
-            closure!(
-                |_: Session, me: Option<User>, interlocutor_status: BoxedUserStatus| {
-                    matches!(interlocutor_status.0, UserStatus::Online(_))
-                        && me.map(|me| me.id()).unwrap_or_default() != user_id
+        let is_online_binding = gtk::ObjectExpression::new(user)
+            .chain_property::<User>("status")
+            .chain_closure::<bool>(closure!(
+                |_: Session, interlocutor_status: BoxedUserStatus| {
+                    matches!(interlocutor_status.0, UserStatus::Online(_)) && my_id != user_id
                 }
-            ),
-        )
-        .bind(self, "is-online", Some(&session));
+            ))
+            .bind(self, "is-online", Some(&session));
 
         self.imp().binding.replace(Some(is_online_binding));
     }


### PR DESCRIPTION
@melix99 Perhaps we should be a little more pragmatic here after all. While I was working on #163, I realized that things get way too complicated. Especially, the chat history becomes unnecessarily complex if we need to rely on a `is_own_chat` expression for deciding whether to show avatars or sender names.

# Commit Message
```
This commit ensures that `Session::me()` always returns the own user
after the session has been added to the widget tree. This is the second
attempt of a pragmatic approach that prevents that a lot of things are
going to become too complicated. Especially, handling the chat history
for the own user would be a real nightmare.
```