### PR TITLE
login: Remove "empty-page" workaround

### DIFF
--- a/data/resources/ui/login.ui
+++ b/data/resources/ui/login.ui
@@ -9,209 +9,165 @@
   </object>
   <template class="Login" parent="AdwBin">
     <child>
-      <object class="GtkStack" id="main_stack">
-        <property name="transition-type">crossfade</property>
+      <object class="GtkBox" id="outer_box">
+        <property name="orientation">vertical</property>
+        <property name="visible">False</property>
         <child>
-          <object class="GtkStackPage">
-            <property name="name">empty-page</property>
-            <property name="child">
-              <object class="GtkHeaderBar">
-                <property name="valign">start</property>
-                <property name="title-widget">
-                  <object class="AdwBin"/>
-                </property>
-              </object>
-            </property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkStackPage">
-            <property name="name">login-flow-page</property>
-            <property name="child">
-              <object class="GtkBox">
-                <property name="orientation">vertical</property>
-                <child>
-                  <object class="GtkHeaderBar">
-                    <child type="start">
-                      <object class="GtkButton" id="previous_button">
-                        <property name="visible">False</property>
-                        <property name="action-name">login.previous</property>
+          <object class="GtkHeaderBar">
+            <child type="start">
+              <object class="GtkButton" id="previous_button">
+                <property name="visible">False</property>
+                <property name="action-name">login.previous</property>
+                <property name="child">
+                  <object class="GtkStack" id="previous_stack">
+                    <child>
+                      <object class="GtkStackPage">
+                        <property name="name">text</property>
                         <property name="child">
-                          <object class="GtkStack" id="previous_stack">
-                            <child>
-                              <object class="GtkStackPage">
-                                <property name="name">text</property>
-                                <property name="child">
-                                  <object class="GtkLabel">
-                                    <property name="use-underline">True</property>
-                                    <property name="label" translatable="yes">_Previous</property>
-                                  </object>
-                                </property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkStackPage">
-                                <property name="name">spinner</property>
-                                <property name="child">
-                                  <object class="GtkSpinner">
-                                    <property name="spinning">True</property>
-                                    <property name="valign">center</property>
-                                    <property name="halign">center</property>
-                                  </object>
-                                </property>
-                              </object>
-                            </child>
+                          <object class="GtkLabel">
+                            <property name="use-underline">True</property>
+                            <property name="label" translatable="yes">_Previous</property>
                           </object>
                         </property>
                       </object>
                     </child>
-                    <child type="end">
-                      <object class="GtkButton" id="next_button">
-                        <property name="action-name">login.next</property>
+                    <child>
+                      <object class="GtkStackPage">
+                        <property name="name">spinner</property>
                         <property name="child">
-                          <object class="GtkStack" id="next_stack">
-                            <child>
-                              <object class="GtkLabel" id="next_label">
-                                <property name="use-underline">True</property>
-                                <property name="label" translatable="yes">_Next</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSpinner" id="next_spinner">
-                                <property name="spinning">True</property>
-                                <property name="valign">center</property>
-                                <property name="halign">center</property>
-                              </object>
-                            </child>
+                          <object class="GtkSpinner">
+                            <property name="spinning">True</property>
+                            <property name="valign">center</property>
+                            <property name="halign">center</property>
                           </object>
                         </property>
-                        <style>
-                          <class name="suggested-action"/>
-                        </style>
                       </object>
                     </child>
                   </object>
-                </child>
-                <child>
-                  <object class="AdwLeaflet" id="content">
-                    <property name="can-unfold">False</property>
-                    <property name="vexpand">True</property>
+                </property>
+              </object>
+            </child>
+            <child type="end">
+              <object class="GtkButton" id="next_button">
+                <property name="action-name">login.next</property>
+                <property name="child">
+                  <object class="GtkStack" id="next_stack">
                     <child>
-                      <object class="AdwLeafletPage">
-                        <property name="name">phone-number-page</property>
+                      <object class="GtkLabel" id="next_label">
+                        <property name="use-underline">True</property>
+                        <property name="label" translatable="yes">_Next</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSpinner" id="next_spinner">
+                        <property name="spinning">True</property>
+                        <property name="valign">center</property>
+                        <property name="halign">center</property>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+                <style>
+                  <class name="suggested-action"/>
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwLeaflet" id="content">
+            <property name="can-unfold">False</property>
+            <property name="vexpand">True</property>
+            <child>
+              <object class="AdwLeafletPage">
+                <property name="name">phone-number-page</property>
+                <property name="child">
+                  <object class="AdwStatusPage">
+                    <property name="icon-name">user-available-symbolic</property>
+                    <property name="title" translatable="yes">Welcome to Telegrand</property>
+                    <child>
+                      <object class="AdwClamp">
+                        <property name="maximum-size">300</property>
+                        <property name="tightening-threshold">200</property>
                         <property name="child">
-                          <object class="AdwStatusPage">
-                            <property name="icon-name">user-available-symbolic</property>
-                            <property name="title" translatable="yes">Welcome to Telegrand</property>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">12</property>
                             <child>
-                              <object class="AdwClamp">
-                                <property name="maximum-size">300</property>
-                                <property name="tightening-threshold">200</property>
-                                <property name="child">
-                                  <object class="GtkBox">
-                                    <property name="orientation">vertical</property>
-                                    <property name="spacing">12</property>
+                              <object class="GtkListBox">
+                                <child>
+                                  <object class="GtkListBoxRow">
+                                    <property name="focusable">False</property>
+                                    <property name="selectable">False</property>
+                                    <property name="activatable">False</property>
+                                    <property name="child">
+                                      <object class="GtkEntry" id="phone_number_entry">
+                                        <property name="activates-default">True</property>
+                                        <property name="placeholder-text" translatable="yes">Phone Number</property>
+                                        <property name="margin-top">6</property>
+                                        <property name="margin-bottom">6</property>
+                                        <property name="margin-start">6</property>
+                                        <property name="margin-end">6</property>
+                                      </object>
+                                    </property>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="boxed-list"/>
+                                </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkListBox">
+                                <child>
+                                  <object class="AdwActionRow">
+                                    <property name="selectable">False</property>
+                                    <property name="activatable">True</property>
+                                    <property name="action-name">login.use-qr-code</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="title" translatable="yes">_Log in using QR code</property>
+                                    <property name="icon-name">scanner-symbolic</property>
                                     <child>
-                                      <object class="GtkListBox">
+                                      <object class="GtkStack" id="phone_number_use_qr_code_stack">
                                         <child>
-                                          <object class="GtkListBoxRow">
-                                            <property name="focusable">False</property>
-                                            <property name="selectable">False</property>
-                                            <property name="activatable">False</property>
+                                          <object class="GtkStackPage">
+                                            <property name="name">image</property>
                                             <property name="child">
-                                              <object class="GtkEntry" id="phone_number_entry">
-                                                <property name="activates-default">True</property>
-                                                <property name="placeholder-text" translatable="yes">Phone Number</property>
-                                                <property name="margin-top">6</property>
-                                                <property name="margin-bottom">6</property>
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
+                                              <object class="GtkImage">
+                                                <property name="icon_name">go-next-symbolic</property>
+                                                <style>
+                                                  <class name="dim-label"/>
+                                                </style>
                                               </object>
                                             </property>
                                           </object>
                                         </child>
-                                        <style>
-                                          <class name="boxed-list"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkListBox">
                                         <child>
-                                          <object class="AdwActionRow">
-                                            <property name="selectable">False</property>
-                                            <property name="activatable">True</property>
-                                            <property name="action-name">login.use-qr-code</property>
-                                            <property name="use-underline">True</property>
-                                            <property name="title" translatable="yes">_Log in using QR code</property>
-                                            <property name="icon-name">scanner-symbolic</property>
-                                            <child>
-                                              <object class="GtkStack" id="phone_number_use_qr_code_stack">
-                                                <child>
-                                                  <object class="GtkStackPage">
-                                                    <property name="name">image</property>
-                                                    <property name="child">
-                                                      <object class="GtkImage">
-                                                        <property name="icon_name">go-next-symbolic</property>
-                                                        <style>
-                                                          <class name="dim-label"/>
-                                                        </style>
-                                                      </object>
-                                                    </property>
-                                                  </object>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkStackPage">
-                                                    <property name="name">spinner</property>
-                                                    <property name="child">
-                                                      <object class="GtkSpinner">
-                                                        <property name="spinning">True</property>
-                                                        <property name="valign">center</property>
-                                                        <property name="halign">center</property>
-                                                      </object>
-                                                    </property>
-                                                  </object>
-                                                </child>
+                                          <object class="GtkStackPage">
+                                            <property name="name">spinner</property>
+                                            <property name="child">
+                                              <object class="GtkSpinner">
+                                                <property name="spinning">True</property>
+                                                <property name="valign">center</property>
+                                                <property name="halign">center</property>
                                               </object>
-                                            </child>
+                                            </property>
                                           </object>
                                         </child>
-                                        <style>
-                                          <class name="boxed-list"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="welcome_page_error_label">
-                                        <property name="visible">False</property>
-                                        <style>
-                                          <class name="error"/>
-                                        </style>
                                       </object>
                                     </child>
                                   </object>
-                                </property>
+                                </child>
+                                <style>
+                                  <class name="boxed-list"/>
+                                </style>
                               </object>
                             </child>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="AdwLeafletPage">
-                        <property name="name">qr-code-page</property>
-                        <property name="child">
-                          <object class="AdwStatusPage">
-                            <property name="title" translatable="yes">Scan Code</property>
-                            <property name="description" translatable="yes">Scan this code with another Telegram app logged into your account.</property>
                             <child>
-                              <object class="GtkImage" id="qr_code_image">
-                                <property name="halign">center</property>
-                                <property name="overflow">hidden</property>
-                                <property name="pixel-size">200</property>
+                              <object class="GtkLabel" id="welcome_page_error_label">
+                                <property name="visible">False</property>
                                 <style>
-                                  <class name="qr-code"/>
-                                  <class name="card"/>
+                                  <class name="error"/>
                                 </style>
                               </object>
                             </child>
@@ -219,492 +175,77 @@
                         </property>
                       </object>
                     </child>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwLeafletPage">
+                <property name="name">qr-code-page</property>
+                <property name="child">
+                  <object class="AdwStatusPage">
+                    <property name="title" translatable="yes">Scan Code</property>
+                    <property name="description" translatable="yes">Scan this code with another Telegram app logged into your account.</property>
                     <child>
-                      <object class="AdwLeafletPage">
-                        <property name="name">code-page</property>
-                        <property name="child">
-                          <object class="AdwStatusPage">
-                            <property name="icon-name">mail-send-symbolic</property>
-                            <property name="title" translatable="yes">Enter the Verification Code</property>
-                            <child>
-                              <object class="AdwClamp">
-                                <property name="maximum-size">300</property>
-                                <property name="tightening-threshold">200</property>
-                                <property name="child">
-                                  <object class="GtkBox">
-                                    <property name="orientation">vertical</property>
-                                    <property name="spacing">12</property>
-                                    <child>
-                                      <object class="GtkListBox">
-                                        <child>
-                                          <object class="GtkListBoxRow">
-                                            <property name="focusable">False</property>
-                                            <property name="selectable">False</property>
-                                            <property name="activatable">False</property>
-                                            <property name="child">
-                                              <object class="GtkEntry" id="code_entry">
-                                                <property name="activates-default">True</property>
-                                                <property name="placeholder-text" translatable="yes">Code</property>
-                                                <property name="margin-top">6</property>
-                                                <property name="margin-bottom">6</property>
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
-                                              </object>
-                                            </property>
-                                          </object>
-                                        </child>
-                                        <style>
-                                          <class name="boxed-list"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="code_error_label">
-                                        <property name="visible">False</property>
-                                        <style>
-                                          <class name="error"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </property>
-                              </object>
-                            </child>
-                          </object>
-                        </property>
+                      <object class="GtkImage" id="qr_code_image">
+                        <property name="halign">center</property>
+                        <property name="overflow">hidden</property>
+                        <property name="pixel-size">200</property>
+                        <style>
+                          <class name="qr-code"/>
+                          <class name="card"/>
+                        </style>
                       </object>
                     </child>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwLeafletPage">
+                <property name="name">code-page</property>
+                <property name="child">
+                  <object class="AdwStatusPage">
+                    <property name="icon-name">mail-send-symbolic</property>
+                    <property name="title" translatable="yes">Enter the Verification Code</property>
                     <child>
-                      <object class="AdwLeafletPage">
-                        <property name="name">registration-page</property>
+                      <object class="AdwClamp">
+                        <property name="maximum-size">300</property>
+                        <property name="tightening-threshold">200</property>
                         <property name="child">
                           <object class="GtkBox">
                             <property name="orientation">vertical</property>
+                            <property name="spacing">12</property>
                             <child>
-                              <object class="AdwStatusPage">
-                                <property name="icon-name">contact-new-symbolic</property>
-                                <property name="title" translatable="yes">Register New Account</property>
-                                <property name="vexpand">True</property>
+                              <object class="GtkListBox">
                                 <child>
-                                  <object class="AdwClamp">
-                                    <property name="maximum-size">300</property>
-                                    <property name="tightening-threshold">200</property>
+                                  <object class="GtkListBoxRow">
+                                    <property name="focusable">False</property>
+                                    <property name="selectable">False</property>
+                                    <property name="activatable">False</property>
                                     <property name="child">
-                                      <object class="GtkBox">
-                                        <property name="orientation">vertical</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkListBox">
-                                            <child>
-                                              <object class="GtkListBoxRow">
-                                                <property name="focusable">False</property>
-                                                <property name="selectable">False</property>
-                                                <property name="activatable">False</property>
-                                                <property name="child">
-                                                  <object class="GtkEntry" id="registration_first_name_entry">
-                                                    <property name="activates-default">True</property>
-                                                    <property name="placeholder-text" translatable="yes">First Name</property>
-                                                    <property name="margin-top">6</property>
-                                                    <property name="margin-bottom">6</property>
-                                                    <property name="margin-start">6</property>
-                                                    <property name="margin-end">6</property>
-                                                  </object>
-                                                </property>
-                                              </object>
-                                            </child>
-                                            <child>
-                                              <object class="GtkListBoxRow">
-                                                <property name="focusable">False</property>
-                                                <property name="selectable">False</property>
-                                                <property name="activatable">False</property>
-                                                <property name="child">
-                                                  <object class="GtkEntry" id="registration_last_name_entry">
-                                                    <property name="activates-default">True</property>
-                                                    <property name="placeholder-text" translatable="yes">Last Name</property>
-                                                    <property name="margin-top">6</property>
-                                                    <property name="margin-bottom">6</property>
-                                                    <property name="margin-start">6</property>
-                                                    <property name="margin-end">6</property>
-                                                  </object>
-                                                </property>
-                                              </object>
-                                            </child>
-                                            <style>
-                                              <class name="boxed-list"/>
-                                            </style>
-                                          </object>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="registration_error_label">
-                                            <property name="visible">False</property>
-                                            <style>
-                                              <class name="error"/>
-                                            </style>
-                                          </object>
-                                        </child>
+                                      <object class="GtkEntry" id="code_entry">
+                                        <property name="activates-default">True</property>
+                                        <property name="placeholder-text" translatable="yes">Code</property>
+                                        <property name="margin-top">6</property>
+                                        <property name="margin-bottom">6</property>
+                                        <property name="margin-start">6</property>
+                                        <property name="margin-end">6</property>
                                       </object>
                                     </property>
                                   </object>
                                 </child>
+                                <style>
+                                  <class name="boxed-list"/>
+                                </style>
                               </object>
                             </child>
                             <child>
-                              <object class="AdwClamp">
-                                <property name="maximum-size">300</property>
-                                <property name="tightening-threshold">200</property>
-                                <property name="child">
-                                  <object class="GtkLabel" id="tos_label">
-                                    <property name="ellipsize">middle</property>
-                                    <property name="justify">center</property>
-                                    <property name="margin-bottom">18</property>
-                                    <property name="use-markup">True</property>
-                                    <property name="valign">end</property>
-                                    <property name="label" translatable="yes">By signing up,
-you agree to the &lt;a href=&quot;&quot;&gt;Terms of Service&lt;/a&gt;.</property>
-                                  </object>
-                                </property>
-                              </object>
-                            </child>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="AdwLeafletPage">
-                        <property name="name">password-page</property>
-                        <property name="child">
-                          <object class="AdwStatusPage">
-                            <property name="icon-name">dialog-password-symbolic</property>
-                            <property name="title" translatable="yes">Enter Your Password</property>
-                            <child>
-                              <object class="AdwClamp">
-                                <property name="maximum-size">300</property>
-                                <property name="tightening-threshold">200</property>
-                                <property name="child">
-                                  <object class="GtkBox">
-                                    <property name="orientation">vertical</property>
-                                    <property name="spacing">12</property>
-                                    <child>
-                                      <object class="GtkListBox">
-                                        <child>
-                                          <object class="GtkListBoxRow">
-                                            <property name="focusable">False</property>
-                                            <property name="selectable">False</property>
-                                            <property name="activatable">False</property>
-                                            <property name="child">
-                                              <object class="GtkPasswordEntry" id="password_entry">
-                                                <property name="activates-default">True</property>
-                                                <property name="placeholder-text" translatable="yes">Password</property>
-                                                <property name="show-peek-icon">True</property>
-                                                <property name="margin-top">6</property>
-                                                <property name="margin-bottom">6</property>
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
-                                              </object>
-                                            </property>
-                                          </object>
-                                        </child>
-                                        <child>
-                                          <object class="AdwActionRow" id="password_hint_action_row">
-                                            <property name="focusable">False</property>
-                                            <property name="selectable">False</property>
-                                            <property name="activatable">False</property>
-                                            <property name="title" translatable="yes">Hint</property>
-                                            <child>
-                                              <object class="GtkLabel" id="password_hint_label">
-                                                <style>
-                                                  <class name="dim-label"/>
-                                                </style>
-                                              </object>
-                                            </child>
-                                          </object>
-                                        </child>
-                                        <style>
-                                          <class name="boxed-list"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkListBox">
-                                        <child>
-                                          <object class="AdwActionRow">
-                                            <property name="selectable">False</property>
-                                            <property name="activatable">True</property>
-                                            <property name="action-name">login.go-to-forgot-password-page</property>
-                                            <property name="use-underline">True</property>
-                                            <property name="title" translatable="yes">_Forgot password?</property>
-                                            <child>
-                                              <object class="GtkImage">
-                                                <property name="icon_name">go-next-symbolic</property>
-                                                <style>
-                                                  <class name="dim-label"/>
-                                                </style>
-                                              </object>
-                                            </child>
-                                          </object>
-                                        </child>
-                                        <style>
-                                          <class name="boxed-list"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="password_error_label">
-                                        <property name="visible">False</property>
-                                        <style>
-                                          <class name="error"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </property>
-                              </object>
-                            </child>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="AdwLeafletPage">
-                        <property name="name">password-forgot-page</property>
-                        <property name="child">
-                          <object class="GtkScrolledWindow">
-                            <property name="child">
-                              <object class="GtkBox">
-                                <property name="orientation">vertical</property>
-                                <property name="valign">center</property>
-                                <!--  Mimick the status page margins. -->
-                                <property name="margin-top">36</property>
-                                <property name="margin-bottom">36</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-end">12</property>
-                                <property name="spacing">36</property>
-                                <child>
-                                  <object class="GtkBox" id="password_recovery_code_send_box">
-                                    <property name="orientation">vertical</property>
-                                    <child>
-                                      <object class="AdwClamp">
-                                        <property name="child">
-                                          <object class="GtkBox">
-                                            <property name="orientation">vertical</property>
-                                            <property name="valign">center</property>
-                                            <child>
-                                              <object class="GtkLabel">
-                                                <property name="wrap">True</property>
-                                                <property name="wrap-mode">word-char</property>
-                                                <property name="justify">center</property>
-                                                <!--  Mimick the status page title margins. -->
-                                                <property name="margin-bottom">12</property>
-                                                <property name="label" translatable="yes">Use Recovery Code</property>
-                                                <style>
-                                                  <class name="title-1"/>
-                                                </style>
-                                              </object>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel">
-                                                <property name="wrap">True</property>
-                                                <property name="wrap-mode">word-char</property>
-                                                <property name="justify">center</property>
-                                                <!--  Mimick the status page description margins. -->
-                                                <property name="margin-bottom">36</property>
-                                                <property name="label" translatable="yes">When you set your cloud password, you provided a recovery email address. We can send you a code to this email address that you can use to reset your password.</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                        </property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="AdwClamp">
-                                        <property name="maximum-size">300</property>
-                                        <property name="tightening-threshold">200</property>
-                                        <property name="child">
-                                          <object class="GtkListBox">
-                                            <child>
-                                              <object class="AdwActionRow">
-                                                <property name="selectable">False</property>
-                                                <property name="activatable">True</property>
-                                                <property name="action-name">login.recover-password</property>
-                                                <property name="use-underline">True</property>
-                                                <property name="title" translatable="yes">_Send recovery code</property>
-                                                <child>
-                                                  <object class="GtkStack" id="password_send_code_stack">
-                                                    <child>
-                                                      <object class="GtkStackPage">
-                                                        <property name="name">image</property>
-                                                        <property name="child">
-                                                          <object class="GtkImage">
-                                                            <property name="icon_name">go-next-symbolic</property>
-                                                            <style>
-                                                              <class name="dim-label"/>
-                                                            </style>
-                                                          </object>
-                                                        </property>
-                                                      </object>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkStackPage">
-                                                        <property name="name">spinner</property>
-                                                        <property name="child">
-                                                          <object class="GtkSpinner">
-                                                            <property name="spinning">True</property>
-                                                            <property name="valign">center</property>
-                                                            <property name="halign">center</property>
-                                                          </object>
-                                                        </property>
-                                                      </object>
-                                                    </child>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                            </child>
-                                            <style>
-                                              <class name="boxed-list"/>
-                                            </style>
-                                          </object>
-                                        </property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSeparator">
-                                        <!--  Mimick the status page margins. -->
-                                        <property name="margin-top">36</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="orientation">vertical</property>
-                                    <child>
-                                      <object class="AdwClamp">
-                                        <property name="child">
-                                          <object class="GtkBox">
-                                            <property name="orientation">vertical</property>
-                                            <child>
-                                              <object class="GtkLabel">
-                                                <property name="wrap">True</property>
-                                                <property name="wrap-mode">word-char</property>
-                                                <property name="justify">center</property>
-                                                <!--  Mimick the status page title margins. -->
-                                                <property name="margin-bottom">12</property>
-                                                <property name="label" translatable="yes">Account Deletion</property>
-                                                <style>
-                                                  <class name="title-1"/>
-                                                </style>
-                                              </object>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="account_deletion_description_label">
-                                                <property name="wrap">True</property>
-                                                <property name="wrap-mode">word-char</property>
-                                                <property name="justify">center</property>
-                                                <!--  Mimick the status page description margins. -->
-                                                <property name="margin-bottom">36</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                        </property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="AdwClamp">
-                                        <property name="maximum-size">300</property>
-                                        <property name="tightening-threshold">200</property>
-                                        <property name="child">
-                                          <object class="GtkButton">
-                                            <property name="action-name">login.show-delete-account-dialog</property>
-                                            <property name="use-underline">True</property>
-                                            <property name="label" translatable="yes">_Delete Account</property>
-                                            <style>
-                                              <class name="destructive-action"/>
-                                            </style>
-                                          </object>
-                                        </property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="AdwLeafletPage">
-                        <property name="name">password-recovery-page</property>
-                        <property name="child">
-                          <object class="AdwStatusPage" id="password_recovery_status_page">
-                            <property name="icon-name">mail-unread-symbolic</property>
-                            <property name="title" translatable="yes">Enter the Code Sent by E-Mail</property>
-                            <child>
-                              <object class="AdwClamp">
-                                <property name="maximum-size">300</property>
-                                <property name="tightening-threshold">200</property>
-                                <property name="child">
-                                  <object class="GtkBox">
-                                    <property name="orientation">vertical</property>
-                                    <property name="spacing">12</property>
-                                    <child>
-                                      <object class="GtkListBox">
-                                        <child>
-                                          <object class="GtkListBoxRow">
-                                            <property name="focusable">False</property>
-                                            <property name="selectable">False</property>
-                                            <property name="activatable">False</property>
-                                            <property name="child">
-                                              <object class="GtkEntry" id="password_recovery_code_entry">
-                                                <property name="activates-default">True</property>
-                                                <property name="placeholder-text" translatable="yes">Code</property>
-                                                <property name="margin-top">6</property>
-                                                <property name="margin-bottom">6</property>
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
-                                              </object>
-                                            </property>
-                                          </object>
-                                        </child>
-                                        <style>
-                                          <class name="boxed-list"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkListBox">
-                                        <child>
-                                          <object class="AdwActionRow">
-                                            <property name="selectable">False</property>
-                                            <property name="activatable">True</property>
-                                            <property name="action-name">login.show-no-email-access-dialog</property>
-                                            <property name="use-underline">True</property>
-                                            <property name="title" translatable="yes">_Unable to access your email?</property>
-                                            <child>
-                                              <object class="GtkImage">
-                                                <property name="icon_name">go-next-symbolic</property>
-                                                <style>
-                                                  <class name="dim-label"/>
-                                                </style>
-                                              </object>
-                                            </child>
-                                          </object>
-                                        </child>
-                                        <style>
-                                          <class name="boxed-list"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="password_recovery_error_label">
-                                        <property name="visible">False</property>
-                                        <style>
-                                          <class name="error"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </property>
+                              <object class="GtkLabel" id="code_error_label">
+                                <property name="visible">False</property>
+                                <style>
+                                  <class name="error"/>
+                                </style>
                               </object>
                             </child>
                           </object>
@@ -712,9 +253,446 @@ you agree to the &lt;a href=&quot;&quot;&gt;Terms of Service&lt;/a&gt;.</propert
                       </object>
                     </child>
                   </object>
-                </child>
+                </property>
               </object>
-            </property>
+            </child>
+            <child>
+              <object class="AdwLeafletPage">
+                <property name="name">registration-page</property>
+                <property name="child">
+                  <object class="GtkBox">
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="AdwStatusPage">
+                        <property name="icon-name">contact-new-symbolic</property>
+                        <property name="title" translatable="yes">Register New Account</property>
+                        <property name="vexpand">True</property>
+                        <child>
+                          <object class="AdwClamp">
+                            <property name="maximum-size">300</property>
+                            <property name="tightening-threshold">200</property>
+                            <property name="child">
+                              <object class="GtkBox">
+                                <property name="orientation">vertical</property>
+                                <property name="spacing">12</property>
+                                <child>
+                                  <object class="GtkListBox">
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="focusable">False</property>
+                                        <property name="selectable">False</property>
+                                        <property name="activatable">False</property>
+                                        <property name="child">
+                                          <object class="GtkEntry" id="registration_first_name_entry">
+                                            <property name="activates-default">True</property>
+                                            <property name="placeholder-text" translatable="yes">First Name</property>
+                                            <property name="margin-top">6</property>
+                                            <property name="margin-bottom">6</property>
+                                            <property name="margin-start">6</property>
+                                            <property name="margin-end">6</property>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkListBoxRow">
+                                        <property name="focusable">False</property>
+                                        <property name="selectable">False</property>
+                                        <property name="activatable">False</property>
+                                        <property name="child">
+                                          <object class="GtkEntry" id="registration_last_name_entry">
+                                            <property name="activates-default">True</property>
+                                            <property name="placeholder-text" translatable="yes">Last Name</property>
+                                            <property name="margin-top">6</property>
+                                            <property name="margin-bottom">6</property>
+                                            <property name="margin-start">6</property>
+                                            <property name="margin-end">6</property>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <style>
+                                      <class name="boxed-list"/>
+                                    </style>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="registration_error_label">
+                                    <property name="visible">False</property>
+                                    <style>
+                                      <class name="error"/>
+                                    </style>
+                                  </object>
+                                </child>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwClamp">
+                        <property name="maximum-size">300</property>
+                        <property name="tightening-threshold">200</property>
+                        <property name="child">
+                          <object class="GtkLabel" id="tos_label">
+                            <property name="ellipsize">middle</property>
+                            <property name="justify">center</property>
+                            <property name="margin-bottom">18</property>
+                            <property name="use-markup">True</property>
+                            <property name="valign">end</property>
+                            <property name="label" translatable="yes">By signing up,
+you agree to the &lt;a href=&quot;&quot;&gt;Terms of Service&lt;/a&gt;.</property>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwLeafletPage">
+                <property name="name">password-page</property>
+                <property name="child">
+                  <object class="AdwStatusPage">
+                    <property name="icon-name">dialog-password-symbolic</property>
+                    <property name="title" translatable="yes">Enter Your Password</property>
+                    <child>
+                      <object class="AdwClamp">
+                        <property name="maximum-size">300</property>
+                        <property name="tightening-threshold">200</property>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkListBox">
+                                <child>
+                                  <object class="GtkListBoxRow">
+                                    <property name="focusable">False</property>
+                                    <property name="selectable">False</property>
+                                    <property name="activatable">False</property>
+                                    <property name="child">
+                                      <object class="GtkPasswordEntry" id="password_entry">
+                                        <property name="activates-default">True</property>
+                                        <property name="placeholder-text" translatable="yes">Password</property>
+                                        <property name="show-peek-icon">True</property>
+                                        <property name="margin-top">6</property>
+                                        <property name="margin-bottom">6</property>
+                                        <property name="margin-start">6</property>
+                                        <property name="margin-end">6</property>
+                                      </object>
+                                    </property>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="AdwActionRow" id="password_hint_action_row">
+                                    <property name="focusable">False</property>
+                                    <property name="selectable">False</property>
+                                    <property name="activatable">False</property>
+                                    <property name="title" translatable="yes">Hint</property>
+                                    <child>
+                                      <object class="GtkLabel" id="password_hint_label">
+                                        <style>
+                                          <class name="dim-label"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="boxed-list"/>
+                                </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkListBox">
+                                <child>
+                                  <object class="AdwActionRow">
+                                    <property name="selectable">False</property>
+                                    <property name="activatable">True</property>
+                                    <property name="action-name">login.go-to-forgot-password-page</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="title" translatable="yes">_Forgot password?</property>
+                                    <child>
+                                      <object class="GtkImage">
+                                        <property name="icon_name">go-next-symbolic</property>
+                                        <style>
+                                          <class name="dim-label"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="boxed-list"/>
+                                </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="password_error_label">
+                                <property name="visible">False</property>
+                                <style>
+                                  <class name="error"/>
+                                </style>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwLeafletPage">
+                <property name="name">password-forgot-page</property>
+                <property name="child">
+                  <object class="GtkScrolledWindow">
+                    <property name="child">
+                      <object class="GtkBox">
+                        <property name="orientation">vertical</property>
+                        <property name="valign">center</property>
+                        <!--  Mimick the status page margins. -->
+                        <property name="margin-top">36</property>
+                        <property name="margin-bottom">36</property>
+                        <property name="margin-start">12</property>
+                        <property name="margin-end">12</property>
+                        <property name="spacing">36</property>
+                        <child>
+                          <object class="GtkBox" id="password_recovery_code_send_box">
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="AdwClamp">
+                                <property name="child">
+                                  <object class="GtkBox">
+                                    <property name="orientation">vertical</property>
+                                    <property name="valign">center</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="wrap">True</property>
+                                        <property name="wrap-mode">word-char</property>
+                                        <property name="justify">center</property>
+                                        <!--  Mimick the status page title margins. -->
+                                        <property name="margin-bottom">12</property>
+                                        <property name="label" translatable="yes">Use Recovery Code</property>
+                                        <style>
+                                          <class name="title-1"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="wrap">True</property>
+                                        <property name="wrap-mode">word-char</property>
+                                        <property name="justify">center</property>
+                                        <!--  Mimick the status page description margins. -->
+                                        <property name="margin-bottom">36</property>
+                                        <property name="label" translatable="yes">When you set your cloud password, you provided a recovery email address. We can send you a code to this email address that you can use to reset your password.</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwClamp">
+                                <property name="maximum-size">300</property>
+                                <property name="tightening-threshold">200</property>
+                                <property name="child">
+                                  <object class="GtkListBox">
+                                    <child>
+                                      <object class="AdwActionRow">
+                                        <property name="selectable">False</property>
+                                        <property name="activatable">True</property>
+                                        <property name="action-name">login.recover-password</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="title" translatable="yes">_Send recovery code</property>
+                                        <child>
+                                          <object class="GtkStack" id="password_send_code_stack">
+                                            <child>
+                                              <object class="GtkStackPage">
+                                                <property name="name">image</property>
+                                                <property name="child">
+                                                  <object class="GtkImage">
+                                                    <property name="icon_name">go-next-symbolic</property>
+                                                    <style>
+                                                      <class name="dim-label"/>
+                                                    </style>
+                                                  </object>
+                                                </property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkStackPage">
+                                                <property name="name">spinner</property>
+                                                <property name="child">
+                                                  <object class="GtkSpinner">
+                                                    <property name="spinning">True</property>
+                                                    <property name="valign">center</property>
+                                                    <property name="halign">center</property>
+                                                  </object>
+                                                </property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <style>
+                                      <class name="boxed-list"/>
+                                    </style>
+                                  </object>
+                                </property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <!--  Mimick the status page margins. -->
+                                <property name="margin-top">36</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="AdwClamp">
+                                <property name="child">
+                                  <object class="GtkBox">
+                                    <property name="orientation">vertical</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="wrap">True</property>
+                                        <property name="wrap-mode">word-char</property>
+                                        <property name="justify">center</property>
+                                        <!--  Mimick the status page title margins. -->
+                                        <property name="margin-bottom">12</property>
+                                        <property name="label" translatable="yes">Account Deletion</property>
+                                        <style>
+                                          <class name="title-1"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="account_deletion_description_label">
+                                        <property name="wrap">True</property>
+                                        <property name="wrap-mode">word-char</property>
+                                        <property name="justify">center</property>
+                                        <!--  Mimick the status page description margins. -->
+                                        <property name="margin-bottom">36</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwClamp">
+                                <property name="maximum-size">300</property>
+                                <property name="tightening-threshold">200</property>
+                                <property name="child">
+                                  <object class="GtkButton">
+                                    <property name="action-name">login.show-delete-account-dialog</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="label" translatable="yes">_Delete Account</property>
+                                    <style>
+                                      <class name="destructive-action"/>
+                                    </style>
+                                  </object>
+                                </property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </property>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwLeafletPage">
+                <property name="name">password-recovery-page</property>
+                <property name="child">
+                  <object class="AdwStatusPage" id="password_recovery_status_page">
+                    <property name="icon-name">mail-unread-symbolic</property>
+                    <property name="title" translatable="yes">Enter the Code Sent by E-Mail</property>
+                    <child>
+                      <object class="AdwClamp">
+                        <property name="maximum-size">300</property>
+                        <property name="tightening-threshold">200</property>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkListBox">
+                                <child>
+                                  <object class="GtkListBoxRow">
+                                    <property name="focusable">False</property>
+                                    <property name="selectable">False</property>
+                                    <property name="activatable">False</property>
+                                    <property name="child">
+                                      <object class="GtkEntry" id="password_recovery_code_entry">
+                                        <property name="activates-default">True</property>
+                                        <property name="placeholder-text" translatable="yes">Code</property>
+                                        <property name="margin-top">6</property>
+                                        <property name="margin-bottom">6</property>
+                                        <property name="margin-start">6</property>
+                                        <property name="margin-end">6</property>
+                                      </object>
+                                    </property>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="boxed-list"/>
+                                </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkListBox">
+                                <child>
+                                  <object class="AdwActionRow">
+                                    <property name="selectable">False</property>
+                                    <property name="activatable">True</property>
+                                    <property name="action-name">login.show-no-email-access-dialog</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="title" translatable="yes">_Unable to access your email?</property>
+                                    <child>
+                                      <object class="GtkImage">
+                                        <property name="icon_name">go-next-symbolic</property>
+                                        <style>
+                                          <class name="dim-label"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="boxed-list"/>
+                                </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="password_recovery_error_label">
+                                <property name="visible">False</property>
+                                <style>
+                                  <class name="error"/>
+                                </style>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/src/login.rs
+++ b/src/login.rs
@@ -31,7 +31,7 @@ mod imp {
         pub has_recovery_email_address: Cell<bool>,
         pub password_recovery_expired: Cell<bool>,
         #[template_child]
-        pub main_stack: TemplateChild<gtk::Stack>,
+        pub outer_box: TemplateChild<gtk::Box>,
         #[template_child]
         pub previous_button: TemplateChild<gtk::Button>,
         #[template_child]
@@ -194,10 +194,6 @@ impl Login {
         imp.client_id.set(client_id);
 
         imp.session.replace(Some(session));
-
-        // We don't know what login page to show at this point, so we show an empty page until we
-        // receive an AuthenticationState that will eventually show the related login page.
-        imp.main_stack.set_visible_child_name("empty-page");
 
         imp.phone_number_entry.set_text("");
         imp.registration_first_name_entry.set_text("");
@@ -380,6 +376,9 @@ impl Login {
                     imp.session.take().unwrap(),
                     true,
                 );
+
+                // Make everything invisible.
+                imp.outer_box.set_visible(false);
             }
             _ => {}
         }
@@ -410,9 +409,8 @@ impl Login {
 
         imp.content.set_visible_child_name(page_name);
 
-        // After we've transitioned to a new login page, let's be sure that we set the stack here
-        // to an ancestor widget of the login leaflet because we might still be in the empty page.
-        imp.main_stack.set_visible_child_name("login-flow-page");
+        // Make sure everything is visible.
+        imp.outer_box.set_visible(true);
 
         self.unfreeze();
         if let Some(widget_to_focus) = widget_to_focus {


### PR DESCRIPTION
This commit removes the workaround of showing an empty stack page for
hiding the login view on start-up, which we introduced in #99.
~~This isn't needed anymore because since #166 we bypass the login view
for already logged-in sessions.~~
Instead, we now simply make the login view invisible, which has the same
effect but is less complex.