### PR TITLE
Reverse the chat history to fix scrolling problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following packages are required to build Telegrand:
 
 - meson
 - cargo
-- GTK >= 4.6.0
+- GTK >= 4.6.0 (with the patch included in the build-aux directory)
 - libadwaita
 - TDLib 1.8.2
 - [Telegram API Credentials](https://my.telegram.org/) (optional, but recommended)

--- a/build-aux/com.github.melix99.telegrand.Devel.json
+++ b/build-aux/com.github.melix99.telegrand.Devel.json
@@ -31,6 +31,21 @@
     ],
     "modules": [
         {
+            "name": "gtk",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/gtk.git",
+                    "tag": "4.6.4"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "gtk-reversed-list.patch"
+                }
+            ]
+        },
+        {
             "name": "tdlib-prebuilt",
             "only-arches": [ "x86_64", "aarch64" ],
             "buildsystem": "simple",

--- a/build-aux/gtk-reversed-list.patch
+++ b/build-aux/gtk-reversed-list.patch
@@ -1,0 +1,234 @@
+From 618badf6e0b2843aa1060e6426d6839e8744f4ad Mon Sep 17 00:00:00 2001
+From: Marco Melorio <marco.melorio@protonmail.com>
+Date: Mon, 7 Feb 2022 19:03:02 +0100
+Subject: [PATCH 1/1] listbase: Add "reversed" property
+
+---
+ gtk/gtklistbase.c | 115 ++++++++++++++++++++++++++++++++++++----------
+ 1 file changed, 90 insertions(+), 25 deletions(-)
+
+diff --git a/gtk/gtklistbase.c b/gtk/gtklistbase.c
+index e4013df05c..9637e74ffa 100644
+--- a/gtk/gtklistbase.c
++++ b/gtk/gtklistbase.c
+@@ -57,6 +57,7 @@ struct _GtkListBasePrivate
+   GtkListItemManager *item_manager;
+   GtkSelectionModel *model;
+   GtkOrientation orientation;
++  gboolean reversed;
+   GtkAdjustment *adjustment[2];
+   GtkScrollablePolicy scroll_policy[2];
+ 
+@@ -87,6 +88,7 @@ enum
+   PROP_HADJUSTMENT,
+   PROP_HSCROLL_POLICY,
+   PROP_ORIENTATION,
++  PROP_REVERSED,
+   PROP_VADJUSTMENT,
+   PROP_VSCROLL_POLICY,
+ 
+@@ -138,10 +140,23 @@ static gboolean
+ gtk_list_base_adjustment_is_flipped (GtkListBase    *self,
+                                      GtkOrientation  orientation)
+ {
+-  if (orientation == GTK_ORIENTATION_VERTICAL)
+-    return FALSE;
++  GtkListBasePrivate *priv = gtk_list_base_get_instance_private (self);
++  gboolean rtl = gtk_widget_get_direction (GTK_WIDGET (self)) == GTK_TEXT_DIR_RTL;
+ 
+-  return gtk_widget_get_direction (GTK_WIDGET (self)) == GTK_TEXT_DIR_RTL;
++  if (priv->orientation == GTK_ORIENTATION_VERTICAL)
++    {
++      if (orientation == GTK_ORIENTATION_VERTICAL)
++        return priv->reversed;
++      else
++        return rtl;
++    }
++  else
++    {
++      if (orientation == GTK_ORIENTATION_HORIZONTAL)
++        return rtl ^ priv->reversed;
++      else
++        return false;
++    }
+ }
+ 
+ static void
+@@ -310,8 +325,7 @@ gtk_list_base_move_focus (GtkListBase    *self,
+ {
+   GtkListBasePrivate *priv = gtk_list_base_get_instance_private (self);
+ 
+-  if (orientation == GTK_ORIENTATION_HORIZONTAL &&
+-      gtk_widget_get_direction (GTK_WIDGET (self)) == GTK_TEXT_DIR_RTL)
++  if (gtk_list_base_adjustment_is_flipped (self, orientation))
+     steps = -steps;
+ 
+   if (orientation == priv->orientation)
+@@ -613,6 +627,10 @@ gtk_list_base_get_property (GObject    *object,
+       g_value_set_enum (value, priv->scroll_policy[GTK_ORIENTATION_HORIZONTAL]);
+       break;
+ 
++    case PROP_REVERSED:
++      g_value_set_boolean (value, priv->reversed);
++      break;
++
+     case PROP_ORIENTATION:
+       g_value_set_enum (value, priv->orientation);
+       break;
+@@ -676,6 +694,22 @@ gtk_list_base_set_scroll_policy (GtkListBase         *self,
+                             : properties[PROP_VSCROLL_POLICY]);
+ }
+ 
++static void
++gtk_list_base_set_reversed (GtkListBase *self,
++                            gboolean     reversed)
++{
++  GtkListBasePrivate *priv = gtk_list_base_get_instance_private (self);
++
++  if (priv->reversed == reversed)
++    return;
++
++  priv->reversed = reversed;
++
++  gtk_widget_queue_resize (GTK_WIDGET (self));
++
++  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_REVERSED]);
++}
++
+ static void
+ gtk_list_base_set_property (GObject      *object,
+                             guint         property_id,
+@@ -695,6 +729,10 @@ gtk_list_base_set_property (GObject      *object,
+       gtk_list_base_set_scroll_policy (self, GTK_ORIENTATION_HORIZONTAL, g_value_get_enum (value));
+       break;
+ 
++    case PROP_REVERSED:
++      gtk_list_base_set_reversed (self, g_value_get_boolean (value));
++      break;
++
+     case PROP_ORIENTATION:
+       {
+         GtkOrientation orientation = g_value_get_enum (value);
+@@ -1134,6 +1172,18 @@ gtk_list_base_class_init (GtkListBaseClass *klass)
+       g_param_spec_override ("vscroll-policy",
+                              g_object_interface_find_property (iface, "vscroll-policy"));
+ 
++  /**
++   * GtkListBase:reversed:
++   *
++   * Whether to show the list in reverse or not.
++   */
++  properties[PROP_REVERSED] =
++    g_param_spec_boolean ("reversed",
++                          P_("Reversed"),
++                          P_("Show the list in reverse"),
++                          FALSE,
++                          G_PARAM_READWRITE | G_PARAM_EXPLICIT_NOTIFY);
++
+   /**
+    * GtkListBase:orientation:
+    *
+@@ -1313,7 +1363,7 @@ update_autoscroll (GtkListBase *self,
+   else
+     delta_x = 0;
+ 
+-  if (gtk_widget_get_direction (GTK_WIDGET (self)) == GTK_TEXT_DIR_RTL)
++  if (gtk_list_base_adjustment_is_flipped (self, GTK_ORIENTATION_HORIZONTAL))
+     delta_x = - delta_x;
+ 
+   height = gtk_widget_get_height (GTK_WIDGET (self));
+@@ -1325,6 +1375,9 @@ update_autoscroll (GtkListBase *self,
+   else
+     delta_y = 0;
+ 
++  if (gtk_list_base_adjustment_is_flipped (self, GTK_ORIENTATION_VERTICAL))
++    delta_y = - delta_y;
++
+   if (delta_x != 0 || delta_y != 0)
+     add_autoscroll (self, delta_x, delta_y);
+   else
+@@ -1356,41 +1409,51 @@ gtk_list_base_size_allocate_child (GtkListBase *self,
+ 
+   if (gtk_list_base_get_orientation (GTK_LIST_BASE (self)) == GTK_ORIENTATION_VERTICAL)
+     {
+-      if (_gtk_widget_get_direction (GTK_WIDGET (self)) == GTK_TEXT_DIR_LTR)
++      if (gtk_list_base_adjustment_is_flipped(self, GTK_ORIENTATION_HORIZONTAL))
++        {
++          int mirror_point = gtk_widget_get_width (GTK_WIDGET (self));
++          child_allocation.x = mirror_point - x - width;
++        }
++      else
+         {
+           child_allocation.x = x;
+-          child_allocation.y = y;
+-          child_allocation.width = width;
+-          child_allocation.height = height;
++        }
++      if (gtk_list_base_adjustment_is_flipped(self, GTK_ORIENTATION_VERTICAL))
++        {
++          int mirror_point = gtk_widget_get_height (GTK_WIDGET (self));
++          child_allocation.y = mirror_point - y - height;
+         }
+       else
+         {
+-          int mirror_point = gtk_widget_get_width (GTK_WIDGET (self));
+-
+-          child_allocation.x = mirror_point - x - width;
+           child_allocation.y = y;
+-          child_allocation.width = width;
+-          child_allocation.height = height;
+         }
++
++      child_allocation.width = width;
++      child_allocation.height = height;
+     }
+   else
+     {
+-      if (_gtk_widget_get_direction (GTK_WIDGET (self)) == GTK_TEXT_DIR_LTR)
++      if (gtk_list_base_adjustment_is_flipped(self, GTK_ORIENTATION_HORIZONTAL))
++        {
++          int mirror_point = gtk_widget_get_width (GTK_WIDGET (self));
++          child_allocation.x = mirror_point - y - height;
++        }
++      else
+         {
+           child_allocation.x = y;
+-          child_allocation.y = x;
+-          child_allocation.width = height;
+-          child_allocation.height = width;
++        }
++      if (gtk_list_base_adjustment_is_flipped(self, GTK_ORIENTATION_VERTICAL))
++        {
++          int mirror_point = gtk_widget_get_height (GTK_WIDGET (self));
++          child_allocation.y = mirror_point - x - width;
+         }
+       else
+         {
+-          int mirror_point = gtk_widget_get_width (GTK_WIDGET (self));
+-
+-          child_allocation.x = mirror_point - y - height;
+           child_allocation.y = x;
+-          child_allocation.width = height;
+-          child_allocation.height = width;
+         }
++
++      child_allocation.width = height;
++      child_allocation.height = width;
+     }
+ 
+   gtk_widget_size_allocate (child, &child_allocation, -1);
+@@ -1406,8 +1469,10 @@ gtk_list_base_widget_to_list (GtkListBase *self,
+   GtkListBasePrivate *priv = gtk_list_base_get_instance_private (self);
+   GtkWidget *widget = GTK_WIDGET (self);
+ 
+-  if (gtk_widget_get_direction (widget) == GTK_TEXT_DIR_RTL)
++  if (gtk_list_base_adjustment_is_flipped (self, GTK_ORIENTATION_HORIZONTAL))
+     x_widget = gtk_widget_get_width (widget) - x_widget;
++  if (gtk_list_base_adjustment_is_flipped (self, GTK_ORIENTATION_VERTICAL))
++    y_widget = gtk_widget_get_height (widget) - y_widget;
+ 
+   gtk_list_base_get_adjustment_values (self, OPPOSITE_ORIENTATION (priv->orientation), across_out, NULL, NULL);
+   gtk_list_base_get_adjustment_values (self, priv->orientation, along_out, NULL, NULL);
+-- 
+2.35.3
+

--- a/data/resources/ui/content-chat-history.ui
+++ b/data/resources/ui/content-chat-history.ui
@@ -38,6 +38,7 @@
                 <property name="vscroll-policy">natural</property>
                 <property name="child">
                   <object class="GtkListView" id="list_view">
+                    <property name="reversed">True</property>
                     <property name="factory">
                       <object class="GtkBuilderListItemFactory">
                         <property name="bytes"><![CDATA[

--- a/src/session/chat/history.rs
+++ b/src/session/chat/history.rs
@@ -121,6 +121,7 @@ impl History {
             .list
             .borrow()
             .iter()
+            .rev()
             .find_map(|item| item.message())
             .map(|m| m.id())
             .unwrap_or_default();
@@ -132,7 +133,7 @@ impl History {
 
         if let Ok(enums::Messages::Messages(result)) = result {
             let messages = result.messages.into_iter().flatten().collect();
-            self.prepend(messages);
+            self.append(messages);
         }
 
         self.set_loading(false);
@@ -148,7 +149,7 @@ impl History {
 
         match update {
             Update::NewMessage(update) => {
-                self.append(update.message);
+                self.push_front(update.message);
             }
             Update::MessageSendSucceeded(update) => {
                 self.remove(update.old_message_id);
@@ -178,25 +179,26 @@ impl History {
             let added = added as usize;
 
             let mut list = imp.list.borrow_mut();
-            let mut previous_timestamp = if position > 0 {
-                list.get(position - 1)
+            let mut previous_timestamp = if position < list.len() - 1 {
+                list.get(position + 1)
                     .and_then(|item| item.message_timestamp())
             } else {
                 None
             };
             let mut dividers: Vec<(usize, Item)> = vec![];
-            let mut index = position;
 
-            for current in list.range(position..position + added) {
+            for (index, current) in list.range(position..position + added).enumerate().rev() {
                 if let Some(current_timestamp) = current.message_timestamp() {
                     if Some(current_timestamp.ymd()) != previous_timestamp.as_ref().map(|t| t.ymd())
                     {
-                        dividers.push((index, Item::for_day_divider(current_timestamp.clone())));
+                        let divider_pos = position + index + 1;
+                        dividers.push((
+                            divider_pos,
+                            Item::for_day_divider(current_timestamp.clone()),
+                        ));
                         previous_timestamp = Some(current_timestamp);
-                        index += 1;
                     }
                 }
-                index += 1;
             }
 
             let dividers_len = dividers.len();
@@ -208,26 +210,25 @@ impl History {
         };
 
         // Check and remove no more needed day divider after removing messages
-        let (position, removed) = {
-            let mut position = position as usize;
+        let removed = {
             let mut removed = removed as usize;
 
             if removed > 0 {
                 let mut list = imp.list.borrow_mut();
-                let previous_item = if position > 0 {
-                    list.get(position - 1)
-                } else {
-                    None
-                };
+                let position = position as usize;
+                let item_before_removed = list.get(position);
 
-                if let Some(ItemType::DayDivider(_)) = previous_item.map(|item| item.type_()) {
-                    let item_after_removed = list.get(position + removed - 1);
+                if let Some(ItemType::DayDivider(_)) = item_before_removed.map(|i| i.type_()) {
+                    let item_after_removed = if position > 0 {
+                        list.get(position - 1)
+                    } else {
+                        None
+                    };
 
                     match item_after_removed.map(|item| item.type_()) {
                         None | Some(ItemType::DayDivider(_)) => {
-                            list.remove(position - 1);
+                            list.remove(position + removed);
 
-                            position -= 1;
                             removed += 1;
                         }
                         _ => {}
@@ -235,42 +236,37 @@ impl History {
                 }
             }
 
-            (position as u32, removed as u32)
+            removed as u32
         };
 
         // Check and remove no more needed day divider after adding messages
-        let removed = {
+        let (position, removed) = {
             let mut removed = removed;
+            let mut position = position as usize;
 
-            if added > 0 {
-                let position = position as usize;
-                let added = added as usize;
-
+            if added > 0 && position > 0 {
                 let mut list = imp.list.borrow_mut();
-                let last_added_timestamp = list
-                    .get(position + added - 1)
-                    .unwrap()
-                    .message_timestamp()
-                    .unwrap();
-                let next_item = list.get(position + added);
+                let last_added_timestamp = list.get(position).unwrap().message_timestamp().unwrap();
+                let next_item = list.get(position - 1);
 
                 if let Some(ItemType::DayDivider(date)) = next_item.map(|item| item.type_()) {
                     if date.ymd() == last_added_timestamp.ymd() {
-                        list.remove(position + added);
+                        list.remove(position - 1);
 
                         removed += 1;
+                        position -= 1;
                     }
                 }
             }
 
-            removed
+            (position as u32, removed)
         };
 
         self.upcast_ref::<gio::ListModel>()
             .items_changed(position, removed, added);
     }
 
-    pub(crate) fn append(&self, message: TelegramMessage) {
+    pub(crate) fn push_front(&self, message: TelegramMessage) {
         let imp = self.imp();
 
         let mut message_map = imp.message_map.borrow_mut();
@@ -280,18 +276,16 @@ impl History {
 
             entry.insert(message.clone());
 
-            imp.list.borrow_mut().push_back(Item::for_message(message));
-
-            let index = imp.list.borrow().len() - 1;
+            imp.list.borrow_mut().push_front(Item::for_message(message));
 
             // We always need to drop all references before handing over control. Else, we could end
             // up with a borrowing error somewhere else.
             drop(message_map);
-            self.items_changed(index as u32, 0, 1);
+            self.items_changed(0, 0, 1);
         }
     }
 
-    fn prepend(&self, messages: Vec<TelegramMessage>) {
+    fn append(&self, messages: Vec<TelegramMessage>) {
         let imp = self.imp();
         let chat = self.chat();
         let added = messages.len();
@@ -305,10 +299,11 @@ impl History {
                 .borrow_mut()
                 .insert(message.id(), message.clone());
 
-            imp.list.borrow_mut().push_front(Item::for_message(message));
+            imp.list.borrow_mut().push_back(Item::for_message(message));
         }
 
-        self.items_changed(0, 0, added as u32);
+        let index = imp.list.borrow().len() - added;
+        self.items_changed(index as u32, 0, added as u32);
     }
 
     fn remove(&self, message_id: i64) {
@@ -325,15 +320,15 @@ impl History {
                 // can exploit this by applying a binary search.
                 let index = list
                     .binary_search_by(|m| match m.type_() {
-                        ItemType::Message(message) => message.id().cmp(&message_id),
+                        ItemType::Message(message) => message_id.cmp(&message.id()),
                         ItemType::DayDivider(date_time) => {
-                            let ordering = date_time.cmp(
-                                &glib::DateTime::from_unix_utc(message.date() as i64).unwrap(),
-                            );
+                            let ordering = glib::DateTime::from_unix_utc(message.date() as i64)
+                                .unwrap()
+                                .cmp(date_time);
                             if let Ordering::Equal = ordering {
                                 // We found the day divider of the message. Therefore, the message
                                 // must be among the following elements.
-                                Ordering::Less
+                                Ordering::Greater
                             } else {
                                 ordering
                             }

--- a/src/session/chat/mod.rs
+++ b/src/session/chat/mod.rs
@@ -362,7 +362,7 @@ impl Chat {
                             None => {
                                 let last_message_id = last_message.id;
 
-                                self.history().append(last_message);
+                                self.history().push_front(last_message);
                                 self.history().message_by_id(last_message_id).unwrap()
                             }
                         };


### PR DESCRIPTION
This is currently a playground for my [gtk branch](https://gitlab.gnome.org/melix99/gtk/-/commits/reversed-list-view) to implement a "reversed" property for the ListView which solves one of the Telegrand's most annoying issues. Fixes #138.

This should be merged only when my branch is merged in gtk main.

EDIT:
MR in gtk repo: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4447