### PR TITLE
preferences-window: Added option to use custom chat width

### DIFF
--- a/data/com.github.melix99.telegrand.gschema.xml.in
+++ b/data/com.github.melix99.telegrand.gschema.xml.in
@@ -31,5 +31,15 @@
       <summary>Color Scheme</summary>
       <description>The color scheme to be used in the app</description>
     </key>
+    <key name="custom-chat-width" type="i">
+      <default>600</default>
+      <summary>Custom chat width</summary>
+      <description>Custom chat width</description>
+    </key>
+    <key name="use-custom-chat-width" type="b">
+      <default>false</default>
+      <summary>Use Custom chat width</summary>
+      <description>Whether or not to use custom chat width</description>
+    </key>
   </schema>
 </schemalist>

--- a/data/resources/ui/content-chat-history.ui
+++ b/data/resources/ui/content-chat-history.ui
@@ -40,7 +40,7 @@
               <class name="chat-history"/>
             </style>
             <property name="child">
-              <object class="AdwClampScrollable">
+              <object class="AdwClampScrollable" id="chat_clamp">
                 <property name="vscroll-policy">natural</property>
                 <property name="child">
                   <object class="GtkListView" id="list_view">
@@ -75,7 +75,7 @@
           <object class="GtkSeparator"/>
         </child>
         <child>
-          <object class="AdwClamp">
+          <object class="AdwClamp" id="action_bar_clamp">
             <property name="child">
               <object class="ContentChatActionBar">
                 <binding name="chat">

--- a/data/resources/ui/preferences-window.ui
+++ b/data/resources/ui/preferences-window.ui
@@ -31,6 +31,35 @@
             </child>
           </object>
         </child>
+        <child>
+          <object class="AdwPreferencesGroup">
+            <property name="title" translatable="yes">Chat Settings</property>
+            <child>
+              <object class="AdwExpanderRow" id="custom_chat_width_exp_row">
+                <property name="title" translatable="yes">Use Custom Chat Width</property>
+                <property name="show-enable-switch">True</property>
+                  <child>
+                  <object class="AdwActionRow">
+                    <property name="title" translatable="yes">Chat Width</property>
+                    <child>
+                      <object class="GtkSpinButton" id="chat_width_spin_btn">
+                        <property name="margin-top">5</property>
+                        <property name="margin-bottom">5</property>
+                        <property name="adjustment">
+                          <object class="GtkAdjustment">
+                            <property name="lower">600</property>
+                            <property name="upper">4000</property>
+                            <property name="step_increment">10</property>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
   </template>

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,6 +13,8 @@ use crate::{config, APPLICATION_OPTS, RUNTIME};
 
 pub static PROTOCOL_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\w+://").unwrap());
 
+pub const DEFAULT_CHAT_SIZE: i32 = 600;
+
 pub fn escape(text: &str) -> String {
     text.replace('&', "&amp;")
         .replace('<', "&lt;")


### PR DESCRIPTION
Let me propose a solution for #228
I've added an option for user to specify custom chat width. It's still WIP and I'm open to your suggestions.
![image](https://user-images.githubusercontent.com/58047802/154351128-2b59327f-4e02-46f3-bf7d-e9ddc7456766.png)

//tag for github :p 
fixes #228