### PR TITLE
session-manager: Fix panic when retrieving the own user

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -403,10 +403,10 @@ impl Session {
         self.imp().me.upgrade().unwrap()
     }
 
-    pub(crate) fn set_me_from_id(&self, my_id: i64) {
+    pub(crate) fn set_me(&self, me: &User) {
         let imp = self.imp();
         assert!(imp.me.upgrade().is_none());
-        imp.me.set(Some(&self.user_list().get(my_id)));
+        imp.me.set(Some(me));
         self.notify("me");
     }
 

--- a/src/session/user_list.rs
+++ b/src/session/user_list.rs
@@ -97,12 +97,11 @@ impl UserList {
     /// so if you use an `id` returned by TDLib, it should be expected that the
     /// relative `User` exists in the list.
     pub(crate) fn get(&self, id: i64) -> User {
-        self.imp()
-            .list
-            .borrow()
-            .get(&id)
-            .expect("Failed to get expected User")
-            .to_owned()
+        self.try_get(id).expect("Failed to get expected User")
+    }
+
+    pub(crate) fn try_get(&self, id: i64) -> Option<User> {
+        self.imp().list.borrow().get(&id).cloned()
     }
 
     pub(crate) fn handle_update(&self, update: Update) {


### PR DESCRIPTION
# From the commit message
```
I have not collected statistics on this, but at an estimated one in
seven launches, the application crashes with the message
`Failed to get expected user`.

It seems that the update for the own user does not always necessarily
arrive in time.

With this commit we make sure that the update arrives before the own
user is set on the session.

backtrace:

thread 'main' panicked at 'Failed to get expected User', src/session/user_list.rs:113:14
stack backtrace:
   0: rust_begin_unwind
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:107:14
   2: core::panicking::panic_display
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:63:5
   3: core::option::expect_failed
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/option.rs:1637:5
   4: core::option::Option<T>::expect
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/option.rs:709:21
   5: telegrand::session::user_list::UserList::get
             at ./src/session/user_list.rs:109:9
   6: telegrand::session::Session::set_me_from_id
             at ./src/session/mod.rs:414:26
   7: telegrand::session_manager::SessionManager::add_logged_in_session::{{closure}}::{{closure}}
             at ./src/session_manager.rs:664:17
   8: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/future/mod.rs:80:19
   9: telegrand::utils::do_async::{{closure}}
             at ./src/utils.rs:210:9
  10: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/future/mod.rs:80:19
  11: <futures_task::future_obj::LocalFutureObj<T> as core::future::future::Future>::poll
             at ./_build/cargo-home/registry/src/github.com-1ecc6299db9ec823/futures-task-0.3.19/src/future_obj.rs:84:18
  12: <glib::main_context_futures::FutureWrapper as core::future::future::Future>::poll
             at ./_build/cargo-home/registry/src/github.com-1ecc6299db9ec823/glib-0.15.1/src/main_context_futures.rs:32:44
  13: glib::main_context_futures::TaskSource::poll::{{closure}}
             at ./_build/cargo-home/registry/src/github.com-1ecc6299db9ec823/glib-0.15.1/src/main_context_futures.rs:233:17
  14: glib::main_context::<impl glib::auto::main_context::MainContext>::with_thread_default
             at ./_build/cargo-home/registry/src/github.com-1ecc6299db9ec823/glib-0.15.1/src/main_context.rs:156:12
  15: glib::main_context_futures::TaskSource::poll
             at ./_build/cargo-home/registry/src/github.com-1ecc6299db9ec823/glib-0.15.1/src/main_context_futures.rs:226:9
  16: glib::main_context_futures::TaskSource::dispatch
             at ./_build/cargo-home/registry/src/github.com-1ecc6299db9ec823/glib-0.15.1/src/main_context_futures.rs:67:34
  17: g_main_context_dispatch
  18: <unknown>
  19: g_main_context_iteration
  20: g_application_run
  21: <O as gio::application::ApplicationExtManual>::run_with_args
             at ./_build/cargo-home/registry/src/github.com-1ecc6299db9ec823/gio-0.15.1/src/application.rs:30:13
  22: <O as gio::application::ApplicationExtManual>::run
             at ./_build/cargo-home/registry/src/github.com-1ecc6299db9ec823/gio-0.15.1/src/application.rs:23:9
  23: telegrand::main
             at ./src/main.rs:78:5
  24: core::ops::function::FnOnce::call_once
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
>>> Child process exited with code 139
```