### PR TITLE
git: Use pre commit hook for rustfmt

### DIFF
--- a/hooks/pre-commit.hook
+++ b/hooks/pre-commit.hook
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Source: Modified version of https://gitlab.gnome.org/World/Rust/gtk-rust-template/-/blob/df33e34f19d16dfb57d1c060f165f710da7b438b/hooks/pre-commit.hook
+
+install_rustfmt() {
+    if ! which rustup &> /dev/null; then
+        curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain none -y
+        export PATH=$PATH:$HOME/.cargo/bin
+        if ! which rustup &> /dev/null; then
+            echo "Failed to install rustup. Performing the commit without style checking."
+            exit 0
+        fi
+    fi
+
+    if ! rustup toolchain list | grep nightly &> /dev/null; then
+        echo "Installing minimal rust nightly toolchain…"
+        rustup toolchain install nightly --profile minimal
+    fi
+
+    if ! rustup component list --toolchain=nightly | grep rustfmt &> /dev/null; then
+        echo "Installing rustfmt…"
+        rustup component add rustfmt --toolchain=nightly
+    fi
+}
+
+if ! which cargo >/dev/null 2>&1 || ! cargo +nightly fmt --help >/dev/null 2>&1; then
+    echo "Unable to check the project’s code style, because rustfmt could not be run."
+
+    if [ ! -t 1 ]; then
+        # No input is possible
+        echo "Performing commit."
+        exit 0
+    fi
+
+    echo ""
+    echo "y: Install rustfmt via rustup"
+    echo "n: Don't install rustfmt and perform the commit"
+    echo "Q: Don't install rustfmt and abort the commit"
+
+    echo ""
+    while true
+    do
+        echo -n "Install rustfmt via rustup? [y/n/Q]: "; read yn < /dev/tty
+        case $yn in
+            [Yy]* ) install_rustfmt; break;;
+            [Nn]* ) echo "Performing commit."; exit 0;;
+            [Qq]* | "" ) echo "Aborting commit."; exit -1 >/dev/null 2>&1;;
+            * ) echo "Invalid input";;
+        esac
+    done
+
+fi
+
+echo "--Checking style--"
+cargo +nightly fmt --all -- --check
+if test $? != 0; then
+    echo "--Checking style fail--"
+    echo "Please fix the above issues, either manually or by running: cargo +nightly fmt --all"
+
+    exit -1
+else
+    echo "--Checking style pass--"
+fi

--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,12 @@ meson.add_dist_script(
   meson.source_root()
 )
 
+if get_option('profile') == 'development'
+  # Setup pre-commit hook for ensuring coding style is always consistent
+  message('Setting up git pre-commit hook..')
+  run_command('cp', '-f', 'hooks/pre-commit.hook', '.git/hooks/pre-commit')
+endif
+
 subdir('data')
 subdir('po')
 subdir('src')


### PR DESCRIPTION
# Commit Message
```
Uses a slightly modified version adapted to nightly rustfmt of
https://gitlab.gnome.org/World/Rust/gtk-rust-template/-/blob/df33e34f19d16dfb57d1c060f165f710da7b438b/hooks/pre-commit.hook
```

Should probably be well tested beforehand.