### PR TITLE
Hide message entry when not needed

### DIFF
--- a/data/resources/ui/content-chat-action-bar.ui
+++ b/data/resources/ui/content-chat-action-bar.ui
@@ -34,5 +34,14 @@
         </style>
       </object>
     </child>
+    <child>
+      <object class="GtkLabel" id="restriction_label">
+        <property name="height-request">48</property>
+        <property name="hexpand">True</property>
+        <property name="wrap">True</property>
+        <property name="wrap-mode">word-char</property>
+        <property name="justify">center</property>
+      </object>
+    </child>
   </template>
 </interface>

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -1,6 +1,12 @@
 use gettextrs::gettext;
+use gtk::glib;
+use gtk::glib::closure;
+use gtk::prelude::GObjectPropertyExpressionExt;
 
-use crate::session::{Chat, User};
+use crate::session::{
+    BasicGroup, BoxedChatMemberStatus, BoxedChatPermissions, Chat, ChatType, Supergroup, User,
+};
+use tdlib::enums::ChatMemberStatus;
 
 /// Creates an expression that produces the display name of a chat. This will either produce the
 /// title of the chat or the translated "Saved Messages" string in the case of the own chat.
@@ -28,5 +34,68 @@ pub(crate) fn user_full_name(user_expression: &gtk::Expression) -> gtk::Expressi
         let last_name = args[2].get::<String>().unwrap();
         first_name + " " + &last_name
     })
+    .upcast()
+}
+
+pub(crate) fn restriction_expression(chat: &Chat) -> gtk::Expression {
+    match chat.type_() {
+        ChatType::Supergroup(data) if !data.is_channel() => {
+            restriction_label_expression::<Supergroup, _>(data)
+        }
+        ChatType::BasicGroup(data) => restriction_label_expression::<BasicGroup, _>(data),
+        _ => gtk::ConstantExpression::new(&"").upcast(),
+    }
+}
+
+fn restriction_label_expression<T: glib::StaticType, V: glib::ToValue>(
+    value: &V,
+) -> gtk::Expression {
+    let member_status_expression = gtk::PropertyExpression::new(
+        T::static_type(),
+        Some(gtk::ConstantExpression::new(value)),
+        "status",
+    );
+    let permissions_expression = Chat::this_expression("permissions");
+
+    gtk::ClosureExpression::new::<String, _, _>(
+        &[member_status_expression, permissions_expression],
+        closure!(|_: glib::Object, status: BoxedChatMemberStatus, chat_permissions: BoxedChatPermissions| {
+            if chat_permissions.0.can_send_messages {
+                match status.0 {
+                    ChatMemberStatus::Restricted(status) if !status.permissions.can_send_messages => {
+                        if status.restricted_until_date == 0 {
+                            gettext("The admins of this group have restricted you from writing here")
+                        } else {
+                            let date =
+                            glib::DateTime::from_unix_utc(status.restricted_until_date.into()).unwrap();
+
+                            gettext!(
+                                "The admins of this group have restricted you from writing here until {}",
+                                date.format(&if glib::DateTime::now_local()
+                                    .unwrap()
+                                    .difference(&date)
+                                    .as_days()
+                                    == 0
+                                {
+                                    // Translators: This is a hours: minutes time format used in restriction label
+                                    gettext("%l:%M %p")
+                                } else {
+                                    // Translators: This is a full date format used in restriction label
+                                    gettext("%B %e, %Y %l:%M %p")
+                                })
+                                .unwrap()
+                                .to_string()
+                            )
+                        }
+                    }
+                    _ => String::new(),
+                }
+            } else if !matches!(status.0, ChatMemberStatus::Creator(_) | ChatMemberStatus::Administrator(_)) {
+                gettext("Writing messages isn't allowed in this group.")
+            } else {
+                String::new()
+            }
+        }),
+    )
     .upcast()
 }

--- a/src/session/chat/mod.rs
+++ b/src/session/chat/mod.rs
@@ -17,11 +17,15 @@ pub(crate) use self::sponsored_message::SponsoredMessage;
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use tdlib::enums::{self, ChatType as TdChatType, MessageContent, Update};
+use tdlib::enums::{self, ChatMemberStatus, ChatType as TdChatType, MessageContent, Update};
 use tdlib::types::{Chat as TelegramChat, ChatNotificationSettings, DraftMessage};
 
 use crate::session::{Avatar, BasicGroup, SecretChat, Supergroup, User};
 use crate::Session;
+
+#[derive(Clone, Debug, PartialEq, glib::Boxed)]
+#[boxed_type(name = "BoxedChatMemberStatus")]
+pub(crate) struct BoxedChatMemberStatus(pub(crate) ChatMemberStatus);
 
 #[derive(Clone, Debug, glib::Boxed)]
 #[boxed_type(name = "ChatType")]

--- a/src/session/chat_list.rs
+++ b/src/session/chat_list.rs
@@ -217,6 +217,16 @@ impl ChatList {
                     chat.handle_update(update);
                 }
             }
+            Update::ChatIsBlocked(ref update_) => {
+                if let Some(chat) = imp.list.borrow().get(&update_.chat_id) {
+                    chat.handle_update(update)
+                }
+            }
+            Update::ChatPermissions(ref update_) => {
+                if let Some(chat) = imp.list.borrow().get(&update_.chat_id) {
+                    chat.handle_update(update)
+                }
+            }
             _ => {}
         }
     }

--- a/src/session/content/chat_action_bar.rs
+++ b/src/session/content/chat_action_bar.rs
@@ -2,17 +2,18 @@ use anyhow::anyhow;
 use ashpd::desktop::file_chooser::{FileChooserProxy, FileFilter, OpenFileOptions};
 use ashpd::{zbus, WindowIdentifier};
 use gettextrs::gettext;
-use glib::clone;
+use glib::{clone, closure};
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib, CompositeTemplate};
-use tdlib::enums::{ChatAction, InputMessageContent};
+use tdlib::enums::{ChatAction, ChatMemberStatus, InputMessageContent, UserType};
 use tdlib::{functions, types};
 
-use crate::session::chat::BoxedDraftMessage;
+use crate::session::chat::{BoxedChatMemberStatus, BoxedChatPermissions, BoxedDraftMessage};
 use crate::session::components::{BoxedFormattedText, MessageEntry};
 use crate::session::content::SendPhotoDialog;
-use crate::session::Chat;
+use crate::session::user::BoxedUserType;
+use crate::session::{BasicGroup, Chat, ChatType, Supergroup, User};
 use crate::utils::{spawn, temp_dir};
 
 const PHOTO_MIME_TYPES: &[&str] = &["image/png", "image/jpeg"];
@@ -28,10 +29,13 @@ mod imp {
         pub(super) chat: RefCell<Option<Chat>>,
         pub(super) chat_action_in_cooldown: Cell<bool>,
         pub(super) emoji_chooser: RefCell<Option<gtk::EmojiChooser>>,
+        pub(super) bindings: RefCell<Vec<gtk::ExpressionWatch>>,
         #[template_child]
         pub(super) message_entry: TemplateChild<MessageEntry>,
         #[template_child]
         pub(super) send_message_button: TemplateChild<gtk::Button>,
+        #[template_child]
+        pub(super) select_file_button: TemplateChild<gtk::Button>,
     }
 
     #[glib::object_subclass]
@@ -363,11 +367,84 @@ impl ChatActionBar {
         }));
 
         let imp = self.imp();
+        let mut bindings = imp.bindings.borrow_mut();
+        while let Some(binding) = bindings.pop() {
+            binding.unwatch();
+        }
 
         if let Some(ref chat) = chat {
             self.load_draft_message(chat.draft_message());
 
             imp.chat_action_in_cooldown.set(false);
+
+            let permissions_expression = Chat::this_expression("permissions");
+            let is_blocked_expression = Chat::this_expression("is-blocked");
+
+            // Handle whether or not message bar should be shown
+            let message_bar_visibility_expression = match chat.type_() {
+                ChatType::Private(data) => {
+                    let user_type_expression =
+                        gtk::ConstantExpression::new(data).chain_property::<User>("type");
+                    message_bar_visibility_in_private_chats(
+                        is_blocked_expression,
+                        user_type_expression,
+                    )
+                }
+                ChatType::Secret(data) => {
+                    let user_type_expression =
+                        gtk::ConstantExpression::new(data.user()).chain_property::<User>("type");
+                    message_bar_visibility_in_private_chats(
+                        is_blocked_expression,
+                        user_type_expression,
+                    )
+                }
+                ChatType::Supergroup(data) => {
+                    let user_status_expression =
+                        gtk::ConstantExpression::new(data).chain_property::<Supergroup>("status");
+                    if data.is_channel() {
+                        gtk::ClosureExpression::with_callback(&[user_status_expression], |args| {
+                            let status = args[1].get::<BoxedChatMemberStatus>().unwrap().0;
+                            matches!(
+                                status,
+                                ChatMemberStatus::Creator(_) | ChatMemberStatus::Administrator(_)
+                            )
+                        })
+                        .upcast()
+                    } else {
+                        message_bar_visibility_in_groups(
+                            permissions_expression.clone(),
+                            user_status_expression,
+                        )
+                    }
+                }
+                ChatType::BasicGroup(data) => {
+                    let user_status_expression =
+                        gtk::ConstantExpression::new(data).chain_property::<BasicGroup>("status");
+                    message_bar_visibility_in_groups(
+                        permissions_expression.clone(),
+                        user_status_expression,
+                    )
+                }
+            };
+
+            let message_bar_visibility_binding =
+                message_bar_visibility_expression.bind(&*imp.message_entry, "visible", Some(chat));
+            let send_button_visibility_binding = message_bar_visibility_expression.bind(
+                &*imp.send_message_button,
+                "visible",
+                Some(chat),
+            );
+            // TODO: So in order to implement it correctly we need to duplicate message_bar_visibility_expression
+            // to only change 3 LOC, so there must be a more efficient way of solving that issue
+            // But for now I'm just leaving it like that, it's still better than nothing
+            let select_file_visibility_binding = message_bar_visibility_expression.bind(
+                &*imp.select_file_button,
+                "visible",
+                Some(chat),
+            );
+            bindings.push(message_bar_visibility_binding);
+            bindings.push(send_button_visibility_binding);
+            bindings.push(select_file_visibility_binding);
         }
 
         imp.chat.replace(chat);
@@ -398,4 +475,45 @@ async fn save_stream_to_file(
         .await?;
 
     Ok(())
+}
+
+fn message_bar_visibility_in_private_chats(
+    is_blocked_expression: gtk::PropertyExpression,
+    user_type_expression: gtk::PropertyExpression,
+) -> gtk::Expression {
+    gtk::ClosureExpression::new::<bool, _, _>(
+        &[is_blocked_expression, user_type_expression],
+        closure!(|_: Chat, is_blocked: bool, user_type: BoxedUserType| {
+            // Hide message bar if account is deleted
+            if let UserType::Deleted = user_type.0 {
+                false
+            } else {
+                !is_blocked
+            }
+        }),
+    )
+    .upcast()
+}
+
+fn message_bar_visibility_in_groups(
+    permissions_expression: gtk::PropertyExpression,
+    user_status_expression: gtk::PropertyExpression,
+) -> gtk::Expression {
+    gtk::ClosureExpression::new::<bool, _, _>(
+        &[permissions_expression, user_status_expression],
+        closure!(
+            |_: Chat, permissions: BoxedChatPermissions, status: BoxedChatMemberStatus| {
+                match status.0 {
+                    ChatMemberStatus::Restricted(data) if !data.permissions.can_send_messages => {
+                        false
+                    }
+                    ChatMemberStatus::Left | ChatMemberStatus::Banned(_) => false,
+                    // Owner and admins are always allowed to send messages
+                    ChatMemberStatus::Creator(_) | ChatMemberStatus::Administrator(_) => true,
+                    _ => permissions.0.can_send_messages,
+                }
+            }
+        ),
+    )
+    .upcast()
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -14,7 +14,7 @@ mod user;
 mod user_list;
 
 use self::avatar::Avatar;
-use self::basic_group::BasicGroup;
+pub(crate) use self::basic_group::BasicGroup;
 use self::basic_group_list::BasicGroupList;
 pub(crate) use self::chat::{Chat, ChatType};
 use self::chat_list::ChatList;
@@ -22,7 +22,7 @@ use self::content::Content;
 use self::secret_chat::SecretChat;
 use self::secret_chat_list::SecretChatList;
 use self::sidebar::Sidebar;
-use self::supergroup::Supergroup;
+pub(crate) use self::supergroup::Supergroup;
 use self::supergroup_list::SupergroupList;
 pub(crate) use self::user::User;
 use self::user_list::UserList;
@@ -314,7 +314,9 @@ impl Session {
             | Update::ChatReadInbox(_)
             | Update::ChatDraftMessage(_)
             | Update::DeleteMessages(_)
-            | Update::ChatAction(_) => {
+            | Update::ChatAction(_)
+            | Update::ChatIsBlocked(_)
+            | Update::ChatPermissions(_) => {
                 self.chat_list().handle_update(update);
             }
             Update::UnreadMessageCount(ref update_) => {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -16,7 +16,7 @@ mod user_list;
 use self::avatar::Avatar;
 pub(crate) use self::basic_group::BasicGroup;
 use self::basic_group_list::BasicGroupList;
-pub(crate) use self::chat::{Chat, ChatType};
+pub(crate) use self::chat::{BoxedChatMemberStatus, BoxedChatPermissions, Chat, ChatType};
 use self::chat_list::ChatList;
 use self::content::Content;
 use self::secret_chat::SecretChat;


### PR DESCRIPTION
This pr is still work in progress
- [x] Implement `status` property for Supergroup and BasicGroup
- [x]  Implement `is-blocked` and `permissions` properties for chat
- [x] Actual handling `message bar` and `restricted_label` states

User restricted in the chat:
![photo](https://user-images.githubusercontent.com/58047802/155611436-d97d0de1-eb33-47f5-93e8-26c2b755d2e2.png)
Writing not allowed in the group:
![photo](https://user-images.githubusercontent.com/58047802/156207989-cbf5da19-ccc0-4cd2-baa5-b9de4a408bc1.png)
Channel:
![photo](https://user-images.githubusercontent.com/58047802/156208042-79cb4be5-8d68-4ac8-90c5-7e6c10d14400.png)
I'll implement `Unmute` button in the future (see #258) 

fixes #35