### PR TITLE
clippy: Fix warning

### DIFF
--- a/src/session_manager.rs
+++ b/src/session_manager.rs
@@ -256,7 +256,7 @@ impl SessionManager {
                 .unwrap();
 
             if on_test_dc == session.database_info().0.use_test_dc
-                && session.me().phone_number().replace(" ", "") == phone_number_digits
+                && session.me().phone_number().replace(' ', "") == phone_number_digits
             {
                 Some(pos)
             } else {


### PR DESCRIPTION
Fix the `single_char_pattern` lint as clippy now warns about it.