### PR TITLE
Use image crate instead of the webp one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,9 +202,6 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-expr"
@@ -847,9 +844,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "image"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db207d030ae38f1eb6f240d5a1c1c88ff422aa005d10f8c6c6fc5e75286ab30e"
+checksum = "28edd9d7bc256be2502e325ac0628bde30b7001b9b52e0abe31a1a9dc2701212"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -883,15 +880,6 @@ name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
-
-[[package]]
-name = "jobserver"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "lazy_static"
@@ -936,15 +924,6 @@ name = "libc"
 version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
-
-[[package]]
-name = "libwebp-sys"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439fd1885aa28937e7edcd68d2e793cb4a22f8733460d2519fbafd2b215672bf"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "locale_config"
@@ -1526,6 +1505,7 @@ dependencies = [
  "futures",
  "gettext-rs",
  "gtk4",
+ "image",
  "indexmap",
  "libadwaita",
  "locale_config",
@@ -1536,7 +1516,6 @@ dependencies = [
  "regex",
  "tdlib",
  "temp-dir",
- "webp",
 ]
 
 [[package]]
@@ -1624,16 +1603,6 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
-name = "webp"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf022f821f166079a407d000ab57e84de020e66ffbbf4edde999bc7d6e371cae"
-dependencies = [
- "image",
- "libwebp-sys",
-]
 
 [[package]]
 name = "wepoll-ffi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ ashpd = { version = "0.3", features = ["feature_gtk4"] }
 futures = { version = "0.3", default-features = false }
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
 gtk = { version = "0.4", package = "gtk4", features = ["v4_6"] }
+image = { version = "0.24", default-features = false, features = ["webp"] }
 indexmap = "1.8"
 locale_config = "0.3"
 log = "0.4"
@@ -20,4 +21,3 @@ qrcode-generator = { version = "4.1", default-features = false }
 regex = "1.5"
 tdlib = { version = "0.1", default-features = false }
 temp-dir = "0.1"
-webp = "0.2"


### PR DESCRIPTION
The image crate recently gained the ability to fully decode rgba8 webp files, so let's use that for decoding stickers instead of the webp crate that relies on the libwebp C library.

This is more of a test currently, ~needs https://github.com/image-rs/image/pull/1685 to be merged first~. ~The PR was merged, let's wait for a new release now.~ A new version is now available.