### PR TITLE
Use released version of tdlib-rs (renamed tdgrand lib)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libwebp-sys"
@@ -1083,9 +1083,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tdgrand"
+name = "tdlib"
 version = "0.1.0"
-source = "git+https://github.com/melix99/tdgrand?branch=main#af2d02c7f444eb7e9ca913226ce86bcde424cdea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1036994567aa8f3b811fccad6ed6398838638753c1cbdf0b55b40be78d5f448"
 dependencies = [
  "futures-channel",
  "log",
@@ -1093,22 +1094,24 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tdgrand-tl-gen",
- "tdgrand-tl-parser",
+ "tdlib-tl-gen",
+ "tdlib-tl-parser",
 ]
 
 [[package]]
-name = "tdgrand-tl-gen"
+name = "tdlib-tl-gen"
 version = "0.1.0"
-source = "git+https://github.com/melix99/tdgrand?branch=main#af2d02c7f444eb7e9ca913226ce86bcde424cdea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c1138279b5aa1b4378846bb03ef2a1b6f74c91586852d2c5406d3719e387fe"
 dependencies = [
- "tdgrand-tl-parser",
+ "tdlib-tl-parser",
 ]
 
 [[package]]
-name = "tdgrand-tl-parser"
+name = "tdlib-tl-parser"
 version = "0.1.0"
-source = "git+https://github.com/melix99/tdgrand?branch=main#af2d02c7f444eb7e9ca913226ce86bcde424cdea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622c9bd699bdf76ff30aea8b3e62cd6950a9817d9451f268b3892166c68a7ae8"
 
 [[package]]
 name = "telegrand"
@@ -1126,7 +1129,7 @@ dependencies = [
  "pretty_env_logger",
  "qrcode-generator",
  "regex",
- "tdgrand",
+ "tdlib",
  "tokio",
  "tokio-stream",
  "webp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ once_cell = "1.10"
 pretty_env_logger = "0.4"
 qrcode-generator = { version = "4.1", default-features = false }
 regex = "1.5"
-tdgrand = { git = "https://github.com/melix99/tdgrand", branch = "main", default-features = false }
+tdlib = { version = "0.1", default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
 webp = "0.2"

--- a/src/login.rs
+++ b/src/login.rs
@@ -3,8 +3,8 @@ use gtk::gdk;
 use gtk::glib::{self, clone};
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use tdgrand::enums::AuthorizationState;
-use tdgrand::{functions, types};
+use tdlib::enums::AuthorizationState;
+use tdlib::{functions, types};
 
 use crate::session::Session;
 use crate::session_manager::SessionManager;

--- a/src/session/avatar.rs
+++ b/src/session/avatar.rs
@@ -2,7 +2,7 @@ use glib::clone;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gdk, gio, glib};
-use tdgrand::types::{ChatPhotoInfo, File, ProfilePhoto};
+use tdlib::types::{ChatPhotoInfo, File, ProfilePhoto};
 
 use crate::Session;
 

--- a/src/session/basic_group.rs
+++ b/src/session/basic_group.rs
@@ -1,8 +1,8 @@
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use tdgrand::enums::Update;
-use tdgrand::types::BasicGroup as TdBasicGroup;
+use tdlib::enums::Update;
+use tdlib::types::BasicGroup as TdBasicGroup;
 
 mod imp {
     use super::*;

--- a/src/session/basic_group_list.rs
+++ b/src/session/basic_group_list.rs
@@ -2,7 +2,7 @@ use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib};
 use indexmap::map::Entry;
-use tdgrand::enums::Update;
+use tdlib::enums::Update;
 
 use crate::session::BasicGroup;
 

--- a/src/session/chat/action.rs
+++ b/src/session/chat/action.rs
@@ -1,6 +1,6 @@
 use gtk::glib;
 use gtk::subclass::prelude::*;
-use tdgrand::enums;
+use tdlib::enums;
 
 use crate::session::chat::{Chat, MessageSender};
 

--- a/src/session/chat/action_list.rs
+++ b/src/session/chat/action_list.rs
@@ -2,7 +2,7 @@ use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib};
 use std::mem;
-use tdgrand::{enums, types};
+use tdlib::{enums, types};
 
 use crate::session::chat::{Chat, ChatAction};
 

--- a/src/session/chat/history.rs
+++ b/src/session/chat/history.rs
@@ -4,9 +4,9 @@ use gtk::subclass::prelude::*;
 use gtk::{gio, glib};
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
-use tdgrand::enums::{self, Update};
-use tdgrand::functions;
-use tdgrand::types::Message as TelegramMessage;
+use tdlib::enums::{self, Update};
+use tdlib::functions;
+use tdlib::types::Message as TelegramMessage;
 
 use crate::session::chat::{Item, ItemType, Message};
 use crate::session::Chat;

--- a/src/session/chat/message.rs
+++ b/src/session/chat/message.rs
@@ -1,8 +1,8 @@
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use tdgrand::enums::{MessageSender as TdMessageSender, Update};
-use tdgrand::types::Message as TdMessage;
+use tdlib::enums::{MessageSender as TdMessageSender, Update};
+use tdlib::types::Message as TdMessage;
 
 use crate::session::chat::BoxedMessageContent;
 use crate::session::{Chat, Session, User};

--- a/src/session/chat/mod.rs
+++ b/src/session/chat/mod.rs
@@ -15,8 +15,8 @@ pub use self::sponsored_message::SponsoredMessage;
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use tdgrand::enums::{self, ChatType as TdChatType, MessageContent, Update};
-use tdgrand::types::{Chat as TelegramChat, ChatNotificationSettings, DraftMessage};
+use tdlib::enums::{self, ChatType as TdChatType, MessageContent, Update};
+use tdlib::types::{Chat as TelegramChat, ChatNotificationSettings, DraftMessage};
 
 use crate::session::{Avatar, BasicGroup, SecretChat, Supergroup, User};
 use crate::Session;

--- a/src/session/chat/sponsored_message.rs
+++ b/src/session/chat/sponsored_message.rs
@@ -1,8 +1,8 @@
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use tdgrand::types::Error as TdError;
-use tdgrand::{enums, functions};
+use tdlib::types::Error as TdError;
+use tdlib::{enums, functions};
 
 use crate::session::chat::BoxedMessageContent;
 use crate::session::Chat;

--- a/src/session/chat_list.rs
+++ b/src/session/chat_list.rs
@@ -2,9 +2,9 @@ use glib::clone;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib};
-use tdgrand::enums::Update;
-use tdgrand::functions;
-use tdgrand::types::Chat as TelegramChat;
+use tdlib::enums::Update;
+use tdlib::functions;
+use tdlib::types::Chat as TelegramChat;
 
 use crate::session::Chat;
 use crate::utils::do_async;

--- a/src/session/content/chat_action_bar.rs
+++ b/src/session/content/chat_action_bar.rs
@@ -3,8 +3,8 @@ use glib::signal::Inhibit;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gdk, glib, CompositeTemplate};
-use tdgrand::enums::{ChatAction, InputMessageContent};
-use tdgrand::{functions, types};
+use tdlib::enums::{ChatAction, InputMessageContent};
+use tdlib::{functions, types};
 
 use crate::session::chat::BoxedDraftMessage;
 use crate::session::Chat;

--- a/src/session/content/item_row.rs
+++ b/src/session/content/item_row.rs
@@ -5,7 +5,7 @@ use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use std::borrow::Cow;
-use tdgrand::enums::{MessageContent, StickerType, UserType};
+use tdlib::enums::{MessageContent, StickerType, UserType};
 
 use crate::session::chat::{ChatType, Item, ItemType, Message, MessageSender, SponsoredMessage};
 use crate::session::content::message_row::{MessagePhoto, MessageSticker, MessageText};

--- a/src/session/content/message_row/photo.rs
+++ b/src/session/content/message_row/photo.rs
@@ -2,8 +2,8 @@ use glib::{clone, closure};
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gdk, gio, glib, CompositeTemplate};
-use tdgrand::enums::MessageContent;
-use tdgrand::types::File;
+use tdlib::enums::MessageContent;
+use tdlib::types::File;
 
 use crate::session::chat::{BoxedMessageContent, Message};
 use crate::session::content::message_row::Media;

--- a/src/session/content/message_row/sticker.rs
+++ b/src/session/content/message_row/sticker.rs
@@ -2,8 +2,8 @@ use glib::clone;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gdk, gio, glib, CompositeTemplate};
-use tdgrand::enums::MessageContent;
-use tdgrand::types::File;
+use tdlib::enums::MessageContent;
+use tdlib::types::File;
 
 use crate::session::chat::Message;
 use crate::session::content::message_row::StickerPaintable;

--- a/src/session/content/message_row/text.rs
+++ b/src/session/content/message_row/text.rs
@@ -3,7 +3,7 @@ use glib::closure;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{glib, CompositeTemplate};
-use tdgrand::enums::MessageContent;
+use tdlib::enums::MessageContent;
 
 use crate::session::chat::{BoxedMessageContent, Message, MessageSender, SponsoredMessage};
 use crate::session::content::{MessageRow, MessageRowExt};

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -33,9 +33,9 @@ use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{glib, CompositeTemplate};
 use std::collections::hash_map::{Entry, HashMap};
-use tdgrand::enums::{NotificationSettingsScope, Update};
-use tdgrand::functions;
-use tdgrand::types::{File, ScopeNotificationSettings};
+use tdlib::enums::{NotificationSettingsScope, Update};
+use tdlib::functions;
+use tdlib::types::{File, ScopeNotificationSettings};
 
 use crate::session_manager::DatabaseInfo;
 use crate::utils::log_out;
@@ -314,7 +314,7 @@ impl Session {
             }
             Update::UnreadMessageCount(ref update_) => {
                 // TODO: Also handle archived chats
-                if let tdgrand::enums::ChatList::Main = update_.chat_list {
+                if let tdlib::enums::ChatList::Main = update_.chat_list {
                     self.chat_list().handle_update(update)
                 }
             }

--- a/src/session/secret_chat.rs
+++ b/src/session/secret_chat.rs
@@ -1,8 +1,8 @@
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use tdgrand::enums::{SecretChatState as TdSecretChatState, Update};
-use tdgrand::types::SecretChat as TdSecretChat;
+use tdlib::enums::{SecretChatState as TdSecretChatState, Update};
+use tdlib::types::SecretChat as TdSecretChat;
 
 use crate::session::User;
 

--- a/src/session/secret_chat_list.rs
+++ b/src/session/secret_chat_list.rs
@@ -2,7 +2,7 @@ use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib};
 use indexmap::map::Entry;
-use tdgrand::enums::Update;
+use tdlib::enums::Update;
 
 use crate::session::SecretChat;
 use crate::Session;

--- a/src/session/sidebar/avatar.rs
+++ b/src/session/sidebar/avatar.rs
@@ -4,7 +4,7 @@ use glib::closure;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{glib, gsk, CompositeTemplate};
-use tdgrand::enums::{UserStatus, UserType};
+use tdlib::enums::{UserStatus, UserType};
 
 use crate::session::user::BoxedUserStatus;
 use crate::session::{Chat, Session, User};

--- a/src/session/sidebar/mod.rs
+++ b/src/session/sidebar/mod.rs
@@ -9,7 +9,7 @@ use glib::clone;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib, CompositeTemplate};
-use tdgrand::{enums, functions};
+use tdlib::{enums, functions};
 
 use crate::session::{Chat, ChatType, User};
 use crate::utils::do_async;

--- a/src/session/sidebar/row.rs
+++ b/src/session/sidebar/row.rs
@@ -4,8 +4,8 @@ use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{glib, CompositeTemplate};
 use std::borrow::Cow;
-use tdgrand::enums::{CallDiscardReason, InputMessageContent, MessageContent};
-use tdgrand::types::{DraftMessage, MessageCall};
+use tdlib::enums::{CallDiscardReason, InputMessageContent, MessageContent};
+use tdlib::types::{DraftMessage, MessageCall};
 
 use crate::session::chat::{
     BoxedChatNotificationSettings, BoxedDraftMessage, BoxedMessageContent, ChatAction,
@@ -749,7 +749,7 @@ fn stringify_message_voice_note(caption_text: &str) -> String {
 }
 
 fn stringify_action(action: &ChatAction) -> String {
-    use tdgrand::enums::ChatAction::*;
+    use tdlib::enums::ChatAction::*;
 
     let show_sender = matches!(
         action.chat().type_(),

--- a/src/session/supergroup.rs
+++ b/src/session/supergroup.rs
@@ -1,8 +1,8 @@
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use tdgrand::enums::Update;
-use tdgrand::types::Supergroup as TdSupergroup;
+use tdlib::enums::Update;
+use tdlib::types::Supergroup as TdSupergroup;
 
 mod imp {
     use super::*;

--- a/src/session/supergroup_list.rs
+++ b/src/session/supergroup_list.rs
@@ -2,7 +2,7 @@ use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib};
 use indexmap::map::Entry;
-use tdgrand::enums::Update;
+use tdlib::enums::Update;
 
 use crate::session::Supergroup;
 

--- a/src/session/user.rs
+++ b/src/session/user.rs
@@ -1,8 +1,8 @@
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use tdgrand::enums::{Update, UserStatus, UserType};
-use tdgrand::types::User as TdUser;
+use tdlib::enums::{Update, UserStatus, UserType};
+use tdlib::types::User as TdUser;
 
 use crate::session::Avatar;
 use crate::Session;

--- a/src/session/user_list.rs
+++ b/src/session/user_list.rs
@@ -2,7 +2,7 @@ use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib};
 use indexmap::map::Entry;
-use tdgrand::enums::Update;
+use tdlib::enums::Update;
 
 use crate::session::User;
 use crate::Session;

--- a/src/session_manager.rs
+++ b/src/session_manager.rs
@@ -37,9 +37,9 @@ use gtk::subclass::prelude::*;
 use gtk::{gio, glib, CompositeTemplate};
 use std::borrow::Borrow;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tdgrand::enums::{self, AuthorizationState, Update};
-use tdgrand::functions;
-use tdgrand::types::{self, UpdateAuthorizationState};
+use tdlib::enums::{self, AuthorizationState, Update};
+use tdlib::functions;
+use tdlib::types::{self, UpdateAuthorizationState};
 use tokio::fs;
 use tokio_stream::wrappers::ReadDirStream;
 
@@ -350,7 +350,7 @@ impl SessionManager {
     /// This function is used to add/load an existing session that already had the
     /// `AuthorizationState::Ready` state from a previous application run.
     pub fn add_existing_session(&self, database_info: DatabaseInfo) {
-        let client_id = tdgrand::create_client();
+        let client_id = tdlib::create_client();
 
         self.imp().clients.borrow_mut().insert(
             client_id,
@@ -370,7 +370,7 @@ impl SessionManager {
     /// This function is used to add a new session for a so far unknown account. This means it will
     /// go through the login process.
     pub fn add_new_session(&self, use_test_dc: bool) {
-        let client_id = tdgrand::create_client();
+        let client_id = tdlib::create_client();
         self.init_new_session(client_id, use_test_dc);
         send_log_level(client_id);
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,9 +5,9 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use std::future::Future;
 use std::path::PathBuf;
-use tdgrand::enums::TextEntityType;
-use tdgrand::types::{self, FormattedText};
-use tdgrand::{enums, functions};
+use tdlib::enums::TextEntityType;
+use tdlib::types::{self, FormattedText};
+use tdlib::{enums, functions};
 
 use crate::session_manager::DatabaseInfo;
 use crate::{config, APPLICATION_OPTS, RUNTIME};

--- a/src/window.rs
+++ b/src/window.rs
@@ -5,10 +5,10 @@ use gtk::subclass::prelude::*;
 use gtk::{gio, glib, CompositeTemplate};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use tdgrand::enums::{
+use tdlib::enums::{
     self, AuthorizationState, MessageContent, MessageSender as TelegramMessageSender, Update,
 };
-use tdgrand::types::{self, Message as TelegramMessage};
+use tdlib::types::{self, Message as TelegramMessage};
 use tokio::task;
 
 use crate::config::{APP_ID, PROFILE};
@@ -142,7 +142,7 @@ impl Window {
                 let receiver_should_stop = receiver_should_stop.clone();
                 let sender = sender.clone();
                 let stop = task::spawn_blocking(move || {
-                    if let Some((update, client_id)) = tdgrand::receive() {
+                    if let Some((update, client_id)) = tdlib::receive() {
                         if receiver_should_stop.load(Ordering::Acquire) {
                             if let Update::AuthorizationState(ref update) = update {
                                 if let AuthorizationState::Closed = update.authorization_state {


### PR DESCRIPTION
I finally released (and renamed) tdgrand (now called tdlib-rs), this also means we finally have proper [hosted docs](https://docs.rs/tdlib/0.1.0/tdlib/) for it.