### PR TITLE
avatar: Improve separation between widget and data

### DIFF
--- a/data/resources/ui/content-user-dialog.ui
+++ b/data/resources/ui/content-user-dialog.ui
@@ -30,9 +30,7 @@
                       <object class="ComponentsAvatar">
                         <property name="size">96</property>
                         <binding name="item">
-                          <lookup name="avatar">
-                            <lookup name="user">ContentUserDialog</lookup>
-                          </lookup>
+                          <lookup name="user">ContentUserDialog</lookup>
                         </binding>
                       </object>
                     </child>

--- a/data/resources/ui/session-entry-row.ui
+++ b/data/resources/ui/session-entry-row.ui
@@ -12,10 +12,8 @@
       <object class="AvatarWithSelection" id="account_avatar">
         <property name="size">40</property>
         <binding name="item">
-          <lookup name="avatar" type="User">
-            <lookup name="me" type="Session">
-              <lookup name="session">SessionEntryRow</lookup>
-            </lookup>
+          <lookup name="me" type="Session">
+            <lookup name="session">SessionEntryRow</lookup>
           </lookup>
         </binding>
       </object>

--- a/data/resources/ui/sidebar.ui
+++ b/data/resources/ui/sidebar.ui
@@ -44,10 +44,8 @@
               <object class="ComponentsAvatar">
                 <property name="size">24</property>
                 <binding name="item">
-                  <lookup name="avatar" type="User">
-                    <lookup name="me" type="Session">
-                      <lookup name="session">Sidebar</lookup>
-                    </lookup>
+                  <lookup name="me" type="Session">
+                    <lookup name="session">Sidebar</lookup>
                   </lookup>
                 </binding>
               </object>

--- a/src/session/avatar.rs
+++ b/src/session/avatar.rs
@@ -1,220 +1,24 @@
-use glib::clone;
-use gtk::prelude::*;
-use gtk::subclass::prelude::*;
-use gtk::{gdk, gio, glib};
-use tdlib::types::{ChatPhotoInfo, File, ProfilePhoto};
+use gtk::glib;
+use tdlib::types::{ChatPhotoInfo as TdChatPhotoInfo, File, ProfilePhoto as TdProfilePhoto};
 
-use crate::Session;
+#[derive(Clone, Debug, glib::Boxed)]
+#[boxed_type(name = "Avatar", nullable)]
+pub(crate) struct Avatar(pub(super) File);
 
-mod imp {
-    use super::*;
-    use once_cell::sync::{Lazy, OnceCell};
-    use std::cell::{Cell, RefCell};
-
-    #[derive(Debug, Default)]
-    pub(crate) struct Avatar {
-        pub(super) image: RefCell<Option<gdk::Paintable>>,
-        pub(super) needed: Cell<bool>,
-        pub(super) display_name: RefCell<Option<String>>,
-        pub(super) icon_name: RefCell<Option<String>>,
-        pub(super) session: OnceCell<Session>,
-
-        pub(super) image_file: RefCell<Option<File>>,
-    }
-
-    #[glib::object_subclass]
-    impl ObjectSubclass for Avatar {
-        const NAME: &'static str = "Avatar";
-        type Type = super::Avatar;
-    }
-
-    impl ObjectImpl for Avatar {
-        fn properties() -> &'static [glib::ParamSpec] {
-            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
-                vec![
-                    glib::ParamSpecObject::new(
-                        "image",
-                        "Image",
-                        "The image of this avatar",
-                        gdk::Paintable::static_type(),
-                        glib::ParamFlags::READABLE,
-                    ),
-                    glib::ParamSpecBoolean::new(
-                        "needed",
-                        "Needed",
-                        "Whether the image needs to be loaded or not",
-                        false,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
-                    ),
-                    glib::ParamSpecString::new(
-                        "display-name",
-                        "Display Name",
-                        "The display name used for this avatar",
-                        None,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
-                    ),
-                    glib::ParamSpecString::new(
-                        "icon-name",
-                        "Icon Name",
-                        "The icon name used for this avatar",
-                        None,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
-                    ),
-                    glib::ParamSpecObject::new(
-                        "session",
-                        "Session",
-                        "The session",
-                        Session::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
-                    ),
-                ]
-            });
-
-            PROPERTIES.as_ref()
-        }
-
-        fn set_property(
-            &self,
-            obj: &Self::Type,
-            _id: usize,
-            value: &glib::Value,
-            pspec: &glib::ParamSpec,
-        ) {
-            match pspec.name() {
-                "needed" => obj.set_needed(value.get().unwrap()),
-                "display-name" => obj.set_display_name(value.get().unwrap()),
-                "icon-name" => obj.set_icon_name(value.get().unwrap()),
-                "session" => self.session.set(value.get().unwrap()).unwrap(),
-                _ => unimplemented!(),
-            }
-        }
-
-        fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
-            match pspec.name() {
-                "image" => obj.image().to_value(),
-                "needed" => obj.needed().to_value(),
-                "display-name" => obj.display_name().to_value(),
-                "icon-name" => obj.icon_name().to_value(),
-                "session" => obj.session().to_value(),
-                _ => unimplemented!(),
-            }
-        }
+impl From<TdChatPhotoInfo> for Avatar {
+    fn from(td_chat_photo_info: TdChatPhotoInfo) -> Self {
+        Self(td_chat_photo_info.small)
     }
 }
 
-glib::wrapper! {
-    pub(crate) struct Avatar(ObjectSubclass<imp::Avatar>);
+impl From<TdProfilePhoto> for Avatar {
+    fn from(td_profile_photo: TdProfilePhoto) -> Self {
+        Self(td_profile_photo.small)
+    }
 }
 
-impl Avatar {
-    pub(crate) fn new(session: &Session) -> Self {
-        glib::Object::new(&[("session", session)]).expect("Failed to create Avatar")
-    }
-
-    pub(crate) fn update_from_chat_photo(&self, chat_photo: Option<ChatPhotoInfo>) {
-        let image_file = chat_photo.map(|data| data.small);
-        self.set_image_file(image_file);
-    }
-
-    pub(crate) fn update_from_user_photo(&self, user_photo: Option<ProfilePhoto>) {
-        let image_file = user_photo.map(|data| data.small);
-        self.set_image_file(image_file);
-    }
-
-    fn load(&self) {
-        if !self.needed() {
-            return;
-        }
-
-        if let Some(file) = &*self.imp().image_file.borrow() {
-            if file.local.is_downloading_completed {
-                let gfile = gio::File::for_path(&file.local.path);
-                let texture = gdk::Texture::from_file(&gfile).unwrap();
-
-                self.set_image(Some(texture.upcast()));
-            } else if file.local.can_be_downloaded && !file.local.is_downloading_active {
-                let (sender, receiver) =
-                    glib::MainContext::sync_channel::<File>(Default::default(), 5);
-
-                receiver.attach(
-                    None,
-                    clone!(@weak self as obj => @default-return glib::Continue(false), move |file| {
-                        obj.set_image_file(Some(file));
-
-                        glib::Continue(true)
-                    }),
-                );
-
-                self.session().download_file(file.id, sender);
-            }
-        }
-    }
-
-    fn set_image_file(&self, file: Option<File>) {
-        let is_some = file.is_some();
-        self.imp().image_file.replace(file);
-
-        if is_some {
-            self.load();
-        } else {
-            self.set_image(None);
-        }
-    }
-
-    pub(crate) fn image(&self) -> Option<gdk::Paintable> {
-        self.imp().image.borrow().clone()
-    }
-
-    fn set_image(&self, image: Option<gdk::Paintable>) {
-        self.imp().image.replace(image);
-        self.notify("image");
-    }
-
-    pub(crate) fn needed(&self) -> bool {
-        self.imp().needed.get()
-    }
-
-    pub(crate) fn set_needed(&self, needed: bool) {
-        if self.needed() == needed {
-            return;
-        }
-
-        self.imp().needed.set(needed);
-
-        if needed {
-            self.load();
-        }
-
-        self.notify("needed");
-    }
-
-    pub(crate) fn display_name(&self) -> Option<String> {
-        self.imp().display_name.borrow().clone()
-    }
-
-    pub(crate) fn set_display_name(&self, display_name: Option<String>) {
-        if self.display_name() == display_name {
-            return;
-        }
-
-        self.imp().display_name.replace(display_name);
-        self.notify("display-name");
-    }
-
-    pub(crate) fn icon_name(&self) -> Option<String> {
-        self.imp().icon_name.borrow().clone()
-    }
-
-    pub(crate) fn set_icon_name(&self, icon_name: Option<String>) {
-        if self.icon_name() == icon_name {
-            return;
-        }
-
-        self.imp().icon_name.replace(icon_name);
-        self.notify("icon-name");
-    }
-
-    pub(crate) fn session(&self) -> &Session {
-        self.imp().session.get().unwrap()
+impl PartialEq for Avatar {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.id == other.0.id
     }
 }

--- a/src/session/components/avatar.rs
+++ b/src/session/components/avatar.rs
@@ -1,9 +1,11 @@
-use glib::closure;
-use gtk::glib;
+use glib::{clone, closure};
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
+use gtk::{gdk, gio, glib};
+use tdlib::types::File;
 
-use crate::session::Avatar as AvatarItem;
+use crate::session::{Avatar as AvatarItem, Chat, User};
+use crate::Session;
 
 mod imp {
     use super::*;
@@ -14,7 +16,9 @@ mod imp {
     #[derive(Debug, Default, CompositeTemplate)]
     #[template(resource = "/com/github/melix99/telegrand/ui/components-avatar.ui")]
     pub(crate) struct Avatar {
-        pub(super) item: RefCell<Option<AvatarItem>>,
+        /// A `Chat` or `User`
+        pub(super) item: RefCell<Option<glib::Object>>,
+        pub(super) handler_id: RefCell<Option<glib::SignalHandlerId>>,
         #[template_child]
         pub(super) avatar: TemplateChild<adw::Avatar>,
     }
@@ -42,14 +46,21 @@ mod imp {
                     glib::ParamSpecObject::new(
                         "item",
                         "Item",
-                        "The avatar item displayed by this widget",
-                        AvatarItem::static_type(),
+                        "The item of the avatar",
+                        glib::Object::static_type(),
+                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                    ),
+                    glib::ParamSpecString::new(
+                        "custom-text",
+                        "Custom Text",
+                        "The custom text of the avatar",
+                        None,
                         glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
                     ),
                     glib::ParamSpecInt::new(
                         "size",
                         "Size",
-                        "The size of this avatar",
+                        "The size of the avatar",
                         -1,
                         i32::MAX,
                         -1,
@@ -70,6 +81,7 @@ mod imp {
         ) {
             match pspec.name() {
                 "item" => obj.set_item(value.get().unwrap()),
+                "custom-text" => obj.set_custom_text(value.get().unwrap()),
                 "size" => obj.set_size(value.get().unwrap()),
                 _ => unimplemented!(),
             }
@@ -78,6 +90,7 @@ mod imp {
         fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
             match pspec.name() {
                 "item" => obj.item().to_value(),
+                "custom-text" => obj.custom_text().to_value(),
                 "size" => obj.size().to_value(),
                 _ => unimplemented!(),
             }
@@ -111,72 +124,126 @@ impl Avatar {
 
     fn setup_expressions(&self) {
         let item_expression = Self::this_expression("item");
-
-        let icon_name_expression = item_expression.chain_property::<AvatarItem>("icon-name");
-
-        let custom_image_expression = item_expression.chain_property::<AvatarItem>("image");
-        let custom_image_expression =
-            gtk::ClosureExpression::new::<Option<gtk::gdk::Paintable>, _, _>(
-                &[
-                    icon_name_expression.clone().upcast(),
-                    custom_image_expression.upcast(),
-                ],
-                closure!(|_: Self,
-                          icon_name: Option<String>,
-                          cusom_image: Option<gtk::gdk::Paintable>| {
-                    match icon_name {
-                        Some(_) => None,
-                        None => cusom_image,
-                    }
-                }),
-            );
-
-        let show_initials_expression = icon_name_expression.chain_closure::<bool>(closure!(
-            |_: Self, icon_name: Option<String>| icon_name.is_none()
-        ));
-
-        let text_expression = item_expression.chain_property::<AvatarItem>("display-name");
-        let text_expression = gtk::ClosureExpression::new::<Option<String>, _, _>(
-            &[
-                icon_name_expression.clone().upcast(),
-                text_expression.upcast(),
-            ],
-            closure!(
-                |_: Self, icon_name: Option<String>, display_name: Option<String>| {
-                    icon_name
-                        // If we use an icon for the avatar, we always want its color to be blue. As
-                        // AdwAvatar doesn't allow us to set the color in an explicit manner, we are
-                        // forced to use this workaround.
-                        .map(|_| Some(String::from("-")))
-                        .unwrap_or(display_name)
-                }
-            ),
-        );
-
         let imp = self.imp();
 
+        // Chat title expression
+        let title_expression = item_expression.chain_property::<Chat>("title");
+        gtk::ClosureExpression::new::<String, _, _>(
+            &[item_expression.clone(), title_expression],
+            closure!(|_: Self, item: Option<glib::Object>, title: String| {
+                item.as_ref()
+                    .and_then(|i| i.downcast_ref::<Chat>())
+                    .filter(|chat| chat.is_own_chat())
+                    // Workaround for having a blue AdwAvatar for Saved Messages chat
+                    .map(|_| "-".to_string())
+                    .unwrap_or(title)
+            }),
+        )
+        .bind(&*imp.avatar, "text", Some(self));
+
+        // User title expression
+        User::full_name_expression(&item_expression).bind(&*imp.avatar, "text", Some(self));
+
+        // Icon expression
+        let icon_name_expression =
+            item_expression.chain_closure::<Option<String>>(closure!(|_: Self,
+                                                                      item: Option<
+                glib::Object,
+            >| {
+                item.as_ref()
+                    .and_then(|i| i.downcast_ref::<Chat>())
+                    .filter(|chat| chat.is_own_chat())
+                    // Show bookmark icon for Saved Messages chat
+                    .map(|_| "user-bookmarks-symbolic")
+            }));
         icon_name_expression.bind(&*imp.avatar, "icon-name", Some(self));
-        custom_image_expression.bind(&*imp.avatar, "custom-image", Some(self));
-        show_initials_expression.bind(&*imp.avatar, "show-initials", Some(self));
-        text_expression.bind(&*imp.avatar, "text", Some(self));
+
+        // Don't show the initials if we show a custom icon
+        icon_name_expression
+            .chain_closure::<bool>(closure!(
+                |_: Self, icon_name: Option<String>| icon_name.is_none()
+            ))
+            .bind(&*imp.avatar, "show-initials", Some(self));
     }
 
-    fn request_avatar_image(&self) {
-        if let Some(item) = &*self.imp().item.borrow() {
-            item.set_needed(true);
+    fn load_image(&self, avatar_item: Option<AvatarItem>, session: Session) {
+        if let Some(avatar_item) = avatar_item {
+            let file = avatar_item.0;
+            if file.local.is_downloading_completed {
+                let gfile = gio::File::for_path(&file.local.path);
+                let texture = gdk::Texture::from_file(&gfile).unwrap();
+                self.imp().avatar.set_custom_image(Some(&texture));
+            } else {
+                let (sender, receiver) =
+                    glib::MainContext::sync_channel::<File>(Default::default(), 5);
+
+                receiver.attach(
+                    None,
+                    clone!(@weak self as obj => @default-return glib::Continue(false), move |file| {
+                        if file.local.is_downloading_completed {
+                            let gfile = gio::File::for_path(&file.local.path);
+                            let texture = gdk::Texture::from_file(&gfile).unwrap();
+                            obj.imp().avatar.set_custom_image(Some(&texture));
+                        }
+                        glib::Continue(true)
+                    }),
+                );
+
+                session.download_file(file.id, sender);
+            }
+        } else {
+            self.imp().avatar.set_custom_image(gdk::Paintable::NONE);
         }
     }
 
-    pub(crate) fn item(&self) -> Option<AvatarItem> {
+    pub(crate) fn item(&self) -> Option<glib::Object> {
         self.imp().item.borrow().clone()
     }
 
-    pub(crate) fn set_item(&self, item: Option<AvatarItem>) {
-        self.imp().item.replace(item);
+    pub(crate) fn set_item(&self, item: Option<glib::Object>) {
+        let imp = self.imp();
 
-        self.request_avatar_image();
+        if let Some(id) = imp.handler_id.take() {
+            self.item().unwrap().disconnect(id);
+        }
 
+        if let Some(ref item) = item {
+            if let Some(chat) = item.downcast_ref::<Chat>() {
+                if chat.is_own_chat() {
+                    imp.avatar.set_custom_image(gdk::Paintable::NONE);
+                } else {
+                    self.load_image(chat.avatar(), chat.session());
+                    let handler_id =
+                        chat.connect_avatar_notify(clone!(@weak self as obj => move |chat, _| {
+                            obj.load_image(chat.avatar(), chat.session());
+                        }));
+                    imp.handler_id.replace(Some(handler_id));
+                }
+            } else if let Some(user) = item.downcast_ref::<User>() {
+                self.load_image(user.avatar(), user.session());
+                let handler_id =
+                    user.connect_avatar_notify(clone!(@weak self as obj => move |user, _| {
+                        obj.load_image(user.avatar(), user.session());
+                    }));
+                imp.handler_id.replace(Some(handler_id));
+            } else {
+                imp.avatar.set_custom_image(gdk::Paintable::NONE);
+            }
+        } else {
+            imp.avatar.set_custom_image(gdk::Paintable::NONE);
+        }
+
+        imp.item.replace(item);
         self.notify("item");
+    }
+
+    pub(crate) fn custom_text(&self) -> Option<String> {
+        self.imp().avatar.text().map(Into::into)
+    }
+
+    pub(crate) fn set_custom_text(&self, text: Option<&str>) {
+        self.imp().avatar.set_text(text);
+        self.notify("custom-text");
     }
 
     pub(crate) fn size(&self) -> i32 {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -74,7 +74,6 @@ mod imp {
         pub(super) channel_chats_notification_settings:
             RefCell<Option<BoxedScopeNotificationSettings>>,
         pub(super) downloading_files: RefCell<HashMap<i32, Vec<SyncSender<File>>>>,
-        pub(super) sender_name_avatars: RefCell<HashMap<String, Avatar>>,
         #[template_child]
         pub(super) leaflet: TemplateChild<adw::Leaflet>,
         #[template_child]
@@ -360,21 +359,6 @@ impl Session {
 
                 let client_id = self.client_id();
                 RUNTIME.spawn(functions::download_file(file_id, 5, 0, 0, false, client_id));
-            }
-        }
-    }
-
-    pub(crate) fn sender_name_avatar(&self, sender_name: &str) -> Avatar {
-        let mut sender_name_avatars = self.imp().sender_name_avatars.borrow_mut();
-
-        match sender_name_avatars.get(sender_name).cloned() {
-            Some(avatar) => avatar,
-            None => {
-                let avatar = crate::session::Avatar::new(self);
-                avatar.set_display_name(Some(sender_name.to_owned()));
-
-                sender_name_avatars.insert(sender_name.to_owned(), avatar.clone());
-                avatar
             }
         }
     }

--- a/src/session/sidebar/avatar.rs
+++ b/src/session/sidebar/avatar.rs
@@ -204,17 +204,15 @@ impl Avatar {
             binding.unwatch();
         }
 
+        self.imp().avatar.set_item(item.clone());
+
         if let Some(ref item) = item {
             if let Some(chat) = item.downcast_ref::<Chat>() {
-                imp.avatar.set_item(Some(chat.avatar().to_owned()));
-
                 match chat.type_().user() {
                     Some(user) => self.setup_is_online_binding(user),
                     None => self.set_is_online(false),
                 }
             } else if let Some(user) = item.downcast_ref::<User>() {
-                imp.avatar.set_item(Some(user.avatar().to_owned()));
-
                 self.setup_is_online_binding(user);
             } else {
                 unreachable!("Unexpected item type: {:?}", item);

--- a/src/session/sidebar/session_switcher/avatar_with_selection.rs
+++ b/src/session/sidebar/session_switcher/avatar_with_selection.rs
@@ -4,7 +4,6 @@ use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 
 use crate::session::components::Avatar;
-use crate::session::Avatar as AvatarItem;
 
 mod imp {
     use super::*;
@@ -45,7 +44,7 @@ mod imp {
                         "item",
                         "Item",
                         "The Avatar item displayed by this widget",
-                        AvatarItem::static_type(),
+                        glib::Object::static_type(),
                         glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
                     ),
                     glib::ParamSpecInt::new(


### PR DESCRIPTION
```
This commit massively refactors the avatars by improving the
separation between the avatar component (widget) and item (gobject).
The avatar item is now just a simple boxed type around
tdlib's ProfilePhoto or ChatPhotoInfo, so it will no longer store
the paintable and other widget-related properties. The widget,
instead, has become the one that holds all the properties and
expressions to correctly display the avatar of either an User
or a Chat.
```

The rationale about the change is that we were storing lots of not-too-useful data and never cleaning them. The most obvious part is storing the paintables inside the avatar item, which means that they were remaining stored inside the gobjects even when we no longer needed them. But it's not just that, the no-longer-needed paintables were also auto-updating when receiving a new avatar update, so that's not really useful.

The avatars are now created on demand like it should have been in the first place. Maybe a caching system could be useful for the chat history, but actually I'm not too sure, both because the avatars are really small to decode (160x160 images) and also because after we implement #251 the number of avatars to show will decrease.

This is also a step towards #231.

CC @marhkb, since I touched a lot of your code.