### PR TITLE
Implement message-photo sending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,6 +1535,7 @@ dependencies = [
  "qrcode-generator",
  "regex",
  "tdlib",
+ "temp-dir",
  "webp",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
+name = "ashpd"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db023823e72175ec1a514231d5ff28ad7f7e15702a3ad7507dbc7ac1feea7b6"
+dependencies = [
+ "enumflags2",
+ "futures",
+ "gdk4-wayland",
+ "gdk4-x11",
+ "gtk4",
+ "rand",
+ "serde",
+ "serde_repr",
+ "zbus",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90622698a1218e0b2fb846c97b5f19a0831f6baddee73d9454156365ccfa473b"
+dependencies = [
+ "easy-parallel",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
+dependencies = [
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "once_cell",
+ "parking",
+ "polling",
+ "slab",
+ "socket2",
+ "waker-fn",
+ "winapi",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-recursion"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-task"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
+
+[[package]]
+name = "async-trait"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +166,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cairo-rs"
@@ -113,6 +228,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +272,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "easy-parallel"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6907e25393cdcc1f4f3f513d9aac1e840eb1cc341a0fccb01171f7d14d10b946"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b3ab37dc79652c9d85f1f7b6070d77d321d2467f5fe7b00d6b7a86c57b092ae"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58dc3c5e468259f19f2d46304a6b28f1c3d034442e14b322d2b850e36f6d5ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +320,21 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -184,6 +361,7 @@ checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -224,6 +402,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,9 +445,13 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -306,6 +514,66 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "system-deps",
+]
+
+[[package]]
+name = "gdk4-wayland"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3604742a9967cf74756cef18e56fbd6481e7bb90f3b931211abb18c0a6a4aa"
+dependencies = [
+ "gdk4",
+ "gdk4-wayland-sys",
+ "gio",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "gdk4-wayland-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cbf7fa3fc7714c72902d82229677f9291f7cceb33855c5cef868f177356c30"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk4-x11"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a54a4f3405461afa18ddc2b5fbeaecc2558fcd8b132ed0c9c7c4ffa2f9ae22"
+dependencies = [
+ "gdk4",
+ "gdk4-x11-sys",
+ "gio",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "gdk4-x11-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eb40aebb4f15b270df2ac2c463bf7f6d82211d9c5df1d13b84541a63a3139d7"
+dependencies = [
+ "gdk4-sys",
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -548,6 +816,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "html-escape"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +867,15 @@ checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -710,6 +993,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +1082,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
+name = "ordered-stream"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44630c059eacfd6e08bdaa51b1db2ce33119caa4ddc1235e923109aa5f25ccb1"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "pango"
 version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +1115,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "pest"
@@ -836,6 +1148,25 @@ name = "pkg-config"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+
+[[package]]
+name = "polling"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "winapi",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "pretty_env_logger"
@@ -931,6 +1262,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1379,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_with"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1413,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1438,22 @@ name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "socket2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1119,6 +1522,7 @@ name = "telegrand"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ashpd",
  "futures",
  "gettext-rs",
  "gtk4",
@@ -1209,6 +1613,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
 name = "webp"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1632,15 @@ checksum = "cf022f821f166079a407d000ab57e84de020e66ffbbf4edde999bc7d6e371cae"
 dependencies = [
  "image",
  "libwebp-sys",
+]
+
+[[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1248,3 +1673,90 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zbus"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb86f3d4592e26a48b2719742aec94f8ae6238ebde20d98183ee185d1275e9a"
+dependencies = [
+ "async-broadcast",
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "byteorder",
+ "derivative",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "lazy_static",
+ "nix",
+ "once_cell",
+ "ordered-stream",
+ "rand",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "winapi",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36823cc10fddc3c6b19f048903262dacaf8274170e9a255784bdd8b4570a8040"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "zbus_names"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45dfcdcf87b71dad505d30cc27b1b7b88a64b6d1c435648f48f9dbc1fdc4b7e1"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
+
+[[package]]
+name = "zvariant"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ea5dc38b2058fae6a5b79009388143dadce1e91c26a67f984a0fc0381c8033"
+dependencies = [
+ "byteorder",
+ "enumflags2",
+ "libc",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2cecc5a61c2a053f7f653a24cd15b3b0195d7f7ddb5042c837fb32e161fb7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 adw = { version = "0.1", package = "libadwaita" }
 anyhow = "1.0"
+ashpd = { version = "0.3", features = ["feature_gtk4"] }
 futures = { version = "0.3", default-features = false }
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
 gtk = { version = "0.4", package = "gtk4", features = ["v4_6"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ pretty_env_logger = "0.4"
 qrcode-generator = { version = "4.1", default-features = false }
 regex = "1.5"
 tdlib = { version = "0.1", default-features = false }
+temp-dir = "0.1"
 webp = "0.2"

--- a/data/resources/resources.gresource.xml
+++ b/data/resources/resources.gresource.xml
@@ -7,6 +7,7 @@
     <file compressed="true" preprocess="xml-stripblanks">ui/add-account-row.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/avatar-with-selection.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/components-avatar.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/components-message-entry.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content-chat-action-bar.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content-chat-history.ui</file>

--- a/data/resources/resources.gresource.xml
+++ b/data/resources/resources.gresource.xml
@@ -17,6 +17,7 @@
     <file compressed="true" preprocess="xml-stripblanks">ui/content-message-photo.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content-message-sticker.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content-message-text.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/content-send-photo-dialog.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/login.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/preferences-window.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/session-entry-row.ui</file>

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -187,26 +187,22 @@
   font-size: 0.95em;
 }
 
-.chat-action-bar > entry {
+.message-entry > entry {
   padding: 0;
 }
 
-.chat-action-bar > entry > scrollbar  {
+.message-entry > entry > scrollbar  {
   box-shadow: none;
   background: none;
 }
 
-.chat-action-bar > entry > scrollbar slider {
+.message-entry > entry > scrollbar slider {
   min-height: 0;
 }
 
-.chat-action-bar > entry > textview {
+.message-entry > entry > textview {
   background: none;
   color: inherit;
-}
-
-.chat-action-bar > entry > textview > text {
-  background: none;
 }
 
 .qr-code:disabled {

--- a/data/resources/ui/components-message-entry.ui
+++ b/data/resources/ui/components-message-entry.ui
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="MessageEntry" parent="GtkWidget">
+    <property name="layout-manager">
+      <object class="GtkBinLayout"/>
+    </property>
+    <style>
+      <class name="message-entry"/>
+    </style>
+    <child>
+      <object class="GtkScrolledWindow" id="scrolled_window">
+        <property name="css-name">entry</property>
+        <property name="max-content-height">200</property>
+        <property name="hscrollbar-policy">never</property>
+        <property name="propagate-natural-height">True</property>
+        <property name="child">
+          <object class="GtkTextView" id="text_view">
+            <property name="top-margin">8</property>
+            <property name="bottom-margin">8</property>
+            <property name="left-margin">9</property>
+            <property name="right-margin">9</property>
+            <property name="wrap-mode">word-char</property>
+          </object>
+        </property>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/resources/ui/content-chat-action-bar.ui
+++ b/data/resources/ui/content-chat-action-bar.ui
@@ -6,24 +6,10 @@
     </property>
     <style>
       <class name="toolbar"/>
-      <class name="chat-action-bar"/>
     </style>
     <child>
-      <object class="GtkScrolledWindow" id="scrolled_window">
-        <property name="css-name">entry</property>
+      <object class="MessageEntry" id="message_entry">
         <property name="hexpand">True</property>
-        <property name="max-content-height">200</property>
-        <property name="hscrollbar-policy">never</property>
-        <property name="propagate-natural-height">True</property>
-        <property name="child">
-          <object class="GtkTextView" id="message_entry">
-            <property name="top-margin">8</property>
-            <property name="bottom-margin">8</property>
-            <property name="left-margin">9</property>
-            <property name="right-margin">9</property>
-            <property name="wrap-mode">word-char</property>
-          </object>
-        </property>
       </object>
     </child>
     <child>

--- a/data/resources/ui/content-chat-action-bar.ui
+++ b/data/resources/ui/content-chat-action-bar.ui
@@ -8,6 +8,16 @@
       <class name="toolbar"/>
     </style>
     <child>
+      <object class="GtkButton" id="select_file_button">
+        <property name="valign">end</property>
+        <property name="action-name">chat-action-bar.select-file</property>
+        <property name="icon-name">mail-attachment-symbolic</property>
+        <style>
+          <class name="circular"/>
+        </style>
+      </object>
+    </child>
+    <child>
       <object class="MessageEntry" id="message_entry">
         <property name="hexpand">True</property>
       </object>

--- a/data/resources/ui/content-chat-history.ui
+++ b/data/resources/ui/content-chat-history.ui
@@ -71,7 +71,7 @@
         <child>
           <object class="AdwClamp">
             <property name="child">
-              <object class="ContentChatActionBar">
+              <object class="ContentChatActionBar" id="chat_action_bar">
                 <binding name="chat">
                   <lookup name="chat">ContentChatHistory</lookup>
                 </binding>

--- a/data/resources/ui/content-send-photo-dialog.ui
+++ b/data/resources/ui/content-send-photo-dialog.ui
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="ContentSendPhotoDialog" parent="GtkWindow">
+    <property name="default-width">500</property>
+    <property name="default-height">500</property>
+    <property name="modal">True</property>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="header_bar">
+        <style>
+          <class name="flat"/>
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkPicture" id="picture">
+            <property name="vexpand">True</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSeparator"/>
+        </child>
+        <child>
+          <object class="AdwClamp">
+            <property name="child">
+              <object class="GtkBox">
+                <style>
+                  <class name="toolbar"/>
+                </style>
+                <child>
+                  <object class="MessageEntry" id="caption_entry">
+                    <property name="hexpand">True</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton">
+                    <property name="action-name">send-photo-dialog.send-message</property>
+                    <property name="icon-name">send-symbolic</property>
+                    <property name="valign">end</property>
+                    <style>
+                      <class name="circular"/>
+                      <class name="suggested-action"/>
+                    </style>
+                  </object>
+                </child>
+              </object>
+            </property>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/resources/ui/session.ui
+++ b/data/resources/ui/session.ui
@@ -20,7 +20,7 @@
           </object>
         </child>
         <child>
-          <object class="Content">
+          <object class="Content" id="content">
             <property name="compact" bind-source="leaflet" bind-property="folded" bind-flags="sync-create"/>
             <property name="chat" bind-source="Session" bind-property="selected-chat" bind-flags="sync-create | bidirectional"/>
           </object>

--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -34,6 +34,17 @@
             </child>
           </object>
         </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="title" translatable="yes" context="shortcut window">Chat History</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Send Photo from Clipboard</property>
+                <property name="accelerator">&lt;ctrl&gt;v</property>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
   </object>

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,10 @@ use gtk::{gio, glib};
 use once_cell::sync::OnceCell;
 use std::path::PathBuf;
 use std::str::FromStr;
+use temp_dir::TempDir;
 
 pub(crate) static APPLICATION_OPTS: OnceCell<ApplicationOptions> = OnceCell::new();
+pub(crate) static TEMP_DIR: OnceCell<PathBuf> = OnceCell::new();
 
 fn main() {
     // Prepare i18n
@@ -68,6 +70,18 @@ fn main() {
             -1
         }
     });
+
+    // Create temp directory.
+    // This value must live during the entire execution of the app.
+    let temp_dir = TempDir::with_prefix("telegrand");
+    match &temp_dir {
+        Ok(temp_dir) => {
+            TEMP_DIR.set(temp_dir.path().to_path_buf()).unwrap();
+        }
+        Err(e) => {
+            log::warn!("Error creating temp directory: {:?}", e);
+        }
+    }
 
     app.run();
 }

--- a/src/session/components/message_entry.rs
+++ b/src/session/components/message_entry.rs
@@ -1,0 +1,150 @@
+use glib::clone;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use gtk::{glib, CompositeTemplate};
+use tdlib::types::FormattedText;
+
+#[derive(Clone, Debug, PartialEq, glib::Boxed)]
+#[boxed_type(name = "BoxedFormattedText", nullable)]
+pub(crate) struct BoxedFormattedText(pub(crate) FormattedText);
+
+mod imp {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use std::cell::RefCell;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(resource = "/com/github/melix99/telegrand/ui/components-message-entry.ui")]
+    pub(crate) struct MessageEntry {
+        pub(super) formatted_text: RefCell<Option<BoxedFormattedText>>,
+        #[template_child]
+        pub(super) scrolled_window: TemplateChild<gtk::ScrolledWindow>,
+        #[template_child]
+        pub(super) text_view: TemplateChild<gtk::TextView>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MessageEntry {
+        const NAME: &'static str = "MessageEntry";
+        type Type = super::MessageEntry;
+        type ParentType = gtk::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for MessageEntry {
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![glib::ParamSpecBoxed::new(
+                    "formatted-text",
+                    "Formatted text",
+                    "The formatted text of the entry",
+                    BoxedFormattedText::static_type(),
+                    glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                )]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(
+            &self,
+            obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "formatted-text" => obj.set_formatted_text(value.get().unwrap()),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "formatted-text" => obj.formatted_text().to_value(),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn constructed(&self, obj: &Self::Type) {
+            self.parent_constructed(obj);
+
+            self.text_view
+                .buffer()
+                .connect_changed(clone!(@weak obj => move |_| {
+                    obj.text_buffer_changed();
+                }));
+        }
+
+        fn dispose(&self, _obj: &Self::Type) {
+            self.scrolled_window.unparent();
+        }
+    }
+
+    impl WidgetImpl for MessageEntry {}
+}
+
+glib::wrapper! {
+    pub(crate) struct MessageEntry(ObjectSubclass<imp::MessageEntry>)
+        @extends gtk::Widget;
+}
+
+impl MessageEntry {
+    pub(crate) fn new() -> Self {
+        glib::Object::new(&[]).unwrap()
+    }
+
+    fn text_buffer_changed(&self) {
+        let imp = self.imp();
+        let buffer = imp.text_view.buffer();
+        let text = buffer
+            .text(&buffer.start_iter(), &buffer.end_iter(), false)
+            .trim()
+            .to_string();
+
+        if text.is_empty() {
+            imp.formatted_text.replace(None);
+        } else {
+            let formatted_text = FormattedText {
+                text,
+                entities: vec![],
+            };
+            imp.formatted_text
+                .replace(Some(BoxedFormattedText(formatted_text)));
+        }
+
+        self.notify("formatted-text");
+    }
+
+    pub(crate) fn formatted_text(&self) -> Option<BoxedFormattedText> {
+        self.imp().formatted_text.borrow().clone()
+    }
+
+    pub(crate) fn set_formatted_text(&self, formatted_text: Option<BoxedFormattedText>) {
+        if self.formatted_text() == formatted_text {
+            return;
+        }
+
+        let text = formatted_text.map(|f| f.0.text).unwrap_or_default();
+        self.imp().text_view.buffer().set_text(&text);
+    }
+
+    pub(crate) fn connect_formatted_text_notify<F: Fn(&Self, &glib::ParamSpec) + 'static>(
+        &self,
+        f: F,
+    ) -> glib::SignalHandlerId {
+        self.connect_notify_local(Some("formatted-text"), f)
+    }
+}
+
+impl Default for MessageEntry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/session/components/mod.rs
+++ b/src/session/components/mod.rs
@@ -1,3 +1,5 @@
 mod avatar;
+mod message_entry;
 
 pub(crate) use self::avatar::Avatar;
+pub(crate) use self::message_entry::{BoxedFormattedText, MessageEntry};

--- a/src/session/content/chat_history.rs
+++ b/src/session/content/chat_history.rs
@@ -24,6 +24,8 @@ mod imp {
         pub(super) window_title: TemplateChild<adw::WindowTitle>,
         #[template_child]
         pub(super) list_view: TemplateChild<gtk::ListView>,
+        #[template_child]
+        pub(super) chat_action_bar: TemplateChild<ChatActionBar>,
     }
 
     #[glib::object_subclass]
@@ -34,7 +36,6 @@ mod imp {
 
         fn class_init(klass: &mut Self::Class) {
             ItemRow::static_type();
-            ChatActionBar::static_type();
             Self::bind_template(klass);
 
             klass.install_action("chat-history.view-info", None, move |widget, _, _| {
@@ -167,6 +168,10 @@ impl ChatHistory {
                 Err(e) => log::warn!("Failed to request a SponsoredMessage: {:?}", e),
             }
         }));
+    }
+
+    pub(crate) fn handle_paste_action(&self) {
+        self.imp().chat_action_bar.handle_paste_action();
     }
 
     pub(crate) fn chat(&self) -> Option<Chat> {

--- a/src/session/content/mod.rs
+++ b/src/session/content/mod.rs
@@ -4,6 +4,7 @@ mod chat_info_dialog;
 mod event_row;
 mod item_row;
 mod message_row;
+mod send_photo_dialog;
 
 use self::chat_action_bar::ChatActionBar;
 use self::chat_history::ChatHistory;
@@ -11,6 +12,7 @@ use self::chat_info_dialog::ChatInfoDialog;
 use self::event_row::EventRow;
 use self::item_row::ItemRow;
 use self::message_row::{MessageRow, MessageRowExt};
+use self::send_photo_dialog::SendPhotoDialog;
 
 use gtk::glib;
 use gtk::prelude::*;

--- a/src/session/content/mod.rs
+++ b/src/session/content/mod.rs
@@ -129,6 +129,10 @@ impl Content {
         glib::Object::new(&[]).expect("Failed to create Content")
     }
 
+    pub(crate) fn handle_paste_action(&self) {
+        self.imp().chat_history.handle_paste_action();
+    }
+
     pub(crate) fn chat(&self) -> Option<Chat> {
         self.imp().chat.borrow().clone()
     }

--- a/src/session/content/send_photo_dialog.rs
+++ b/src/session/content/send_photo_dialog.rs
@@ -1,0 +1,117 @@
+use glib::clone;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use gtk::{glib, CompositeTemplate};
+use tdlib::enums::{InputFile, InputMessageContent};
+use tdlib::functions;
+use tdlib::types::{InputFileLocal, InputMessagePhoto};
+
+use crate::expressions;
+use crate::session::components::MessageEntry;
+use crate::session::Chat;
+use crate::utils::spawn;
+
+mod imp {
+    use super::*;
+    use once_cell::unsync::OnceCell;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(resource = "/com/github/melix99/telegrand/ui/content-send-photo-dialog.ui")]
+    pub(crate) struct SendPhotoDialog {
+        pub(super) chat: OnceCell<Chat>,
+        pub(super) path: OnceCell<String>,
+        #[template_child]
+        pub(super) header_bar: TemplateChild<gtk::HeaderBar>,
+        #[template_child]
+        pub(super) picture: TemplateChild<gtk::Picture>,
+        #[template_child]
+        pub(super) caption_entry: TemplateChild<MessageEntry>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for SendPhotoDialog {
+        const NAME: &'static str = "ContentSendPhotoDialog";
+        type Type = super::SendPhotoDialog;
+        type ParentType = gtk::Window;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+
+            klass.install_action(
+                "send-photo-dialog.send-message",
+                None,
+                move |widget, _, _| {
+                    spawn(clone!(@weak widget => async move {
+                        widget.send_message().await;
+                    }));
+                },
+            );
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for SendPhotoDialog {}
+    impl WidgetImpl for SendPhotoDialog {}
+    impl WindowImpl for SendPhotoDialog {}
+}
+
+glib::wrapper! {
+    pub(crate) struct SendPhotoDialog(ObjectSubclass<imp::SendPhotoDialog>)
+        @extends gtk::Widget, gtk::Window;
+}
+
+impl SendPhotoDialog {
+    pub(crate) fn new(parent_window: &Option<gtk::Window>, chat: Chat, path: String) -> Self {
+        let send_photo_dialog: Self =
+            glib::Object::new(&[("transient-for", parent_window)]).unwrap();
+        let imp = send_photo_dialog.imp();
+
+        let chat_expression = gtk::ConstantExpression::new(&chat);
+        expressions::chat_display_name(&chat_expression).bind(
+            &send_photo_dialog,
+            "title",
+            glib::Object::NONE,
+        );
+
+        imp.picture.set_filename(Some(&path));
+        imp.chat.set(chat).unwrap();
+        imp.path.set(path).unwrap();
+
+        send_photo_dialog
+    }
+
+    async fn send_message(&self) {
+        let imp = self.imp();
+
+        let chat = imp.chat.get().unwrap();
+        let chat_id = chat.id();
+        let client_id = chat.session().client_id();
+        let path = imp.path.get().unwrap().clone();
+
+        let paintable = imp.picture.paintable().unwrap();
+        let width = paintable.intrinsic_width();
+        let height = paintable.intrinsic_height();
+
+        let file = InputFile::Local(InputFileLocal { path });
+        let content = InputMessageContent::InputMessagePhoto(InputMessagePhoto {
+            photo: file,
+            thumbnail: None,
+            added_sticker_file_ids: vec![],
+            width,
+            height,
+            caption: imp.caption_entry.formatted_text().map(|f| f.0),
+            ttl: 0,
+        });
+
+        // TODO: maybe show an error dialog when this fails?
+        if functions::send_message(chat_id, 0, 0, None, content, client_id)
+            .await
+            .is_ok()
+        {
+            self.close();
+        }
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -77,6 +77,8 @@ mod imp {
         pub(super) leaflet: TemplateChild<adw::Leaflet>,
         #[template_child]
         pub(super) sidebar: TemplateChild<Sidebar>,
+        #[template_child]
+        pub(super) content: TemplateChild<Content>,
     }
 
     #[glib::object_subclass]
@@ -86,7 +88,6 @@ mod imp {
         type ParentType = adw::Bin;
 
         fn class_init(klass: &mut Self::Class) {
-            Content::static_type();
             Self::bind_template(klass);
 
             klass.install_action("content.go-back", None, move |widget, _, _| {
@@ -367,6 +368,10 @@ impl Session {
                 });
             }
         }
+    }
+
+    pub(crate) fn handle_paste_action(&self) {
+        self.imp().content.handle_paste_action();
     }
 
     pub(crate) fn begin_chats_search(&self) {

--- a/src/session_manager.rs
+++ b/src/session_manager.rs
@@ -745,6 +745,16 @@ impl SessionManager {
         }));
     }
 
+    pub(crate) fn handle_paste_action(&self) {
+        if let Some(client_id) = self.active_logged_in_client_id() {
+            let clients = self.imp().clients.borrow();
+            let client = clients.get(&client_id).unwrap();
+            if let ClientState::LoggedIn = client.state {
+                client.session.handle_paste_action();
+            }
+        }
+    }
+
     pub(crate) fn begin_chats_search(&self) {
         if let Some(client_id) = self.active_logged_in_client_id() {
             let clients = self.imp().clients.borrow();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,7 @@ use tdlib::types::{self, FormattedText};
 use tdlib::{enums, functions};
 
 use crate::session_manager::DatabaseInfo;
-use crate::{config, APPLICATION_OPTS};
+use crate::{config, APPLICATION_OPTS, TEMP_DIR};
 
 static PROTOCOL_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\w+://").unwrap());
 
@@ -150,6 +150,11 @@ pub(crate) fn human_friendly_duration(mut seconds: i32) -> String {
 /// Returns the Telegrand data directory (e.g. /home/bob/.local/share/telegrand).
 pub(crate) fn data_dir() -> &'static PathBuf {
     &APPLICATION_OPTS.get().unwrap().data_dir
+}
+
+/// Returns the Telegrand temp directory (e.g. /tmp/telegrand2-0).
+pub(crate) fn temp_dir() -> Option<&'static PathBuf> {
+    TEMP_DIR.get()
 }
 
 pub(crate) async fn send_tdlib_parameters(

--- a/src/window.rs
+++ b/src/window.rs
@@ -45,12 +45,21 @@ mod imp {
             Self::bind_template(klass);
 
             klass.add_binding_action(
+                gdk::Key::v,
+                gdk::ModifierType::CONTROL_MASK,
+                "win.paste",
+                None,
+            );
+            klass.install_action("win.paste", None, move |widget, _, _| {
+                widget.imp().session_manager.handle_paste_action();
+            });
+
+            klass.add_binding_action(
                 gdk::Key::F,
                 gdk::ModifierType::CONTROL_MASK | gdk::ModifierType::SHIFT_MASK,
                 "sidebar.begin-chats-search",
                 None,
             );
-
             klass.install_action("sidebar.begin-chats-search", None, |widget, _, _| {
                 widget.imp().session_manager.begin_chats_search();
             });


### PR DESCRIPTION
The first commit is about implementing a more general MessageEntry widget which is basically the _TextView made to look like an entry_ that we currently have in the chat-action-bar, but that now also wraps a tdlib's FormattedText. This will be useful when we implement formatting in it.

The second one adds a SendPhotoDialog which allows sending photos + it uses the MessageEntry for the caption. For the file chooser I added [ashpd](https://github.com/bilelmoussaoui/ashpd) as a dependency. We could have used [GtkFileChooserNative](https://docs.gtk.org/gtk4/class.FileChooserNative.html) for that, but for some reason the filtering seems broken, so... I just used ashpd which we'll also need for other things in the future anyway.

![send-photo](https://user-images.githubusercontent.com/23530586/160955193-46ab77fe-f9a0-40b0-8f75-69b51a351d01.png)