### PR TITLE
ci: Remove clippy target cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,6 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Cache target
-        id: cache-target
-        uses: actions/cache@v2
-        with:
-          path: target
-          key: ${{ runner.os }}-target-${{ hashFiles('Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-target-
-
       - name: Create dummy versions of configured file
         run: |
           sed \


### PR DESCRIPTION
It was causing the build to fail because of a compiler version mismatch
between the cached builds and the current compiler version.