### PR TITLE
Delete messages

### DIFF
--- a/data/resources/resources.gresource.xml
+++ b/data/resources/resources.gresource.xml
@@ -19,6 +19,7 @@
     <file compressed="true" preprocess="xml-stripblanks">ui/content-message-text.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/content-send-photo-dialog.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/login.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/message-menu.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/phone-number-input.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/preferences-window.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/session-entry-row.ui</file>

--- a/data/resources/ui/content-message-media.ui
+++ b/data/resources/ui/content-message-media.ui
@@ -28,7 +28,6 @@
         </child>
         <child>
           <object class="GtkLabel" id="caption_label">
-            <property name="selectable">True</property>
             <property name="use-markup">True</property>
             <property name="wrap">True</property>
             <property name="wrap-mode">word-char</property>

--- a/data/resources/ui/content-message-photo.ui
+++ b/data/resources/ui/content-message-photo.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <template class="ContentMessagePhoto" parent="GtkWidget">
+  <template class="ContentMessagePhoto" parent="ContentMessageBase">
     <property name="layout-manager">
       <object class="GtkBinLayout"/>
     </property>

--- a/data/resources/ui/content-message-photo.ui
+++ b/data/resources/ui/content-message-photo.ui
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <template class="ContentMessagePhoto" parent="ContentMessageRow">
-    <property name="content">
-      <object class="ContentMessageMedia" id="media"/>
+  <template class="ContentMessagePhoto" parent="GtkWidget">
+    <property name="layout-manager">
+      <object class="GtkBinLayout"/>
     </property>
+    <child>
+      <object class="ContentMessageMedia" id="media"/>
+    </child>
   </template>
 </interface>

--- a/data/resources/ui/content-message-sticker.ui
+++ b/data/resources/ui/content-message-sticker.ui
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <template class="ContentMessageSticker" parent="ContentMessageRow">
-    <property name="content">
-      <object class="ContentStickerPicture" id="picture"/>
+  <template class="ContentMessageSticker" parent="GtkWidget">
+    <property name="layout-manager">
+      <object class="GtkBinLayout"/>
     </property>
+    <child>
+      <object class="ContentStickerPicture" id="picture"/>
+    </child>
   </template>
 </interface>

--- a/data/resources/ui/content-message-sticker.ui
+++ b/data/resources/ui/content-message-sticker.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <template class="ContentMessageSticker" parent="GtkWidget">
+  <template class="ContentMessageSticker" parent="ContentMessageBase">
     <property name="layout-manager">
       <object class="GtkBinLayout"/>
     </property>

--- a/data/resources/ui/content-message-text.ui
+++ b/data/resources/ui/content-message-text.ui
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <template class="ContentMessageText" parent="ContentMessageRow">
-    <property name="content">
-      <object class="GtkBox">
+  <template class="ContentMessageText" parent="GtkWidget">
+    <property name="layout-manager">
+      <object class="GtkBoxLayout">
         <property name="orientation">vertical</property>
         <property name="spacing">3</property>
-        <style>
-          <class name="message-bubble"/>
-        </style>
-        <child>
-          <object class="GtkLabel" id="sender_label">
-            <property name="ellipsize">end</property>
-            <property name="single-line-mode">True</property>
-            <property name="xalign">0</property>
-            <style>
-              <class name="sender-text"/>
-            </style>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="content_label">
-            <property name="selectable">True</property>
-            <property name="use-markup">True</property>
-            <property name="wrap">True</property>
-            <property name="wrap-mode">word-char</property>
-            <property name="xalign">0</property>
-            <style>
-              <class name="message-text"/>
-            </style>
-          </object>
-        </child>
       </object>
     </property>
+    <style>
+      <class name="message-bubble"/>
+    </style>
+    <child>
+      <object class="GtkLabel" id="sender_label">
+        <property name="ellipsize">end</property>
+        <property name="single-line-mode">True</property>
+        <property name="xalign">0</property>
+        <style>
+          <class name="sender-text"/>
+        </style>
+      </object>
+    </child>
+    <child>
+      <object class="GtkLabel" id="content_label">
+        <property name="selectable">True</property>
+        <property name="use-markup">True</property>
+        <property name="wrap">True</property>
+        <property name="wrap-mode">word-char</property>
+        <property name="xalign">0</property>
+        <style>
+          <class name="message-text"/>
+        </style>
+      </object>
+    </child>
   </template>
 </interface>

--- a/data/resources/ui/content-message-text.ui
+++ b/data/resources/ui/content-message-text.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <template class="ContentMessageText" parent="GtkWidget">
+  <template class="ContentMessageText" parent="ContentMessageBase">
     <property name="layout-manager">
       <object class="GtkBoxLayout">
         <property name="orientation">vertical</property>

--- a/data/resources/ui/content-message-text.ui
+++ b/data/resources/ui/content-message-text.ui
@@ -22,7 +22,6 @@
     </child>
     <child>
       <object class="GtkLabel" id="content_label">
-        <property name="selectable">True</property>
         <property name="use-markup">True</property>
         <property name="wrap">True</property>
         <property name="wrap-mode">word-char</property>

--- a/data/resources/ui/message-menu.ui
+++ b/data/resources/ui/message-menu.ui
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <menu id="model">
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">Delete for _everyone</attribute>
+        <attribute name="action">message-row.revoke-delete</attribute>
+        <attribute name="hidden-when">action-disabled</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">_Delete for me</attribute>
+        <attribute name="action">message-row.delete</attribute>
+        <attribute name="hidden-when">action-disabled</attribute>
+      </item>
+    </section>
+  </menu>
+  <object class="GtkPopoverMenu" id="menu">
+    <property name="menu-model">model</property>
+  </object>
+</interface>

--- a/src/session/content/chat_history.rs
+++ b/src/session/content/chat_history.rs
@@ -13,6 +13,7 @@ mod imp {
     use super::*;
     use adw::subclass::prelude::BinImpl;
     use once_cell::sync::Lazy;
+    use once_cell::unsync::OnceCell;
     use std::cell::{Cell, RefCell};
 
     #[derive(Debug, Default, CompositeTemplate)]
@@ -20,6 +21,7 @@ mod imp {
     pub(crate) struct ChatHistory {
         pub(super) compact: Cell<bool>,
         pub(super) chat: RefCell<Option<Chat>>,
+        pub(super) message_menu: OnceCell<gtk::PopoverMenu>,
         #[template_child]
         pub(super) window_title: TemplateChild<adw::WindowTitle>,
         #[template_child]
@@ -168,6 +170,14 @@ impl ChatHistory {
                 Err(e) => log::warn!("Failed to request a SponsoredMessage: {:?}", e),
             }
         }));
+    }
+
+    pub(crate) fn message_menu(&self) -> &gtk::PopoverMenu {
+        self.imp().message_menu.get_or_init(|| {
+            gtk::Builder::from_resource("/com/github/melix99/telegrand/ui/message-menu.ui")
+                .object::<gtk::PopoverMenu>("menu")
+                .unwrap()
+        })
     }
 
     pub(crate) fn handle_paste_action(&self) {

--- a/src/session/content/message_row/base.rs
+++ b/src/session/content/message_row/base.rs
@@ -1,0 +1,93 @@
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use gtk::{glib, CompositeTemplate};
+
+mod imp {
+    use super::*;
+
+    use crate::session::content::ChatHistory;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(string = r#"
+    <interface>
+      <template class="ContentMessageBase" parent="GtkWidget">
+        <child>
+          <object class="GtkGestureClick">
+            <property name="button">3</property>
+            <signal name="released" handler="on_pressed" swapped="true"/>
+          </object>
+        </child>
+        <child>
+          <object class="GtkGestureLongPress">
+            <property name="touch-only">True</property>
+            <signal name="pressed" handler="on_pressed" swapped="true"/>
+          </object>
+        </child>
+      </template>
+    </interface>
+    "#)]
+    pub(crate) struct MessageBase {}
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MessageBase {
+        const NAME: &'static str = "ContentMessageBase";
+        const ABSTRACT: bool = true;
+        type Type = super::MessageBase;
+        type ParentType = gtk::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+            Self::bind_template_callbacks(klass);
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    #[gtk::template_callbacks]
+    impl MessageBase {
+        #[template_callback]
+        fn on_pressed(&self) {
+            self.show_message_menu();
+        }
+
+        fn show_message_menu(&self) {
+            let obj = self.instance();
+            let chat_history = obj.ancestor(ChatHistory::static_type()).unwrap();
+            let menu = chat_history
+                .downcast_ref::<ChatHistory>()
+                .unwrap()
+                .message_menu();
+
+            menu.unparent();
+            menu.set_parent(&obj);
+            menu.popup();
+        }
+    }
+
+    impl ObjectImpl for MessageBase {
+        fn dispose(&self, obj: &Self::Type) {
+            let mut child = obj.first_child();
+            while let Some(child_) = child {
+                child = child_.next_sibling();
+                child_.unparent();
+            }
+        }
+    }
+
+    impl WidgetImpl for MessageBase {}
+}
+
+glib::wrapper! {
+    pub(crate) struct MessageBase(ObjectSubclass<imp::MessageBase>)
+        @extends gtk::Widget;
+}
+
+pub(crate) trait MessageBaseImpl: WidgetImpl + ObjectImpl + 'static {}
+
+unsafe impl<T: MessageBaseImpl> IsSubclassable<T> for MessageBase {
+    fn class_init(class: &mut glib::Class<Self>) {
+        Self::parent_class_init::<T>(class.upcast_ref_mut());
+    }
+}

--- a/src/session/content/message_row/photo.rs
+++ b/src/session/content/message_row/photo.rs
@@ -6,7 +6,7 @@ use tdlib::enums::MessageContent;
 use tdlib::types::File;
 
 use crate::session::chat::{BoxedMessageContent, Message};
-use crate::session::content::message_row::Media;
+use crate::session::content::message_row::{Media, MessageBase, MessageBaseImpl};
 use crate::utils::parse_formatted_text;
 use crate::Session;
 
@@ -29,7 +29,7 @@ mod imp {
     impl ObjectSubclass for MessagePhoto {
         const NAME: &'static str = "ContentMessagePhoto";
         type Type = super::MessagePhoto;
-        type ParentType = gtk::Widget;
+        type ParentType = MessageBase;
 
         fn class_init(klass: &mut Self::Class) {
             Self::bind_template(klass);
@@ -73,18 +73,15 @@ mod imp {
                 _ => unimplemented!(),
             }
         }
-
-        fn dispose(&self, _obj: &Self::Type) {
-            self.media.unparent();
-        }
     }
 
     impl WidgetImpl for MessagePhoto {}
+    impl MessageBaseImpl for MessagePhoto {}
 }
 
 glib::wrapper! {
     pub(crate) struct MessagePhoto(ObjectSubclass<imp::MessagePhoto>)
-        @extends gtk::Widget;
+        @extends gtk::Widget, MessageBase;
 }
 
 impl MessagePhoto {

--- a/src/session/content/message_row/photo.rs
+++ b/src/session/content/message_row/photo.rs
@@ -7,13 +7,12 @@ use tdlib::types::File;
 
 use crate::session::chat::{BoxedMessageContent, Message};
 use crate::session::content::message_row::Media;
-use crate::session::content::{MessageRow, MessageRowExt};
 use crate::utils::parse_formatted_text;
 use crate::Session;
 
 mod imp {
     use super::*;
-    use glib::WeakRef;
+    use once_cell::sync::Lazy;
     use std::cell::RefCell;
 
     #[derive(Debug, Default, CompositeTemplate)]
@@ -21,7 +20,7 @@ mod imp {
     pub(crate) struct MessagePhoto {
         pub(super) binding: RefCell<Option<gtk::ExpressionWatch>>,
         pub(super) handler_id: RefCell<Option<glib::SignalHandlerId>>,
-        pub(super) old_message: WeakRef<glib::Object>,
+        pub(super) message: RefCell<Option<Message>>,
         #[template_child]
         pub(super) media: TemplateChild<Media>,
     }
@@ -30,7 +29,7 @@ mod imp {
     impl ObjectSubclass for MessagePhoto {
         const NAME: &'static str = "ContentMessagePhoto";
         type Type = super::MessagePhoto;
-        type ParentType = MessageRow;
+        type ParentType = gtk::Widget;
 
         fn class_init(klass: &mut Self::Class) {
             Self::bind_template(klass);
@@ -42,9 +41,41 @@ mod imp {
     }
 
     impl ObjectImpl for MessagePhoto {
-        fn constructed(&self, obj: &Self::Type) {
-            self.parent_constructed(obj);
-            obj.connect_message_notify(|obj, _| obj.update_widget());
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![glib::ParamSpecObject::new(
+                    "message",
+                    "Message",
+                    "The message represented by this row",
+                    Message::static_type(),
+                    glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                )]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(
+            &self,
+            obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "message" => obj.set_message(value.get().unwrap()),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "message" => obj.message().to_value(),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn dispose(&self, _obj: &Self::Type) {
+            self.media.unparent();
         }
     }
 
@@ -53,24 +84,33 @@ mod imp {
 
 glib::wrapper! {
     pub(crate) struct MessagePhoto(ObjectSubclass<imp::MessagePhoto>)
-        @extends gtk::Widget, MessageRow;
+        @extends gtk::Widget;
 }
 
 impl MessagePhoto {
-    fn update_widget(&self) {
+    pub(crate) fn new(message: &Message) -> Self {
+        glib::Object::new(&[("message", message)]).expect("Failed to create MessagePhoto")
+    }
+
+    pub(crate) fn message(&self) -> Message {
+        self.imp().message.borrow().clone().unwrap()
+    }
+
+    pub(crate) fn set_message(&self, message: Message) {
         let imp = self.imp();
+
+        if imp.message.borrow().as_ref() == Some(&message) {
+            return;
+        }
 
         if let Some(binding) = imp.binding.take() {
             binding.unwatch();
         }
 
-        if let Some(old_message) = imp.old_message.upgrade() {
-            if let Some(id) = imp.handler_id.take() {
-                old_message.disconnect(id);
-            }
+        if let Some(old_message) = imp.message.take() {
+            let handler_id = imp.handler_id.take().unwrap();
+            old_message.disconnect(handler_id);
         }
-
-        let message = self.message().downcast::<Message>().unwrap();
 
         // Setup caption expression
         let caption_binding = Message::this_expression("content")
@@ -92,7 +132,8 @@ impl MessagePhoto {
         imp.handler_id.replace(Some(handler_id));
         self.update_photo(&message);
 
-        imp.old_message.set(Some(self.message().as_ref()));
+        imp.message.replace(Some(message));
+        self.notify("message");
     }
 
     fn update_photo(&self, message: &Message) {

--- a/src/session/content/message_row/sticker.rs
+++ b/src/session/content/message_row/sticker.rs
@@ -9,7 +9,7 @@ use tdlib::enums::MessageContent;
 use tdlib::types::File;
 
 use crate::session::chat::Message;
-use crate::session::content::message_row::StickerPicture;
+use crate::session::content::message_row::{MessageBase, MessageBaseImpl, StickerPicture};
 use crate::utils::spawn;
 
 mod imp {
@@ -29,7 +29,7 @@ mod imp {
     impl ObjectSubclass for MessageSticker {
         const NAME: &'static str = "ContentMessageSticker";
         type Type = super::MessageSticker;
-        type ParentType = gtk::Widget;
+        type ParentType = MessageBase;
 
         fn class_init(klass: &mut Self::Class) {
             Self::bind_template(klass);
@@ -73,18 +73,15 @@ mod imp {
                 _ => unimplemented!(),
             }
         }
-
-        fn dispose(&self, _obj: &Self::Type) {
-            self.picture.unparent();
-        }
     }
 
     impl WidgetImpl for MessageSticker {}
+    impl MessageBaseImpl for MessageSticker {}
 }
 
 glib::wrapper! {
     pub(crate) struct MessageSticker(ObjectSubclass<imp::MessageSticker>)
-        @extends gtk::Widget;
+        @extends gtk::Widget, MessageBase;
 }
 
 impl MessageSticker {

--- a/src/session/content/message_row/text.rs
+++ b/src/session/content/message_row/text.rs
@@ -8,6 +8,7 @@ use std::hash::{Hash, Hasher};
 use tdlib::enums::MessageContent;
 
 use crate::session::chat::{BoxedMessageContent, Message, MessageSender, SponsoredMessage};
+use crate::session::content::message_row::{MessageBase, MessageBaseImpl};
 use crate::session::{Chat, ChatType};
 use crate::utils::parse_formatted_text;
 
@@ -32,7 +33,7 @@ mod imp {
     impl ObjectSubclass for MessageText {
         const NAME: &'static str = "ContentMessageText";
         type Type = super::MessageText;
-        type ParentType = gtk::Widget;
+        type ParentType = MessageBase;
 
         fn class_init(klass: &mut Self::Class) {
             Self::bind_template(klass);
@@ -76,19 +77,15 @@ mod imp {
                 _ => unimplemented!(),
             }
         }
-
-        fn dispose(&self, _obj: &Self::Type) {
-            self.sender_label.unparent();
-            self.content_label.unparent();
-        }
     }
 
     impl WidgetImpl for MessageText {}
+    impl MessageBaseImpl for MessageText {}
 }
 
 glib::wrapper! {
     pub(crate) struct MessageText(ObjectSubclass<imp::MessageText>)
-        @extends gtk::Widget;
+        @extends gtk::Widget, MessageBase;
 }
 
 impl MessageText {

--- a/src/session/content/mod.rs
+++ b/src/session/content/mod.rs
@@ -11,7 +11,7 @@ use self::chat_history::ChatHistory;
 use self::chat_info_dialog::ChatInfoDialog;
 use self::event_row::EventRow;
 use self::item_row::ItemRow;
-use self::message_row::{MessageRow, MessageRowExt};
+use self::message_row::MessageRow;
 use self::send_photo_dialog::SendPhotoDialog;
 
 use gtk::glib;


### PR DESCRIPTION
This is a fairly big set of changes that allow messages to have shared actions (e.g. reply, delete, forward, etc.). For now only the delete action is implemented.

To implement the "shared action" behavior, the obvious solution was to add them inside the MessageRow, but actually I noticed how much that type was being bloated by stuff, which wasn't really ideal since we expect that widget to be recycled. So, with this new implementation the MessageRow is an actual (final) widget, which is the one that aggregates all the shared message functionality and it displays the "content" widget, which now are subclasses of a new abstract class, the MessageBase. The MessageBase only has the basic api that we expect all of our message content types to implement/manage.

~To implement all of this I started using the new gobject crate, which makes creating subclassable types and creating actions a lot easier.~ I decided to wait a bit more before using that crate, since it seems that it will be included in gtk-rs-core directly.