### PR TITLE
sidebar: Use a custom "fixed" selection model

### DIFF
--- a/data/resources/ui/session.ui
+++ b/data/resources/ui/session.ui
@@ -7,7 +7,7 @@
         <child>
           <object class="Sidebar" id="sidebar">
             <property name="compact" bind-source="leaflet" bind-property="folded" bind-flags="sync-create"/>
-            <property name="selected-chat" bind-source="Session" bind-property="selected-chat" bind-flags="sync-create | bidirectional"/>
+            <property name="selected-chat" bind-source="content" bind-property="chat" bind-flags="sync-create | bidirectional"/>
             <property name="session">Session</property>
           </object>
         </child>
@@ -22,7 +22,6 @@
         <child>
           <object class="Content" id="content">
             <property name="compact" bind-source="leaflet" bind-property="folded" bind-flags="sync-create"/>
-            <property name="chat" bind-source="Session" bind-property="selected-chat" bind-flags="sync-create | bidirectional"/>
           </object>
         </child>
       </object>

--- a/data/resources/ui/sidebar.ui
+++ b/data/resources/ui/sidebar.ui
@@ -80,7 +80,16 @@
         <property name="vexpand">True</property>
         <property name="hscrollbar-policy">never</property>
         <child>
-          <object class="GtkListView" id="list_view">
+          <object class="GtkListView">
+            <property name="single-click-activate">True</property>
+            <signal name="activate" handler="list_activate" swapped="true"/>
+            <property name="model">
+              <object class="SidebarSelection" id="selection">
+                <binding name="hide-selection">
+                  <lookup name="compact">Sidebar</lookup>
+                </binding>
+              </object>
+            </property>
             <property name="factory">
               <object class="GtkBuilderListItemFactory">
                 <property name="bytes"><![CDATA[

--- a/src/session/sidebar/mod.rs
+++ b/src/session/sidebar/mod.rs
@@ -1,8 +1,10 @@
 mod avatar;
 mod row;
+mod selection;
 mod session_switcher;
 
 use self::row::Row;
+use self::selection::Selection;
 use self::session_switcher::SessionSwitcher;
 
 use gettextrs::gettext;
@@ -20,6 +22,7 @@ pub(crate) use self::avatar::Avatar;
 
 mod imp {
     use super::*;
+    use glib::subclass::Signal;
     use once_cell::sync::Lazy;
     use std::cell::{Cell, RefCell};
 
@@ -32,7 +35,6 @@ mod imp {
         pub(super) selected_chat: RefCell<Option<Chat>>,
         pub(super) session: RefCell<Option<Session>>,
         pub(super) filter: RefCell<Option<gtk::CustomFilter>>,
-        pub(super) selection: RefCell<Option<gtk::SingleSelection>>,
         pub(super) searched_chats: RefCell<Vec<i64>>,
         pub(super) searched_users: RefCell<Vec<i64>>,
         pub(super) already_searched_users: RefCell<Vec<i64>>,
@@ -47,7 +49,7 @@ mod imp {
         #[template_child]
         pub(super) scrolled_window: TemplateChild<gtk::ScrolledWindow>,
         #[template_child]
-        pub(super) list_view: TemplateChild<gtk::ListView>,
+        pub(super) selection: TemplateChild<Selection>,
     }
 
     #[glib::object_subclass]
@@ -60,6 +62,7 @@ mod imp {
             ComponentsAvatar::static_type();
             Row::static_type();
             Self::bind_template(klass);
+            Self::bind_template_callbacks(klass);
         }
 
         fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
@@ -67,7 +70,46 @@ mod imp {
         }
     }
 
+    #[gtk::template_callbacks]
+    impl Sidebar {
+        #[template_callback]
+        async fn list_activate(&self, pos: u32) {
+            let instance = self.instance();
+            self.selection.set_selected_position(pos);
+
+            instance.emit_by_name::<()>("list-activated", &[]);
+
+            if let Some(item) = self.selection.selected_item() {
+                if let Some(chat) = item.downcast_ref::<Chat>() {
+                    instance.set_selected_chat(Some(chat.clone()));
+                } else if let Some(user) = item.downcast_ref::<User>() {
+                    // Create a chat with the user and then select the created chat
+                    let user_id = user.id();
+                    let session = user.session();
+                    let client_id = session.client_id();
+                    let result = functions::create_private_chat(user_id, false, client_id).await;
+
+                    if let Ok(enums::Chat::Chat(chat)) = result {
+                        let chat = session.chat_list().get(chat.id);
+                        instance.set_selected_chat(Some(chat));
+                    }
+                }
+
+                return;
+            }
+
+            instance.set_selected_chat(None);
+        }
+    }
+
     impl ObjectImpl for Sidebar {
+        fn signals() -> &'static [Signal] {
+            static SIGNALS: Lazy<Vec<Signal>> = Lazy::new(|| {
+                vec![Signal::builder("list-activated", &[], <()>::static_type().into()).build()]
+            });
+            SIGNALS.as_ref()
+        }
+
         fn properties() -> &'static [glib::ParamSpec] {
             static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
                 vec![
@@ -252,17 +294,9 @@ impl Sidebar {
             return;
         }
 
-        // TODO: change the selection in the sidebar if it's
-        // different from the current selection
-
         let imp = self.imp();
-        if selected_chat.is_none() {
-            imp.selection
-                .borrow()
-                .as_ref()
-                .unwrap()
-                .set_selected(gtk::INVALID_LIST_POSITION);
-        }
+        imp.selection
+            .set_selected_item(selected_chat.clone().map(Chat::upcast));
 
         imp.selected_chat.replace(selected_chat);
         self.notify("selected-chat");
@@ -332,39 +366,9 @@ impl Sidebar {
 
             let filter_model = gtk::FilterListModel::new(Some(&model), Some(&filter));
             let sort_model = gtk::SortListModel::new(Some(&filter_model), Some(&sorter));
-            let selection = gtk::SingleSelection::new(Some(&sort_model));
-            selection.set_autoselect(false);
 
-            selection.connect_selected_item_notify(
-                clone!(@weak self as obj, @weak session => move |selection| {
-                    if let Some(item) = selection.selected_item() {
-                        if let Some(chat) = item.downcast_ref::<Chat>() {
-                            obj.set_selected_chat(Some(chat.to_owned()));
-                        } else if let Some(user) = item.downcast_ref::<User>() {
-                            // Create a chat with the user and then select the created chat
-                            let user_id = user.id();
-                            let client_id = session.client_id();
-
-                            spawn(clone!(@weak obj, @weak session => async move {
-                                let result =
-                                    functions::create_private_chat(user_id, false, client_id).await;
-                                if let Ok(enums::Chat::Chat(chat)) = result {
-                                    let chat = session.chat_list().get(chat.id);
-                                    obj.set_selected_chat(Some(chat));
-                                }
-                            }));
-                        } else {
-                            unreachable!("Unexpected item type: {:?}", item);
-                        }
-                    } else {
-                        obj.set_selected_chat(None);
-                    }
-                }),
-            );
-
-            imp.list_view.set_model(Some(&selection));
+            imp.selection.set_model(Some(sort_model.upcast()));
             imp.filter.replace(Some(filter));
-            imp.selection.replace(Some(selection));
         }
 
         imp.session.replace(session);
@@ -379,5 +383,17 @@ impl Sidebar {
         self.imp()
             .session_switcher
             .set_sessions(sessions, this_session);
+    }
+
+    pub(crate) fn connect_list_activated<F: Fn(&Self) + 'static>(
+        &self,
+        f: F,
+    ) -> glib::SignalHandlerId {
+        self.connect_local("list-activated", true, move |values| {
+            let obj = values[0].get::<Self>().unwrap();
+            f(&obj);
+
+            None
+        })
     }
 }

--- a/src/session/sidebar/mod.rs
+++ b/src/session/sidebar/mod.rs
@@ -173,6 +173,8 @@ mod imp {
         }
 
         fn constructed(&self, obj: &Self::Type) {
+            self.parent_constructed(obj);
+
             self.search_entry
                 .connect_search_changed(clone!(@weak obj => move |entry| {
                     let query = entry.text().to_string();

--- a/src/session/sidebar/selection.rs
+++ b/src/session/sidebar/selection.rs
@@ -1,0 +1,289 @@
+use glib::clone;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use gtk::{gio, glib};
+
+mod imp {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use std::cell::{Cell, RefCell};
+
+    #[derive(Debug, Default)]
+    pub(crate) struct Selection {
+        pub(super) model: RefCell<Option<gio::ListModel>>,
+        pub(super) item: RefCell<Option<glib::Object>>,
+        pub(super) hide_selection: Cell<bool>,
+        pub(super) item_position: Cell<u32>,
+        pub(super) signal_handler: RefCell<Option<glib::SignalHandlerId>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for Selection {
+        const NAME: &'static str = "SidebarSelection";
+        type Type = super::Selection;
+        type Interfaces = (gio::ListModel, gtk::SelectionModel);
+    }
+
+    impl ObjectImpl for Selection {
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![
+                    glib::ParamSpecObject::new(
+                        "model",
+                        "Model",
+                        "The model being wrapped",
+                        gio::ListModel::static_type(),
+                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                    ),
+                    glib::ParamSpecObject::new(
+                        "selected-item",
+                        "Selected item",
+                        "The selected item",
+                        glib::Object::static_type(),
+                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                    ),
+                    glib::ParamSpecBoolean::new(
+                        "hide-selection",
+                        "Hide selection",
+                        "Whether to hide the selection or not",
+                        false,
+                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                    ),
+                ]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(
+            &self,
+            obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "model" => obj.set_model(value.get().unwrap()),
+                "selected-item" => obj.set_selected_item(value.get().unwrap()),
+                "hide-selection" => obj.set_hide_selection(value.get().unwrap()),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "model" => obj.model().to_value(),
+                "selected-item" => obj.selected_item().to_value(),
+                "hide-selection" => obj.hide_selection().to_value(),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn constructed(&self, obj: &Self::Type) {
+            self.parent_constructed(obj);
+            self.item_position.set(gtk::INVALID_LIST_POSITION)
+        }
+
+        fn dispose(&self, obj: &Self::Type) {
+            obj.disconnect_model_signal();
+        }
+    }
+
+    impl ListModelImpl for Selection {
+        fn item_type(&self, _list_model: &Self::Type) -> glib::Type {
+            glib::Object::static_type()
+        }
+
+        fn n_items(&self, _list_model: &Self::Type) -> u32 {
+            self.model
+                .borrow()
+                .as_ref()
+                .map(|m| m.n_items())
+                .unwrap_or_default()
+        }
+
+        fn item(&self, _list_model: &Self::Type, position: u32) -> Option<glib::Object> {
+            self.model.borrow().as_ref().and_then(|m| m.item(position))
+        }
+    }
+
+    impl SelectionModelImpl for Selection {
+        fn is_selected(&self, model: &Self::Type, position: u32) -> bool {
+            let item_position = self.item_position.get();
+            if model.hide_selection() || item_position == gtk::INVALID_LIST_POSITION {
+                return false;
+            }
+
+            position == item_position
+        }
+
+        fn selection_in_range(
+            &self,
+            model: &Self::Type,
+            _position: u32,
+            _n_items: u32,
+        ) -> gtk::Bitset {
+            let result = gtk::Bitset::new_empty();
+            let item_position = self.item_position.get();
+            if !model.hide_selection() && item_position != gtk::INVALID_LIST_POSITION {
+                result.add(item_position);
+            }
+
+            result
+        }
+    }
+}
+
+glib::wrapper! {
+    // TODO: This is basically https://gitlab.gnome.org/GNOME/libadwaita/-/merge_requests/504,
+    // so when that selection model will arrive in libadwaita we should use that instead
+    pub(crate) struct Selection(ObjectSubclass<imp::Selection>)
+        @implements gio::ListModel, gtk::SelectionModel;
+}
+
+impl Selection {
+    fn find_item_position(&self, item: &glib::Object, start_pos: u32, end_pos: u32) -> u32 {
+        if let Some(model) = self.model() {
+            for pos in start_pos..end_pos {
+                let check = model.item(pos);
+
+                if check.as_ref() == Some(item) {
+                    return pos;
+                }
+            }
+        }
+
+        gtk::INVALID_LIST_POSITION
+    }
+
+    fn model_items_changed(&self, position: u32, removed: u32, added: u32) {
+        let imp = self.imp();
+        let item_position = imp.item_position.get();
+
+        if let Some(selected_item) = self.selected_item() {
+            if item_position == gtk::INVALID_LIST_POSITION {
+                // Maybe the item got newly added
+                imp.item_position.set(self.find_item_position(
+                    &selected_item,
+                    position,
+                    position + added,
+                ));
+            } else if item_position < position {
+                // Nothing to do, position stays the same
+            } else if item_position < position + removed {
+                imp.item_position.set(self.find_item_position(
+                    &selected_item,
+                    position,
+                    position + added,
+                ));
+            } else {
+                imp.item_position.set(item_position + (added - removed));
+            }
+        }
+
+        self.items_changed(position, removed, added);
+    }
+
+    fn disconnect_model_signal(&self) {
+        if let Some(model) = self.model() {
+            let handler = self.imp().signal_handler.take().unwrap();
+            model.disconnect(handler);
+        }
+    }
+
+    pub(crate) fn model(&self) -> Option<gio::ListModel> {
+        self.imp().model.borrow().clone()
+    }
+
+    pub(crate) fn set_model(&self, model: Option<gio::ListModel>) {
+        if self.model() == model {
+            return;
+        }
+
+        let n_items_before = self.n_items();
+        self.disconnect_model_signal();
+
+        let imp = self.imp();
+        let n_items = if let Some(ref model) = model {
+            let handler =
+                model.connect_items_changed(clone!(@weak self as obj => move |_, p, r, a| {
+                    obj.model_items_changed(p, r, a);
+                }));
+            imp.signal_handler.replace(Some(handler));
+
+            model.n_items()
+        } else {
+            0
+        };
+
+        imp.model.replace(model);
+
+        self.items_changed(0, n_items_before, n_items);
+
+        self.notify("model");
+    }
+
+    pub(crate) fn selected_item(&self) -> Option<glib::Object> {
+        self.imp().item.borrow().clone()
+    }
+
+    fn set_selected_item_internal(&self, item: Option<glib::Object>, position: u32) {
+        let imp = self.imp();
+
+        imp.item.replace(item);
+
+        let old_position = imp.item_position.get();
+        imp.item_position.set(position);
+
+        if !self.hide_selection() {
+            if old_position == gtk::INVALID_LIST_POSITION {
+                self.selection_changed(position, 1);
+            } else if position == gtk::INVALID_LIST_POSITION {
+                self.selection_changed(old_position, 1);
+            } else if position < old_position {
+                self.selection_changed(position, old_position - position + 1);
+            } else {
+                self.selection_changed(old_position, position - old_position + 1);
+            }
+        }
+
+        self.notify("selected-item");
+    }
+
+    pub(crate) fn set_selected_item(&self, selected_item: Option<glib::Object>) {
+        if self.selected_item() == selected_item {
+            return;
+        }
+
+        let position = selected_item
+            .as_ref()
+            .map(|i| self.find_item_position(i, 0, self.n_items()))
+            .unwrap_or(gtk::INVALID_LIST_POSITION);
+
+        self.set_selected_item_internal(selected_item, position);
+    }
+
+    pub(crate) fn set_selected_position(&self, position: u32) {
+        let item = self.item(position);
+        self.set_selected_item_internal(item, position);
+    }
+
+    pub(crate) fn hide_selection(&self) -> bool {
+        self.imp().hide_selection.get()
+    }
+
+    pub(crate) fn set_hide_selection(&self, hide_selection: bool) {
+        if self.hide_selection() == hide_selection {
+            return;
+        }
+
+        let imp = self.imp();
+
+        imp.hide_selection.set(hide_selection);
+        self.notify("hide-selection");
+
+        let item_position = imp.item_position.get();
+        if item_position != gtk::INVALID_LIST_POSITION {
+            self.selection_changed(item_position, 1);
+        }
+    }
+}


### PR DESCRIPTION
I've proposed this selection model in libadwaita in https://gitlab.gnome.org/GNOME/libadwaita/-/merge_requests/504, but, since it has no activity, I've created a rust implementation for now. This allows us to manually manage the selection, which means that it fixes the problem of chats being automatically deselected while searching and it will also open up doors for features like opening the chat after pressing a notification or opening a chat from the ChatHistory (e.g. by pressing on the avatar), etc.