### PR TITLE
Item-row: Move message content checks to the MessageRow

### DIFF
--- a/src/session/content/item_row.rs
+++ b/src/session/content/item_row.rs
@@ -5,7 +5,7 @@ use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use std::borrow::Cow;
-use tdlib::enums::{MessageContent, StickerType, UserType};
+use tdlib::enums::{MessageContent, UserType};
 
 use crate::session::chat::{ChatType, Item, ItemType, Message, MessageSender, SponsoredMessage};
 use crate::session::content::{EventRow, MessageRow};
@@ -101,15 +101,6 @@ impl ItemRow {
                         let content = message.content().0;
 
                         match content {
-                            MessageContent::MessagePhoto(_) => {
-                                self.update_or_create_message_row(message.to_owned().upcast())
-                            }
-                            MessageContent::MessageSticker(data)
-                                if matches!(data.sticker.r#type, StickerType::Static)
-                                    || matches!(data.sticker.r#type, StickerType::Mask(_)) =>
-                            {
-                                self.update_or_create_message_row(message.to_owned().upcast())
-                            }
                             MessageContent::MessageChatChangeTitle(data) => {
                                 self.get_or_create_event_row().set_label(&format!(
                                     "<b>{}</b>",

--- a/src/session/content/message_row/mod.rs
+++ b/src/session/content/message_row/mod.rs
@@ -19,7 +19,7 @@ use glib::clone;
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use tdlib::enums::MessageContent;
+use tdlib::enums::{MessageContent, StickerType};
 
 use crate::session::chat::{Message, MessageForwardOrigin, MessageSender};
 use crate::session::components::Avatar;
@@ -250,7 +250,12 @@ impl MessageRow {
                 MessageContent::MessagePhoto(_) => {
                     self.update_or_create_photo_content(message_.clone());
                 }
-                MessageContent::MessageSticker(_) => {
+                MessageContent::MessageSticker(data)
+                    if matches!(
+                        data.sticker.r#type,
+                        StickerType::Static | StickerType::Mask(_)
+                    ) =>
+                {
                     self.update_or_create_sticker_content(message_.clone());
                 }
                 _ => {


### PR DESCRIPTION
This fixes the check for animated stickers, which wasn't working anymore
after #277 and it was causing a crash.