### PR TITLE
Handle `marked-as-unread` property of chats to its entire extent

### DIFF
--- a/data/resources/ui/sidebar-row-menu.ui
+++ b/data/resources/ui/sidebar-row-menu.ui
@@ -12,6 +12,16 @@
         <attribute name="action">sidebar-row.unpin</attribute>
         <attribute name="hidden-when">action-disabled</attribute>
       </item>
+      <item>
+        <attribute name="label" translatable="yes">_Mark as Unread</attribute>
+        <attribute name="action">sidebar-row.mark-as-unread</attribute>
+        <attribute name="hidden-when">action-disabled</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Mark as _Read</attribute>
+        <attribute name="action">sidebar-row.mark-as-read</attribute>
+        <attribute name="hidden-when">action-disabled</attribute>
+      </item>
     </section>
   </menu>
   <object class="GtkPopoverMenu" id="menu">

--- a/data/resources/ui/sidebar-row.ui
+++ b/data/resources/ui/sidebar-row.ui
@@ -98,28 +98,40 @@
               </object>
             </child>
             <child>
-              <object class="GtkImage" id="pin_icon">
-                <property name="icon-name">view-pin-symbolic</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="unread_mention_label">
-                <property name="valign">center</property>
-                <property name="justify">center</property>
-                <property name="label">@</property>
-                <style>
-                  <class name="unread-mention-count"/>
-                </style>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="unread_count_label">
-                <property name="valign">center</property>
-                <property name="ellipsize">end</property>
-                <property name="justify">center</property>
+              <object class="GtkStack" id="status_stack">
+                <child>
+                  <object class="AdwBin" id="empty_status_bin"/>
+                </child>
+                <child>
+                  <object class="GtkImage" id="pin_icon">
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="icon-name">view-pin-symbolic</property>
+                    <style>
+                      <class name="dim-label"/>
+                    </style>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="unread_mention_label">
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="justify">center</property>
+                    <property name="label">@</property>
+                    <style>
+                      <class name="unread-mention-count"/>
+                    </style>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="unread_count_label">
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="width-chars">1</property>
+                    <property name="ellipsize">end</property>
+                    <property name="justify">center</property>
+                  </object>
+                </child>
               </object>
             </child>
           </object>

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -233,6 +233,7 @@ impl Session {
             Update::ChatAction(_)
             | Update::ChatDraftMessage(_)
             | Update::ChatIsBlocked(_)
+            | Update::ChatIsMarkedAsUnread(_)
             | Update::ChatLastMessage(_)
             | Update::ChatNotificationSettings(_)
             | Update::ChatPermissions(_)

--- a/src/tdlib/chat.rs
+++ b/src/tdlib/chat.rs
@@ -586,4 +586,20 @@ impl Chat {
         )
         .await
     }
+
+    pub(crate) async fn mark_as_read(&self) -> Result<enums::Ok, types::Error> {
+        if let Some(message) = self.last_message() {
+            functions::view_messages(
+                self.id(),
+                0,
+                vec![message.id()],
+                true,
+                self.session().client_id(),
+            )
+            .await?;
+        }
+
+        functions::toggle_chat_is_marked_as_unread(self.id(), false, self.session().client_id())
+            .await
+    }
 }

--- a/src/tdlib/chat.rs
+++ b/src/tdlib/chat.rs
@@ -324,6 +324,7 @@ impl Chat {
                 }
             }
             ChatIsBlocked(update) => self.set_is_blocked(update.is_blocked),
+            ChatIsMarkedAsUnread(update) => self.set_marked_as_unread(update.is_marked_as_unread),
             ChatLastMessage(update) => {
                 self.set_last_message(update.last_message.map(|m| Message::new(m, self)));
 
@@ -438,6 +439,14 @@ impl Chat {
 
     pub(crate) fn is_marked_as_unread(&self) -> bool {
         self.imp().is_marked_as_unread.get()
+    }
+
+    fn set_marked_as_unread(&self, is_marked_as_unread: bool) {
+        if self.is_marked_as_unread() == is_marked_as_unread {
+            return;
+        }
+        self.imp().is_marked_as_unread.set(is_marked_as_unread);
+        self.notify("is-marked-as-unread");
     }
 
     pub(crate) fn last_message(&self) -> Option<Message> {

--- a/src/tdlib/chat.rs
+++ b/src/tdlib/chat.rs
@@ -602,4 +602,9 @@ impl Chat {
         functions::toggle_chat_is_marked_as_unread(self.id(), false, self.session().client_id())
             .await
     }
+
+    pub(crate) async fn mark_as_unread(&self) -> Result<enums::Ok, types::Error> {
+        functions::toggle_chat_is_marked_as_unread(self.id(), true, self.session().client_id())
+            .await
+    }
 }

--- a/src/tdlib/chat.rs
+++ b/src/tdlib/chat.rs
@@ -66,6 +66,7 @@ mod imp {
         pub(super) title: RefCell<String>,
         pub(super) avatar: RefCell<Option<Avatar>>,
         pub(super) last_read_outbox_message_id: Cell<i64>,
+        pub(super) is_marked_as_unread: Cell<bool>,
         pub(super) last_message: RefCell<Option<Message>>,
         pub(super) order: Cell<i64>,
         pub(super) is_pinned: Cell<bool>,
@@ -133,6 +134,13 @@ mod imp {
                         std::i64::MIN,
                         std::i64::MAX,
                         0,
+                        glib::ParamFlags::READABLE,
+                    ),
+                    glib::ParamSpecBoolean::new(
+                        "is-marked-as-unread",
+                        "is-marked-as-unread",
+                        "Whether the chat is marked as unread",
+                        false,
                         glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecObject::new(
@@ -231,6 +239,7 @@ mod imp {
                 "title" => obj.title().to_value(),
                 "avatar" => obj.avatar().to_value(),
                 "last-read-outbox-message-id" => obj.last_read_outbox_message_id().to_value(),
+                "is-marked-as-unread" => obj.is_marked_as_unread().to_value(),
                 "last-message" => obj.last_message().to_value(),
                 "order" => obj.order().to_value(),
                 "is-pinned" => obj.is_pinned().to_value(),
@@ -271,6 +280,7 @@ impl Chat {
         imp.avatar.replace(avatar);
         imp.last_read_outbox_message_id
             .set(td_chat.last_read_outbox_message_id);
+        imp.is_marked_as_unread.set(td_chat.is_marked_as_unread);
         imp.last_message.replace(last_message);
 
         for position in td_chat.positions {
@@ -424,6 +434,10 @@ impl Chat {
             .last_read_outbox_message_id
             .set(last_read_outbox_message_id);
         self.notify("last-read-outbox-message-id");
+    }
+
+    pub(crate) fn is_marked_as_unread(&self) -> bool {
+        self.imp().is_marked_as_unread.get()
     }
 
     pub(crate) fn last_message(&self) -> Option<Message> {

--- a/src/tdlib/chat_list.rs
+++ b/src/tdlib/chat_list.rs
@@ -127,6 +127,7 @@ impl ChatList {
             ChatAction(ref update_) => self.handle_chat_update(update_.chat_id, update),
             ChatDraftMessage(ref update_) => self.handle_chat_update(update_.chat_id, update),
             ChatIsBlocked(ref update_) => self.handle_chat_update(update_.chat_id, update),
+            ChatIsMarkedAsUnread(ref update_) => self.handle_chat_update(update_.chat_id, update),
             ChatLastMessage(ref update_) => self.handle_chat_update(update_.chat_id, update),
             ChatNotificationSettings(ref update_) => {
                 self.handle_chat_update(update_.chat_id, update);


### PR DESCRIPTION
- [x] Show whether a chat is marked as unread in the sidebar
- [x] Support marking chats as read/unread through menu entries
- [x] Unselect chat as soon as it is marked as unread
- [x] Mark chat as read when selected in the sidebar 