### PR TITLE
message-row: Reduce width of outgoing messages

### DIFF
--- a/src/session/content/message_row/mod.rs
+++ b/src/session/content/message_row/mod.rs
@@ -278,7 +278,7 @@ impl MessageRow {
 
         if is_outgoing {
             content.set_halign(gtk::Align::End);
-            content.set_margin_start(AVATAR_SIZE + SPACING);
+            content.set_margin_start((AVATAR_SIZE + SPACING) * 2);
             content.set_margin_end(0);
             content.add_css_class("outgoing");
         } else {


### PR DESCRIPTION
Quoting the commit message
```
Currently, two messages with the same content can have different
dimensions depending on whether the message is outgoing or incoming. An
outgoing message has a potentially larger width because it has no avatar
and the space of the missing avatar is directly taken by the message.
This is especially noticeable when the application window has a small
width.

This behavior not only looks very inharmonious but also interferes with
the quick differentiation between incoming and outgoing messages. 
Especially pictures that have only a very narrow frame with the accent
color can be problematic.

This is easily solved with this commit, in which the left margin of the
outgoing message is extended by the right margin of an incoming message
(doubling).
```

Before | After
:--------:|:--------:
![](https://user-images.githubusercontent.com/3630213/173859802-f7e573aa-21d4-4dd3-a540-fb5017c37a69.png)  |  ![](https://user-images.githubusercontent.com/3630213/173859805-82a092d6-c106-4e04-9360-354142611570.png)
