### PR TITLE
fix: Avoid usize overflow when inserting day dividers

### DIFF
--- a/src/tdlib/chat_history.rs
+++ b/src/tdlib/chat_history.rs
@@ -177,7 +177,7 @@ impl ChatHistory {
             let added = added as usize;
 
             let mut list = imp.list.borrow_mut();
-            let mut previous_timestamp = if position < list.len() - 1 {
+            let mut previous_timestamp = if position + 1 < list.len() {
                 list.get(position + 1)
                     .and_then(|item| item.message_timestamp())
             } else {


### PR DESCRIPTION
If a chat does not contain any messages, then the application crashes
when tag dividers are inserted into the history.

  thread 'main' panicked at 'attempt to subtract with overflow',
  src/tdlib/chat_history.rs:180:56

This crash can be easily avoided by transforming the inequality
`x < y - 1` to `x + 1 < y`.

Fixes #358.