### PR TITLE
sidebar-selection: Check when both positions are invalid

### DIFF
--- a/src/session/sidebar/selection.rs
+++ b/src/session/sidebar/selection.rs
@@ -234,7 +234,10 @@ impl Selection {
         let old_position = imp.item_position.get();
         imp.item_position.set(position);
 
-        if !self.hide_selection() {
+        if !self.hide_selection()
+            && (old_position != gtk::INVALID_LIST_POSITION
+                || position != gtk::INVALID_LIST_POSITION)
+        {
             if old_position == gtk::INVALID_LIST_POSITION {
                 self.selection_changed(position, 1);
             } else if position == gtk::INVALID_LIST_POSITION {


### PR DESCRIPTION
This case was not handled and it was causing a hard-to-debug crash in my
local branch. The cause of the crash was that we were notifying a change
in the position of GTK_INVALID_LIST_POSITION, which is of course...
invalid.