### PR TITLE
New search

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,6 @@ sudo ninja -C _build install
 
 ## Acknowledgment
 
-The general code architecture was heavily inspired by [fractal-next](https://gitlab.gnome.org/GNOME/fractal/-/tree/fractal-next).
+The general code architecture was heavily inspired by [Fractal](https://gitlab.gnome.org/GNOME/fractal).
+
+Also, some logic is inspired by [Telegram X](https://github.com/TGX-Android/Telegram-X), which helps to understand how to use some TDLib features correctly and to their fullest potential.

--- a/data/resources/resources.gresource.xml
+++ b/data/resources/resources.gresource.xml
@@ -34,6 +34,7 @@
     <file compressed="true" preprocess="xml-stripblanks">ui/sidebar-avatar.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/sidebar-row.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/sidebar-row-menu.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/sidebar-search.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/sidebar-session-switcher.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/sidebar.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/window.ui</file>

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -112,6 +112,10 @@
   background-color: @light_5;
 }
 
+sidebarsearchitemrow {
+  border-spacing: 12px;
+}
+
 .chat-history listview {
   padding: 3px 0;
 }

--- a/data/resources/ui/sidebar-search.ui
+++ b/data/resources/ui/sidebar-search.ui
@@ -10,6 +10,7 @@
             <property name="title-widget">
               <object class="GtkSearchEntry" id="search_entry">
                 <property name="placeholder-text" translatable="yes">Search</property>
+                <signal name="search-changed" handler="search" swapped="true"/>
               </object>
             </property>
             <child type="start">
@@ -21,8 +22,50 @@
           </object>
         </child>
         <child>
-          <object class="GtkStack">
+          <object class="GtkStack" id="stack">
             <property name="vexpand">True</property>
+            <child>
+              <object class="GtkStackPage">
+                <property name="name">results</property>
+                <property name="child">
+                  <object class="GtkScrolledWindow">
+                    <property name="hscrollbar-policy">never</property>
+                    <child>
+                      <object class="GtkListView">
+                        <property name="single-click-activate">True</property>
+                        <signal name="activate" handler="list_activate" swapped="true"/>
+                        <property name="model">
+                          <object class="GtkNoSelection" id="selection"/>
+                        </property>
+                        <property name="factory">
+                          <object class="GtkBuilderListItemFactory">
+                            <property name="bytes"><![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="GtkListItem">
+    <property name="child">
+      <object class="SidebarSearchRow">
+        <property name="margin-top">6</property>
+        <property name="margin-bottom">6</property>
+        <binding name="item">
+          <lookup name="item">GtkListItem</lookup>
+        </binding>
+      </object>
+    </property>
+  </template>
+</interface>
+                            ]]></property>
+                          </object>
+                        </property>
+                        <style>
+                          <class name="navigation-sidebar"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+              </object>
+            </child>
             <child>
               <object class="GtkStackPage">
                 <property name="name">empty</property>

--- a/data/resources/ui/sidebar-search.ui
+++ b/data/resources/ui/sidebar-search.ui
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="SidebarSearch" parent="GtkWidget">
+    <child>
+      <object class="GtkBox" id="content">
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="AdwHeaderBar">
+            <property name="show-end-title-buttons" bind-source="SidebarSearch" bind-property="compact" bind-flags="sync-create"/>
+            <property name="title-widget">
+              <object class="GtkSearchEntry" id="search_entry">
+                <property name="placeholder-text" translatable="yes">Search</property>
+              </object>
+            </property>
+            <child type="start">
+              <object class="GtkButton">
+                <property name="action-name">sidebar-search.go-back</property>
+                <property name="icon-name">go-previous-symbolic</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkStack">
+            <property name="vexpand">True</property>
+            <child>
+              <object class="GtkStackPage">
+                <property name="name">empty</property>
+                <property name="child">
+                  <object class="AdwStatusPage">
+                    <property name="icon-name">system-search-symbolic</property>
+                    <property name="title" translatable="yes">No Search Results</property>
+                    <property name="description" translatable="yes">Try a different search.</property>
+                    <style>
+                      <class name="compact"/>
+                    </style>
+                  </object>
+                </property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/resources/ui/sidebar.ui
+++ b/data/resources/ui/sidebar.ui
@@ -29,8 +29,10 @@
     </property>
     <child>
       <object class="GtkStack" id="stack">
+        <property name="transition-duration">100</property>
+        <property name="transition-type">crossfade</property>
         <child>
-          <object class="GtkBox">
+          <object class="GtkBox" id="main_box">
             <property name="orientation">vertical</property>
             <child>
               <object class="AdwHeaderBar">
@@ -59,6 +61,12 @@
                   <object class="GtkMenuButton">
                     <property name="icon-name">open-menu-symbolic</property>
                     <property name="menu-model">primary_menu</property>
+                  </object>
+                </child>
+                <child type="end">
+                  <object class="GtkButton">
+                    <property name="action-name">sidebar.start-search</property>
+                    <property name="icon-name">system-search-symbolic</property>
                   </object>
                 </child>
               </object>
@@ -104,6 +112,13 @@
                 </child>
               </object>
             </child>
+          </object>
+        </child>
+        <child>
+          <object class="SidebarSearch" id="search">
+            <property name="compact" bind-source="Sidebar" bind-property="compact" bind-flags="sync-create"/>
+            <property name="session" bind-source="Sidebar" bind-property="session" bind-flags="sync-create"/>
+            <signal name="close" handler="close_search" swapped="true"/>
           </object>
         </child>
       </object>

--- a/data/resources/ui/sidebar.ui
+++ b/data/resources/ui/sidebar.ui
@@ -32,55 +32,55 @@
         <child>
           <object class="GtkBox">
             <property name="orientation">vertical</property>
-    <child>
-      <object class="AdwHeaderBar">
-        <property name="show-end-title-buttons" bind-source="Sidebar" bind-property="compact" bind-flags="sync-create"/>
-        <child type="start">
-          <object class="GtkMenuButton">
-            <property name="popover">
-              <object class="SessionSwitcher" id="session_switcher"/>
-            </property>
-            <style>
-              <class name="image-button"/>
-            </style>
-            <property name="child">
-              <object class="ComponentsAvatar">
-                <property name="size">24</property>
-                <binding name="item">
-                  <lookup name="me" type="Session">
-                    <lookup name="session">Sidebar</lookup>
-                  </lookup>
-                </binding>
+            <child>
+              <object class="AdwHeaderBar">
+                <property name="show-end-title-buttons" bind-source="Sidebar" bind-property="compact" bind-flags="sync-create"/>
+                <child type="start">
+                  <object class="GtkMenuButton">
+                    <property name="popover">
+                      <object class="SessionSwitcher" id="session_switcher"/>
+                    </property>
+                    <style>
+                      <class name="image-button"/>
+                    </style>
+                    <property name="child">
+                      <object class="ComponentsAvatar">
+                        <property name="size">24</property>
+                        <binding name="item">
+                          <lookup name="me" type="Session">
+                            <lookup name="session">Sidebar</lookup>
+                          </lookup>
+                        </binding>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+                <child type="end">
+                  <object class="GtkMenuButton">
+                    <property name="icon-name">open-menu-symbolic</property>
+                    <property name="menu-model">primary_menu</property>
+                  </object>
+                </child>
               </object>
-            </property>
-          </object>
-        </child>
-        <child type="end">
-          <object class="GtkMenuButton">
-            <property name="icon-name">open-menu-symbolic</property>
-            <property name="menu-model">primary_menu</property>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkScrolledWindow">
-        <property name="vexpand">True</property>
-        <property name="hscrollbar-policy">never</property>
-        <child>
-          <object class="GtkListView">
-            <property name="single-click-activate">True</property>
-            <signal name="activate" handler="list_activate" swapped="true"/>
-            <property name="model">
-              <object class="SidebarSelection" id="selection">
-                <binding name="hide-selection">
-                  <lookup name="compact">Sidebar</lookup>
-                </binding>
-              </object>
-            </property>
-            <property name="factory">
-              <object class="GtkBuilderListItemFactory">
-                <property name="bytes"><![CDATA[
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="vexpand">True</property>
+                <property name="hscrollbar-policy">never</property>
+                <child>
+                  <object class="GtkListView">
+                    <property name="single-click-activate">True</property>
+                    <signal name="activate" handler="list_activate" swapped="true"/>
+                    <property name="model">
+                      <object class="SidebarSelection" id="selection">
+                        <binding name="hide-selection">
+                          <lookup name="compact">Sidebar</lookup>
+                        </binding>
+                      </object>
+                    </property>
+                    <property name="factory">
+                      <object class="GtkBuilderListItemFactory">
+                        <property name="bytes"><![CDATA[
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <template class="GtkListItem">
@@ -93,17 +93,17 @@
     </property>
   </template>
 </interface>
-                ]]></property>
+                        ]]></property>
+                      </object>
+                    </property>
+                    <style>
+                      <class name="navigation-sidebar"/>
+                      <class name="chat-list"/>
+                    </style>
+                  </object>
+                </child>
               </object>
-            </property>
-            <style>
-              <class name="navigation-sidebar"/>
-              <class name="chat-list"/>
-            </style>
-          </object>
-        </child>
-      </object>
-    </child>
+            </child>
           </object>
         </child>
       </object>

--- a/data/resources/ui/sidebar.ui
+++ b/data/resources/ui/sidebar.ui
@@ -58,21 +58,6 @@
             <property name="menu-model">primary_menu</property>
           </object>
         </child>
-        <child type="end">
-          <object class="GtkToggleButton">
-            <property name="icon-name">system-search-symbolic</property>
-            <property name="active" bind-source="search_bar" bind-property="search-mode-enabled" bind-flags="bidirectional|sync-create"/>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkSearchBar" id="search_bar">
-        <property name="child">
-          <object class="GtkSearchEntry" id="search_entry">
-            <property name="hexpand">True</property>
-          </object>
-        </property>
       </object>
     </child>
     <child>

--- a/data/resources/ui/sidebar.ui
+++ b/data/resources/ui/sidebar.ui
@@ -25,12 +25,15 @@
   <template class="Sidebar" parent="GtkWidget">
     <property name="width-request">300</property>
     <property name="layout-manager">
-      <object class="GtkBoxLayout">
-        <property name="orientation">vertical</property>
-      </object>
+      <object class="GtkBinLayout"/>
     </property>
     <child>
-      <object class="AdwHeaderBar" id="header_bar">
+      <object class="GtkStack" id="stack">
+        <child>
+          <object class="GtkBox">
+            <property name="orientation">vertical</property>
+    <child>
+      <object class="AdwHeaderBar">
         <property name="show-end-title-buttons" bind-source="Sidebar" bind-property="compact" bind-flags="sync-create"/>
         <child type="start">
           <object class="GtkMenuButton">
@@ -61,7 +64,7 @@
       </object>
     </child>
     <child>
-      <object class="GtkScrolledWindow" id="scrolled_window">
+      <object class="GtkScrolledWindow">
         <property name="vexpand">True</property>
         <property name="hscrollbar-policy">never</property>
         <child>
@@ -97,6 +100,10 @@
               <class name="navigation-sidebar"/>
               <class name="chat-list"/>
             </style>
+          </object>
+        </child>
+      </object>
+    </child>
           </object>
         </child>
       </object>

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -195,7 +195,7 @@ mod imp {
         fn constructed(&self, obj: &Self::Type) {
             self.parent_constructed(obj);
             self.sidebar
-                .connect_list_activated(clone!(@weak obj => move |_| {
+                .connect_chat_selected(clone!(@weak obj => move |_| {
                     obj.imp().leaflet.navigate(adw::NavigationDirection::Forward);
                 }));
         }

--- a/src/session/sidebar/mod.rs
+++ b/src/session/sidebar/mod.rs
@@ -190,6 +190,7 @@ impl Sidebar {
 
     pub(crate) fn begin_chats_search(&self) {
         let imp = self.imp();
+        imp.search.reset();
         imp.search.grab_focus();
         imp.stack.set_visible_child(&*imp.search);
     }

--- a/src/session/sidebar/mod.rs
+++ b/src/session/sidebar/mod.rs
@@ -35,11 +35,9 @@ mod imp {
         pub(super) session: RefCell<Option<Session>>,
         pub(super) row_menu: OnceCell<gtk::PopoverMenu>,
         #[template_child]
-        pub(super) header_bar: TemplateChild<adw::HeaderBar>,
+        pub(super) stack: TemplateChild<gtk::Stack>,
         #[template_child]
         pub(super) session_switcher: TemplateChild<SessionSwitcher>,
-        #[template_child]
-        pub(super) scrolled_window: TemplateChild<gtk::ScrolledWindow>,
         #[template_child]
         pub(super) selection: TemplateChild<Selection>,
     }
@@ -150,8 +148,7 @@ mod imp {
         }
 
         fn dispose(&self, _obj: &Self::Type) {
-            self.header_bar.unparent();
-            self.scrolled_window.unparent();
+            self.stack.unparent();
         }
     }
 

--- a/src/session/sidebar/mod.rs
+++ b/src/session/sidebar/mod.rs
@@ -8,15 +8,12 @@ use self::row::Row;
 use self::selection::Selection;
 use self::session_switcher::SessionSwitcher;
 
-use gettextrs::gettext;
 use glib::clone;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use gtk::{gio, glib, CompositeTemplate};
-use tdlib::{enums, functions};
+use gtk::{glib, CompositeTemplate};
 
-use crate::tdlib::{Chat, ChatType, User};
-use crate::utils::spawn;
+use crate::tdlib::Chat;
 use crate::Session;
 
 pub(crate) use self::avatar::Avatar;
@@ -36,19 +33,11 @@ mod imp {
         pub(super) compact: Cell<bool>,
         pub(super) selected_chat: RefCell<Option<Chat>>,
         pub(super) session: RefCell<Option<Session>>,
-        pub(super) filter: RefCell<Option<gtk::CustomFilter>>,
-        pub(super) searched_chats: RefCell<Vec<i64>>,
-        pub(super) searched_users: RefCell<Vec<i64>>,
-        pub(super) already_searched_users: RefCell<Vec<i64>>,
         pub(super) row_menu: OnceCell<gtk::PopoverMenu>,
         #[template_child]
         pub(super) header_bar: TemplateChild<adw::HeaderBar>,
         #[template_child]
         pub(super) session_switcher: TemplateChild<SessionSwitcher>,
-        #[template_child]
-        pub(super) search_bar: TemplateChild<gtk::SearchBar>,
-        #[template_child]
-        pub(super) search_entry: TemplateChild<gtk::SearchEntry>,
         #[template_child]
         pub(super) scrolled_window: TemplateChild<gtk::ScrolledWindow>,
         #[template_child]
@@ -76,32 +65,17 @@ mod imp {
     #[gtk::template_callbacks]
     impl Sidebar {
         #[template_callback]
-        async fn list_activate(&self, pos: u32) {
-            let instance = self.instance();
+        fn list_activate(&self, pos: u32) {
             self.selection.set_selected_position(pos);
 
+            let instance = self.instance();
+            let chat = self
+                .selection
+                .selected_item()
+                .map(|i| i.downcast().unwrap());
+            instance.set_selected_chat(chat);
+
             instance.emit_by_name::<()>("list-activated", &[]);
-
-            if let Some(item) = self.selection.selected_item() {
-                if let Some(chat) = item.downcast_ref::<Chat>() {
-                    instance.set_selected_chat(Some(chat.clone()));
-                } else if let Some(user) = item.downcast_ref::<User>() {
-                    // Create a chat with the user and then select the created chat
-                    let user_id = user.id();
-                    let session = user.session();
-                    let client_id = session.client_id();
-                    let result = functions::create_private_chat(user_id, false, client_id).await;
-
-                    if let Ok(enums::Chat::Chat(chat)) = result {
-                        let chat = session.chat_list().get(chat.id);
-                        instance.set_selected_chat(Some(chat));
-                    }
-                }
-
-                return;
-            }
-
-            instance.set_selected_chat(None);
         }
     }
 
@@ -175,21 +149,8 @@ mod imp {
             }
         }
 
-        fn constructed(&self, obj: &Self::Type) {
-            self.parent_constructed(obj);
-
-            self.search_entry
-                .connect_search_changed(clone!(@weak obj => move |entry| {
-                    let query = entry.text().to_string();
-                    spawn(clone!(@weak obj => async move {
-                        obj.search(query).await;
-                    }));
-                }));
-        }
-
         fn dispose(&self, _obj: &Self::Type) {
             self.header_bar.unparent();
-            self.search_bar.unparent();
             self.scrolled_window.unparent();
         }
     }
@@ -221,82 +182,7 @@ impl Sidebar {
         })
     }
 
-    pub(crate) fn begin_chats_search(&self) {
-        let imp = self.imp();
-        imp.search_bar.set_search_mode(true);
-        imp.search_entry.grab_focus();
-    }
-
-    async fn search(&self, query: String) {
-        let imp = self.imp();
-        imp.searched_chats.borrow_mut().clear();
-        imp.searched_users.borrow_mut().clear();
-        imp.already_searched_users.borrow_mut().clear();
-
-        if query.is_empty() {
-            if let Some(filter) = imp.filter.borrow().as_ref() {
-                filter.changed(gtk::FilterChange::Different);
-            }
-        } else {
-            let client_id = self
-                .session()
-                .expect("The session needs to be set to be able to search")
-                .client_id();
-
-            // Search chats
-            let result = functions::search_chats(query.clone(), 100, client_id).await;
-            if let Ok(enums::Chats::Chats(chats)) = result {
-                if let Some(filter) = imp.filter.borrow().as_ref() {
-                    let session = self
-                        .session()
-                        .expect("The session needs to be set to be able to search");
-                    let chat_list = session.chat_list();
-
-                    // This will hold the own user id if the user has searched for the own
-                    // chat.
-                    let maybe_own_user_id = if gettext("Saved Messages")
-                        .to_lowercase()
-                        .contains(&query.to_lowercase())
-                    {
-                        Some(session.me().id())
-                    } else {
-                        None
-                    };
-
-                    imp.already_searched_users.borrow_mut().extend(
-                        chats
-                            .chat_ids
-                            .iter()
-                            .map(|id| chat_list.get(*id))
-                            .filter_map(|chat| match chat.type_() {
-                                ChatType::Private(user) => Some(user.id()),
-                                _ => None,
-                            })
-                            .chain(maybe_own_user_id.into_iter()),
-                    );
-
-                    imp.searched_chats.borrow_mut().extend(
-                        chats
-                            .chat_ids
-                            .into_iter()
-                            // The own user id is the same as the own chat id, so we can
-                            // chain this here.
-                            .chain(maybe_own_user_id.map(|id| id as i64).into_iter()),
-                    );
-                    filter.changed(gtk::FilterChange::Different);
-                }
-            }
-
-            // Search contacts
-            let result = functions::search_contacts(query, 100, client_id).await;
-            if let Ok(enums::Users::Users(users)) = result {
-                if let Some(filter) = imp.filter.borrow().as_ref() {
-                    imp.searched_users.borrow_mut().extend(users.user_ids);
-                    filter.changed(gtk::FilterChange::Different);
-                }
-            }
-        }
-    }
+    pub(crate) fn begin_chats_search(&self) {}
 
     pub(crate) fn selected_chat(&self) -> Option<Chat> {
         self.imp().selected_chat.borrow().clone()
@@ -323,51 +209,14 @@ impl Sidebar {
         let imp = self.imp();
 
         if let Some(ref session) = session {
-            // Merge ChatList and UserList into a single list model
-            let list = gio::ListStore::new(gio::ListModel::static_type());
-            list.append(session.chat_list());
-            list.append(session.user_list());
-            let model = gtk::FlattenListModel::new(Some(&list));
-
-            let filter = gtk::CustomFilter::new(
-                clone!(@weak self as obj => @default-return false, move |item| {
-                    let imp = obj.imp();
-                    let is_searching = !imp.search_entry.text().is_empty();
-
-                    if is_searching {
-                        if let Some(chat) = item.downcast_ref::<Chat>() {
-                            imp.searched_chats.borrow().contains(&chat.id())
-                        } else if let Some(user) = item.downcast_ref::<User>() {
-                            // Show searched users, but only the ones that haven't
-                            // already been searched by the chats search
-                            !imp.already_searched_users.borrow().contains(&user.id())
-                                && imp.searched_users.borrow().contains(&user.id())
-                        } else {
-                            false
-                        }
-                    } else if let Some(chat) = item.downcast_ref::<Chat>() {
-                        chat.order() > 0
-                    } else {
-                        false
-                    }
-                }),
-            );
-            let sorter = gtk::CustomSorter::new(move |obj1, obj2| {
-                let chat1 = obj1.downcast_ref::<Chat>();
-                let chat2 = obj2.downcast_ref::<Chat>();
-
-                // Always show chats first and then users
-                if let Some(chat1) = chat1 {
-                    if let Some(chat2) = chat2 {
-                        chat2.order().cmp(&chat1.order()).into()
-                    } else {
-                        gtk::Ordering::Smaller
-                    }
-                } else if chat2.is_some() {
-                    gtk::Ordering::Larger
-                } else {
-                    gtk::Ordering::Equal
-                }
+            let filter = gtk::CustomFilter::new(|item| {
+                let chat = item.downcast_ref::<Chat>().unwrap();
+                chat.order() > 0
+            });
+            let sorter = gtk::CustomSorter::new(|item1, item2| {
+                let chat1 = item1.downcast_ref::<Chat>().unwrap();
+                let chat2 = item2.downcast_ref::<Chat>().unwrap();
+                chat2.order().cmp(&chat1.order()).into()
             });
 
             session.chat_list().connect_positions_changed(
@@ -377,11 +226,10 @@ impl Sidebar {
                 }),
             );
 
-            let filter_model = gtk::FilterListModel::new(Some(&model), Some(&filter));
+            let filter_model = gtk::FilterListModel::new(Some(session.chat_list()), Some(&filter));
             let sort_model = gtk::SortListModel::new(Some(&filter_model), Some(&sorter));
 
             imp.selection.set_model(Some(sort_model.upcast()));
-            imp.filter.replace(Some(filter));
         }
 
         imp.session.replace(session);

--- a/src/session/sidebar/search/item_row.rs
+++ b/src/session/sidebar/search/item_row.rs
@@ -1,3 +1,4 @@
+use gettextrs::gettext;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{glib, CompositeTemplate};
@@ -119,7 +120,11 @@ impl ItemRow {
         let imp = self.imp();
 
         if let Some(chat) = item.as_ref().and_then(|i| i.downcast_ref::<Chat>()) {
-            imp.label.set_label(&chat.title());
+            if chat.is_own_chat() {
+                imp.label.set_label(&gettext("Saved Messages"));
+            } else {
+                imp.label.set_label(&chat.title());
+            }
         } else if let Some(user) = item.as_ref().and_then(|i| i.downcast_ref::<User>()) {
             imp.label
                 .set_label(&(user.first_name() + " " + &user.last_name()));

--- a/src/session/sidebar/search/item_row.rs
+++ b/src/session/sidebar/search/item_row.rs
@@ -1,0 +1,141 @@
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use gtk::{glib, CompositeTemplate};
+
+use crate::tdlib::{Chat, User};
+
+mod imp {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use std::cell::RefCell;
+
+    use crate::session::components::Avatar;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(string = r#"
+    <interface>
+      <template class="SidebarSearchItemRow" parent="GtkWidget">
+        <child>
+          <object class="ComponentsAvatar" id="avatar">
+            <property name="size">32</property>
+            <binding name="item">
+              <lookup name="item">SidebarSearchItemRow</lookup>
+            </binding>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label">
+            <property name="ellipsize">end</property>
+          </object>
+        </child>
+      </template>
+    </interface>
+    "#)]
+    pub(crate) struct ItemRow {
+        /// A `Chat` or `User`
+        pub(super) item: RefCell<Option<glib::Object>>,
+        #[template_child]
+        pub(super) avatar: TemplateChild<Avatar>,
+        #[template_child]
+        pub(super) label: TemplateChild<gtk::Label>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for ItemRow {
+        const NAME: &'static str = "SidebarSearchItemRow";
+        type Type = super::ItemRow;
+        type ParentType = gtk::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+
+            klass.set_css_name("sidebarsearchitemrow");
+            klass.set_layout_manager_type::<gtk::BoxLayout>();
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for ItemRow {
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![glib::ParamSpecObject::new(
+                    "item",
+                    "Item",
+                    "The item of this row",
+                    glib::Object::static_type(),
+                    glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                )]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(
+            &self,
+            obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "item" => obj.set_item(value.get().unwrap()),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "item" => obj.item().to_value(),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn dispose(&self, _obj: &Self::Type) {
+            self.avatar.unparent();
+            self.label.unparent();
+        }
+    }
+
+    impl WidgetImpl for ItemRow {}
+}
+
+glib::wrapper! {
+    pub(crate) struct ItemRow(ObjectSubclass<imp::ItemRow>)
+        @extends gtk::Widget;
+}
+
+impl ItemRow {
+    pub(crate) fn new(item: &Option<glib::Object>) -> Self {
+        glib::Object::new(&[("item", item)]).expect("Failed to create SidebarSearchItemRow")
+    }
+
+    pub(crate) fn set_item(&self, item: Option<glib::Object>) {
+        if self.item() == item {
+            return;
+        }
+
+        let imp = self.imp();
+
+        if let Some(chat) = item.as_ref().and_then(|i| i.downcast_ref::<Chat>()) {
+            imp.label.set_label(&chat.title());
+        } else if let Some(user) = item.as_ref().and_then(|i| i.downcast_ref::<User>()) {
+            imp.label
+                .set_label(&(user.first_name() + " " + &user.last_name()));
+        } else {
+            imp.label.set_label("");
+
+            if let Some(ref item) = item {
+                log::warn!("Unexpected item type {:?}", item);
+            }
+        }
+
+        imp.item.replace(item);
+        self.notify("item");
+    }
+
+    pub(crate) fn item(&self) -> Option<glib::Object> {
+        self.imp().item.borrow().clone()
+    }
+}

--- a/src/session/sidebar/search/mod.rs
+++ b/src/session/sidebar/search/mod.rs
@@ -1,0 +1,138 @@
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use gtk::{glib, CompositeTemplate};
+
+use crate::Session;
+
+mod imp {
+    use super::*;
+    use glib::subclass::Signal;
+    use once_cell::sync::Lazy;
+    use std::cell::{Cell, RefCell};
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(resource = "/com/github/melix99/telegrand/ui/sidebar-search.ui")]
+    pub(crate) struct Search {
+        pub(super) session: RefCell<Option<Session>>,
+        pub(super) compact: Cell<bool>,
+        #[template_child]
+        pub(super) content: TemplateChild<gtk::Box>,
+        #[template_child]
+        pub(super) search_entry: TemplateChild<gtk::SearchEntry>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for Search {
+        const NAME: &'static str = "SidebarSearch";
+        type Type = super::Search;
+        type ParentType = gtk::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+
+            klass.set_layout_manager_type::<gtk::BinLayout>();
+            klass.install_action("sidebar-search.go-back", None, move |widget, _, _| {
+                widget.emit_by_name::<()>("close", &[]);
+            });
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for Search {
+        fn signals() -> &'static [Signal] {
+            static SIGNALS: Lazy<Vec<Signal>> = Lazy::new(|| {
+                vec![Signal::builder("close", &[], <()>::static_type().into()).build()]
+            });
+            SIGNALS.as_ref()
+        }
+
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![
+                    glib::ParamSpecObject::new(
+                        "session",
+                        "Session",
+                        "The session",
+                        Session::static_type(),
+                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                    ),
+                    glib::ParamSpecBoolean::new(
+                        "compact",
+                        "Compact",
+                        "Whether a compact view is used or not",
+                        false,
+                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                    ),
+                ]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(
+            &self,
+            obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "session" => obj.set_session(value.get().unwrap()),
+                "compact" => obj.set_compact(value.get().unwrap()),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "session" => obj.session().to_value(),
+                "compact" => obj.compact().to_value(),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn dispose(&self, _obj: &Self::Type) {
+            self.content.unparent();
+        }
+    }
+
+    impl WidgetImpl for Search {
+        fn grab_focus(&self, _widget: &Self::Type) -> bool {
+            self.search_entry.grab_focus();
+            true
+        }
+    }
+}
+
+glib::wrapper! {
+    pub(crate) struct Search(ObjectSubclass<imp::Search>)
+        @extends gtk::Widget;
+}
+
+impl Search {
+    pub(crate) fn session(&self) -> Option<Session> {
+        self.imp().session.borrow().clone()
+    }
+
+    pub(crate) fn set_session(&self, session: Option<Session>) {
+        if self.session() == session {
+            return;
+        }
+        self.imp().session.replace(session);
+        self.notify("session");
+    }
+
+    pub(crate) fn compact(&self) -> bool {
+        self.imp().compact.get()
+    }
+
+    pub(crate) fn set_compact(&self, compact: bool) {
+        if self.compact() == compact {
+            return;
+        }
+        self.imp().compact.set(compact);
+        self.notify("compact");
+    }
+}

--- a/src/session/sidebar/search/mod.rs
+++ b/src/session/sidebar/search/mod.rs
@@ -274,7 +274,7 @@ impl Search {
             if let Some(chat) = session.chat_list().try_get(user.id()) {
                 sidebar.select_chat(chat);
             } else {
-                match functions::create_private_chat(user.id(), false, session.client_id()).await {
+                match functions::create_private_chat(user.id(), true, session.client_id()).await {
                     Ok(enums::Chat::Chat(data)) => {
                         let chat = session.chat_list().get(data.id);
                         sidebar.select_chat(chat);

--- a/src/session/sidebar/search/mod.rs
+++ b/src/session/sidebar/search/mod.rs
@@ -1,7 +1,18 @@
+mod item_row;
+mod row;
+
+use self::item_row::ItemRow;
+use self::row::Row;
+
+use glib::clone;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use gtk::{glib, CompositeTemplate};
+use gtk::{gio, glib, CompositeTemplate};
+use tdlib::{enums, functions};
 
+use crate::session::Sidebar;
+use crate::tdlib::{Chat, User};
+use crate::utils::spawn;
 use crate::Session;
 
 mod imp {
@@ -19,6 +30,10 @@ mod imp {
         pub(super) content: TemplateChild<gtk::Box>,
         #[template_child]
         pub(super) search_entry: TemplateChild<gtk::SearchEntry>,
+        #[template_child]
+        pub(super) stack: TemplateChild<gtk::Stack>,
+        #[template_child]
+        pub(super) selection: TemplateChild<gtk::NoSelection>,
     }
 
     #[glib::object_subclass]
@@ -28,7 +43,10 @@ mod imp {
         type ParentType = gtk::Widget;
 
         fn class_init(klass: &mut Self::Class) {
+            Row::static_type();
+
             Self::bind_template(klass);
+            Self::Type::bind_template_callbacks(klass);
 
             klass.set_layout_manager_type::<gtk::BinLayout>();
             klass.install_action("sidebar-search.go-back", None, move |widget, _, _| {
@@ -111,7 +129,22 @@ glib::wrapper! {
         @extends gtk::Widget;
 }
 
+#[gtk::template_callbacks]
 impl Search {
+    pub(crate) fn reset(&self) {
+        let imp = self.imp();
+        if imp.search_entry.text().is_empty() {
+            // Update recently found chats
+            spawn(clone!(@weak self as obj => async move {
+                obj.search().await;
+            }));
+        } else {
+            // Reset the search entry. This will also start the search
+            // for getting the recently found chats.
+            imp.search_entry.set_text("");
+        }
+    }
+
     pub(crate) fn session(&self) -> Option<Session> {
         self.imp().session.borrow().clone()
     }
@@ -134,5 +167,123 @@ impl Search {
         }
         self.imp().compact.set(compact);
         self.notify("compact");
+    }
+
+    #[template_callback]
+    async fn search(&self) {
+        let imp = self.imp();
+        let session = self.session().unwrap();
+        let query = imp.search_entry.text().to_string();
+        let list = gio::ListStore::new(glib::Object::static_type());
+        let mut found_chat_ids: Vec<i64> = vec![];
+
+        imp.selection.set_model(Some(&list));
+        list.connect_items_changed(clone!(@weak self as obj => move |list, _, _, _| {
+            obj.imp().stack.set_visible_child_name(if list.n_items() > 0 {
+                "results"
+            } else {
+                "empty"
+            });
+        }));
+
+        // Show the results page prematurely, so that we don't show the empty page
+        // before even starting the search.
+        imp.stack.set_visible_child_name("results");
+
+        // Search chats locally (or get the recently found chats if the query is empty)
+        match functions::search_chats(query.clone(), 30, session.client_id()).await {
+            Ok(enums::Chats::Chats(mut data)) if !data.chat_ids.is_empty() => {
+                let chats: Vec<Chat> = data
+                    .chat_ids
+                    .iter()
+                    .map(|id| session.chat_list().get(*id))
+                    .collect();
+
+                found_chat_ids.append(&mut data.chat_ids);
+                list.extend_from_slice(&chats);
+            }
+            Err(e) => {
+                log::warn!("Error searching chats: {:?}", e);
+            }
+            _ => {}
+        }
+
+        // Show the empty page if there are no results after the first part of the search
+        if list.n_items() == 0 {
+            imp.stack.set_visible_child_name("empty");
+        }
+
+        // If the query is empty, we can stop the search here as we just need the
+        // recently found chats that the previous search call returned.
+        if query.is_empty() {
+            return;
+        }
+
+        // Search contacts
+        match functions::search_contacts(
+            query,
+            50 - found_chat_ids.len() as i32,
+            session.client_id(),
+        )
+        .await
+        {
+            Ok(enums::Users::Users(data)) if !data.user_ids.is_empty() => {
+                let users: Vec<User> = data
+                    .user_ids
+                    .into_iter()
+                    .filter_map(|id| {
+                        // The user IDs are the same as their respective private chat IDs,
+                        // so we can just check for chat IDs here.
+                        if found_chat_ids.contains(&id) {
+                            None
+                        } else {
+                            found_chat_ids.push(id);
+                            Some(session.user_list().get(id))
+                        }
+                    })
+                    .collect();
+
+                list.extend_from_slice(&users);
+            }
+            Err(e) => {
+                log::warn!("Error searching contacts: {:?}", e);
+            }
+            _ => {}
+        }
+    }
+
+    #[template_callback]
+    async fn list_activate(&self, position: u32) {
+        let item = self.imp().selection.item(position).unwrap();
+        let sidebar = self
+            .ancestor(Sidebar::static_type())
+            .unwrap()
+            .downcast::<Sidebar>()
+            .unwrap();
+
+        if let Some(chat) = item.downcast_ref::<Chat>() {
+            sidebar.select_chat(chat.clone());
+        } else if let Some(user) = item.downcast_ref::<User>() {
+            let session = self.session().unwrap();
+
+            // Check if a private chat with this user already exists
+            if let Some(chat) = session.chat_list().try_get(user.id()) {
+                sidebar.select_chat(chat);
+            } else {
+                match functions::create_private_chat(user.id(), false, session.client_id()).await {
+                    Ok(enums::Chat::Chat(data)) => {
+                        let chat = session.chat_list().get(data.id);
+                        sidebar.select_chat(chat);
+                    }
+                    Err(e) => {
+                        log::warn!("Failed to create private chat: {:?}", e);
+                    }
+                }
+            }
+        } else {
+            log::warn!("Unexpected item type: {:?}", item);
+        }
+
+        self.emit_by_name::<()>("close", &[]);
     }
 }

--- a/src/session/sidebar/search/row.rs
+++ b/src/session/sidebar/search/row.rs
@@ -1,0 +1,125 @@
+use gtk::glib;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+
+use crate::session::sidebar::search::ItemRow;
+use crate::tdlib::{Chat, User};
+
+mod imp {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use std::cell::RefCell;
+
+    #[derive(Debug, Default)]
+    pub(crate) struct Row {
+        /// A `Chat` or `User`
+        pub(super) item: RefCell<Option<glib::Object>>,
+        pub(super) child: RefCell<Option<gtk::Widget>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for Row {
+        const NAME: &'static str = "SidebarSearchRow";
+        type Type = super::Row;
+        type ParentType = gtk::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.set_layout_manager_type::<gtk::BinLayout>();
+        }
+    }
+
+    impl ObjectImpl for Row {
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![glib::ParamSpecObject::new(
+                    "item",
+                    "Item",
+                    "The item of this row",
+                    glib::Object::static_type(),
+                    glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                )]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(
+            &self,
+            obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "item" => obj.set_item(value.get().unwrap()),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            match pspec.name() {
+                "item" => obj.item().to_value(),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn dispose(&self, _obj: &Self::Type) {
+            if let Some(child) = self.child.take() {
+                child.unparent();
+            }
+        }
+    }
+
+    impl WidgetImpl for Row {}
+}
+
+glib::wrapper! {
+    pub(crate) struct Row(ObjectSubclass<imp::Row>)
+        @extends gtk::Widget;
+}
+
+impl Row {
+    pub(crate) fn set_item(&self, item: Option<glib::Object>) {
+        if self.item() == item {
+            return;
+        }
+
+        let imp = self.imp();
+
+        if item
+            .as_ref()
+            .map(|i| i.type_() == Chat::static_type() || i.type_() == User::static_type())
+            .unwrap_or_default()
+        {
+            self.update_or_create_item_row(item.clone());
+        } else {
+            if let Some(child) = imp.child.take() {
+                child.unparent();
+            }
+
+            if let Some(ref item) = item {
+                log::warn!("Unexpected item type: {:?}", item);
+            }
+        }
+
+        imp.item.replace(item);
+        self.notify("item");
+    }
+
+    pub(crate) fn item(&self) -> Option<glib::Object> {
+        self.imp().item.borrow().clone()
+    }
+
+    fn update_or_create_item_row(&self, item: Option<glib::Object>) {
+        let mut child_ref = self.imp().child.borrow_mut();
+        match child_ref.as_ref().and_then(|c| c.downcast_ref::<ItemRow>()) {
+            Some(item_row) => {
+                item_row.set_item(item);
+            }
+            None => {
+                let item_row = ItemRow::new(&item);
+                item_row.set_parent(self);
+                *child_ref = Some(item_row.upcast());
+            }
+        }
+    }
+}

--- a/src/tdlib/chat_list.rs
+++ b/src/tdlib/chat_list.rs
@@ -163,12 +163,11 @@ impl ChatList {
     /// so if you use an `id` returned by TDLib, it should be expected that the
     /// relative `Chat` exists in the list.
     pub(crate) fn get(&self, id: i64) -> Chat {
-        self.imp()
-            .list
-            .borrow()
-            .get(&id)
-            .expect("Failed to get expected Chat")
-            .to_owned()
+        self.try_get(id).expect("Failed to get expected Chat")
+    }
+
+    pub(crate) fn try_get(&self, id: i64) -> Option<Chat> {
+        self.imp().list.borrow().get(&id).cloned()
     }
 
     fn insert_chat(&self, chat: TelegramChat) {


### PR DESCRIPTION
Compared to the previous implementation, this new widget is completely
separated from the chat list in the sidebar, meaning that we don't use
the overly complicated merged ChatList + UserList model for the ListView
and the same SidebarRow that we already use for the regular (and already
complex) chat list in the Sidebar.

Also, the new widget is more easily expandable to support more object
types, like messages and custom objects (e.g. section headers).

This new widget also gained the ability to show recent searches when the
query is empty.

Part of the new search logic is inspired by Telegram X.

This is also a continuation of #353, to also remove `UserList` from `Session`.
This will probably be completed in a next PR since this one is already pretty big.

EDIT:

This currently crashes when opening a chat of a contact that is not present in the chat list. This will be fixed by #360.