### PR TITLE
tdlib: Read only properties

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -233,12 +233,12 @@ impl Session {
 
     pub(crate) fn handle_update(&self, update: Update) {
         match update {
-            Update::BasicGroup(ref data) => {
+            Update::BasicGroup(data) => {
                 let mut basic_groups = self.imp().basic_groups.borrow_mut();
                 match basic_groups.entry(data.basic_group.id) {
-                    Entry::Occupied(entry) => entry.get().handle_update(&update),
+                    Entry::Occupied(entry) => entry.get().update(data.basic_group),
                     Entry::Vacant(entry) => {
-                        entry.insert(BasicGroup::from_td_object(&data.basic_group));
+                        entry.insert(BasicGroup::from_td_object(data.basic_group));
                     }
                 }
             }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -280,13 +280,13 @@ impl Session {
                     }
                 }
             }
-            Update::SecretChat(ref data) => {
+            Update::SecretChat(data) => {
                 let mut secret_chats = self.imp().secret_chats.borrow_mut();
                 match secret_chats.entry(data.secret_chat.id) {
-                    Entry::Occupied(entry) => entry.get().handle_update(&update),
+                    Entry::Occupied(entry) => entry.get().update(data.secret_chat),
                     Entry::Vacant(entry) => {
                         let user = self.user_list().get(data.secret_chat.user_id);
-                        entry.insert(SecretChat::from_td_object(&data.secret_chat, &user));
+                        entry.insert(SecretChat::from_td_object(data.secret_chat, user));
                     }
                 }
             }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -290,12 +290,12 @@ impl Session {
                     }
                 }
             }
-            Update::Supergroup(ref data) => {
+            Update::Supergroup(data) => {
                 let mut supergroups = self.imp().supergroups.borrow_mut();
                 match supergroups.entry(data.supergroup.id) {
-                    Entry::Occupied(entry) => entry.get().handle_update(&update),
+                    Entry::Occupied(entry) => entry.get().update(data.supergroup),
                     Entry::Vacant(entry) => {
-                        entry.insert(Supergroup::from_td_object(&data.supergroup));
+                        entry.insert(Supergroup::from_td_object(data.supergroup));
                     }
                 }
             }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -130,21 +130,21 @@ mod imp {
                         "Private Chats Notification Settings",
                         "This session's notification settings for private chats",
                         BoxedScopeNotificationSettings::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecBoxed::new(
                         "group-chats-notification-settings",
                         "Group Chats Notification Settings",
                         "This session's notification settings for group chats",
                         BoxedScopeNotificationSettings::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecBoxed::new(
                         "channel-chats-notification-settings",
                         "Channel Chats Notification Settings",
                         "This session's notification settings for channel chats",
                         BoxedScopeNotificationSettings::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                 ]
             });
@@ -154,7 +154,7 @@ mod imp {
 
         fn set_property(
             &self,
-            obj: &Self::Type,
+            _obj: &Self::Type,
             _id: usize,
             value: &glib::Value,
             pspec: &glib::ParamSpec,
@@ -167,18 +167,6 @@ mod imp {
                 "database-info" => {
                     let database_info = value.get().unwrap();
                     self.database_info.set(database_info).unwrap();
-                }
-                "private-chats-notification-settings" => {
-                    let scope_notification_settings = value.get().unwrap();
-                    obj.set_private_chats_notification_settings(scope_notification_settings);
-                }
-                "group-chats-notification-settings" => {
-                    let scope_notification_settings = value.get().unwrap();
-                    obj.set_group_chats_notification_settings(scope_notification_settings);
-                }
-                "channel-chats-notification-settings" => {
-                    let scope_notification_settings = value.get().unwrap();
-                    obj.set_channel_chats_notification_settings(scope_notification_settings);
                 }
                 _ => unimplemented!(),
             }

--- a/src/tdlib/chat.rs
+++ b/src/tdlib/chat.rs
@@ -270,9 +270,34 @@ impl Chat {
         imp.avatar.replace(avatar);
         imp.last_read_outbox_message_id
             .set(td_chat.last_read_outbox_message_id);
-        // TODO: Initialize last-message
-        // TODO: Initialize order
-        // TODO: Initialize is-pinned
+
+        match td_chat.last_message {
+            Some(last_message) => {
+                let message = match chat.history().message_by_id(last_message.id) {
+                    Some(message) => message,
+                    None => {
+                        let last_message_id = last_message.id;
+
+                        chat.history().push_front(last_message);
+                        chat.history().message_by_id(last_message_id).unwrap()
+                    }
+                };
+
+                imp.last_message.replace(Some(message));
+            }
+            None => {
+                imp.last_message.replace(None);
+            }
+        }
+
+        for position in td_chat.positions {
+            if let enums::ChatList::Main = position.list {
+                imp.order.set(position.order);
+                imp.is_pinned.set(position.is_pinned);
+                break;
+            }
+        }
+
         imp.unread_mention_count.set(td_chat.unread_mention_count);
         imp.unread_count.set(td_chat.unread_count);
         imp.draft_message.replace(draft_message);

--- a/src/tdlib/chat.rs
+++ b/src/tdlib/chat.rs
@@ -96,41 +96,35 @@ mod imp {
                         std::i64::MIN,
                         std::i64::MAX,
                         0,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecBoxed::new(
                         "type",
                         "Type",
                         "The type of this chat",
                         ChatType::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecBoolean::new(
                         "is-blocked",
                         "Is blocked",
                         "Whether this chat is blocked for the user",
                         false,
-                        glib::ParamFlags::READWRITE
-                            | glib::ParamFlags::CONSTRUCT
-                            | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecString::new(
                         "title",
                         "Title",
                         "The title of this chat",
                         Some(""),
-                        glib::ParamFlags::READWRITE
-                            | glib::ParamFlags::CONSTRUCT
-                            | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecBoxed::new(
                         "avatar",
                         "Avatar",
                         "The avatar of this chat",
                         Avatar::static_type(),
-                        glib::ParamFlags::READWRITE
-                            | glib::ParamFlags::CONSTRUCT
-                            | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecInt64::new(
                         "last-read-outbox-message-id",
@@ -139,18 +133,14 @@ mod imp {
                         std::i64::MIN,
                         std::i64::MAX,
                         0,
-                        glib::ParamFlags::READWRITE
-                            | glib::ParamFlags::CONSTRUCT
-                            | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecObject::new(
                         "last-message",
                         "Last Message",
                         "The last message sent on this chat",
                         Message::static_type(),
-                        glib::ParamFlags::READWRITE
-                            | glib::ParamFlags::CONSTRUCT
-                            | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecInt64::new(
                         "order",
@@ -159,18 +149,14 @@ mod imp {
                         std::i64::MIN,
                         std::i64::MAX,
                         0,
-                        glib::ParamFlags::READWRITE
-                            | glib::ParamFlags::CONSTRUCT
-                            | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecBoolean::new(
                         "is-pinned",
                         "Is Pinned",
                         "The parameter to determine if this chat is pinned in the chat list",
                         false,
-                        glib::ParamFlags::READWRITE
-                            | glib::ParamFlags::CONSTRUCT
-                            | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecInt::new(
                         "unread-mention-count",
@@ -179,9 +165,7 @@ mod imp {
                         std::i32::MIN,
                         std::i32::MAX,
                         0,
-                        glib::ParamFlags::READWRITE
-                            | glib::ParamFlags::CONSTRUCT
-                            | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecInt::new(
                         "unread-count",
@@ -190,27 +174,21 @@ mod imp {
                         std::i32::MIN,
                         std::i32::MAX,
                         0,
-                        glib::ParamFlags::READWRITE
-                            | glib::ParamFlags::CONSTRUCT
-                            | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecBoxed::new(
                         "draft-message",
                         "Draft Message",
                         "The draft message of this chat",
                         BoxedDraftMessage::static_type(),
-                        glib::ParamFlags::READWRITE
-                            | glib::ParamFlags::CONSTRUCT
-                            | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecBoxed::new(
                         "notification-settings",
                         "Notification Settings",
                         "The notification settings of this chat",
                         BoxedChatNotificationSettings::static_type(),
-                        glib::ParamFlags::READWRITE
-                            | glib::ParamFlags::CONSTRUCT
-                            | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecObject::new(
                         "history",
@@ -231,51 +209,18 @@ mod imp {
                         "Session",
                         "The session",
                         Session::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecBoxed::new(
                         "permissions",
                         "Permissions",
                         "The permissions of this chat",
                         BoxedChatPermissions::static_type(),
-                        glib::ParamFlags::READWRITE
-                            | glib::ParamFlags::CONSTRUCT
-                            | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                 ]
             });
             PROPERTIES.as_ref()
-        }
-
-        fn set_property(
-            &self,
-            obj: &Self::Type,
-            _id: usize,
-            value: &glib::Value,
-            pspec: &glib::ParamSpec,
-        ) {
-            match pspec.name() {
-                "id" => self.id.set(value.get().unwrap()),
-                "type" => self.type_.set(value.get().unwrap()).unwrap(),
-                "is-blocked" => obj.set_is_blocked(value.get().unwrap()),
-                "title" => {
-                    obj.set_title(value.get::<Option<String>>().unwrap().unwrap_or_default())
-                }
-                "avatar" => obj.set_avatar(value.get().unwrap()),
-                "last-read-outbox-message-id" => {
-                    obj.set_last_read_outbox_message_id(value.get().unwrap());
-                }
-                "last-message" => obj.set_last_message(value.get().unwrap()),
-                "order" => obj.set_order(value.get().unwrap()),
-                "is-pinned" => obj.set_is_pinned(value.get().unwrap()),
-                "unread-mention-count" => obj.set_unread_mention_count(value.get().unwrap()),
-                "unread-count" => obj.set_unread_count(value.get().unwrap()),
-                "draft-message" => obj.set_draft_message(value.get().unwrap()),
-                "notification-settings" => obj.set_notification_settings(value.get().unwrap()),
-                "permissions" => obj.set_permissions(value.get().unwrap()),
-                "session" => self.session.set(Some(&value.get().unwrap())),
-                _ => unimplemented!(),
-            }
         }
 
         fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
@@ -308,32 +253,35 @@ glib::wrapper! {
 }
 
 impl Chat {
-    pub(crate) fn new(chat: TelegramChat, session: Session) -> Self {
-        let type_ = ChatType::from_td_object(&chat.r#type, &session);
-        let avatar = chat.photo.map(Avatar::from);
-        let draft_message = chat.draft_message.map(BoxedDraftMessage);
+    pub(crate) fn new(td_chat: TelegramChat, session: &Session) -> Self {
+        let chat: Chat = glib::Object::new(&[]).expect("Failed to create Chat");
+        let imp = chat.imp();
 
-        glib::Object::new(&[
-            ("id", &chat.id),
-            ("type", &type_),
-            ("is-blocked", &chat.is_blocked),
-            ("title", &chat.title),
-            (
-                "last-read-outbox-message-id",
-                &chat.last_read_outbox_message_id,
-            ),
-            ("avatar", &avatar),
-            ("draft-message", &draft_message),
-            ("unread-mention-count", &chat.unread_mention_count),
-            ("unread-count", &chat.unread_count),
-            (
-                "notification-settings",
-                &BoxedChatNotificationSettings(chat.notification_settings),
-            ),
-            ("permissions", &BoxedChatPermissions(chat.permissions)),
-            ("session", &session),
-        ])
-        .expect("Failed to create Chat")
+        let type_ = ChatType::from_td_object(&td_chat.r#type, session);
+        let avatar = td_chat.photo.map(Avatar::from);
+        let draft_message = td_chat.draft_message.map(BoxedDraftMessage);
+        let notification_settings = BoxedChatNotificationSettings(td_chat.notification_settings);
+        let permissions = BoxedChatPermissions(td_chat.permissions);
+
+        imp.id.set(td_chat.id);
+        imp.type_.set(type_).unwrap();
+        imp.is_blocked.set(td_chat.is_blocked);
+        imp.title.replace(td_chat.title);
+        imp.avatar.replace(avatar);
+        imp.last_read_outbox_message_id
+            .set(td_chat.last_read_outbox_message_id);
+        // TODO: Initialize last-message
+        // TODO: Initialize order
+        // TODO: Initialize is-pinned
+        imp.unread_mention_count.set(td_chat.unread_mention_count);
+        imp.unread_count.set(td_chat.unread_count);
+        imp.draft_message.replace(draft_message);
+        imp.notification_settings
+            .replace(Some(notification_settings));
+        imp.session.set(Some(session));
+        imp.permissions.replace(Some(permissions));
+
+        chat
     }
 
     pub(crate) fn handle_update(&self, update: Update) {
@@ -432,7 +380,7 @@ impl Chat {
         self.imp().is_blocked.get()
     }
 
-    pub(crate) fn set_is_blocked(&self, is_blocked: bool) {
+    fn set_is_blocked(&self, is_blocked: bool) {
         if self.is_blocked() == is_blocked {
             return;
         }
@@ -444,7 +392,7 @@ impl Chat {
         self.imp().title.borrow().to_owned()
     }
 
-    pub(crate) fn set_title(&self, title: String) {
+    fn set_title(&self, title: String) {
         if self.title() == title {
             return;
         }
@@ -456,7 +404,7 @@ impl Chat {
         self.imp().avatar.borrow().to_owned()
     }
 
-    pub(crate) fn set_avatar(&self, avatar: Option<Avatar>) {
+    fn set_avatar(&self, avatar: Option<Avatar>) {
         if self.avatar() == avatar {
             return;
         }
@@ -489,7 +437,7 @@ impl Chat {
         self.imp().last_message.borrow().to_owned()
     }
 
-    pub(crate) fn set_last_message(&self, last_message: Option<Message>) {
+    fn set_last_message(&self, last_message: Option<Message>) {
         if self.last_message() == last_message {
             return;
         }
@@ -501,7 +449,7 @@ impl Chat {
         self.imp().order.get()
     }
 
-    pub(crate) fn set_order(&self, order: i64) {
+    fn set_order(&self, order: i64) {
         if self.order() == order {
             return;
         }
@@ -520,7 +468,7 @@ impl Chat {
         self.imp().is_pinned.get()
     }
 
-    pub(crate) fn set_is_pinned(&self, is_pinned: bool) {
+    fn set_is_pinned(&self, is_pinned: bool) {
         if self.is_pinned() == is_pinned {
             return;
         }
@@ -532,7 +480,7 @@ impl Chat {
         self.imp().unread_mention_count.get()
     }
 
-    pub(crate) fn set_unread_mention_count(&self, unread_mention_count: i32) {
+    fn set_unread_mention_count(&self, unread_mention_count: i32) {
         if self.unread_mention_count() == unread_mention_count {
             return;
         }
@@ -544,7 +492,7 @@ impl Chat {
         self.imp().unread_count.get()
     }
 
-    pub(crate) fn set_unread_count(&self, unread_count: i32) {
+    fn set_unread_count(&self, unread_count: i32) {
         if self.unread_count() == unread_count {
             return;
         }
@@ -556,7 +504,7 @@ impl Chat {
         self.imp().draft_message.borrow().to_owned()
     }
 
-    pub(crate) fn set_draft_message(&self, draft_message: Option<BoxedDraftMessage>) {
+    fn set_draft_message(&self, draft_message: Option<BoxedDraftMessage>) {
         if self.draft_message() == draft_message {
             return;
         }
@@ -573,10 +521,7 @@ impl Chat {
             .to_owned()
     }
 
-    pub(crate) fn set_notification_settings(
-        &self,
-        notification_settings: BoxedChatNotificationSettings,
-    ) {
+    fn set_notification_settings(&self, notification_settings: BoxedChatNotificationSettings) {
         if self.imp().notification_settings.borrow().as_ref() == Some(&notification_settings) {
             return;
         }
@@ -608,7 +553,7 @@ impl Chat {
         self.imp().permissions.borrow().to_owned().unwrap()
     }
 
-    pub(crate) fn set_permissions(&self, permissions: BoxedChatPermissions) {
+    fn set_permissions(&self, permissions: BoxedChatPermissions) {
         if self.imp().permissions.borrow().as_ref() == Some(&permissions) {
             return;
         }

--- a/src/tdlib/chat_action.rs
+++ b/src/tdlib/chat_action.rs
@@ -39,40 +39,25 @@ mod imp {
                         "Type",
                         "The type of this chat action",
                         BoxedChatActionType::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecBoxed::new(
                         "sender",
                         "Sender",
                         "The sender of this chat action",
                         MessageSender::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecObject::new(
                         "chat",
                         "Chat",
                         "The chat relative to this chat action",
                         Chat::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                        glib::ParamFlags::READABLE,
                     ),
                 ]
             });
             PROPERTIES.as_ref()
-        }
-
-        fn set_property(
-            &self,
-            _obj: &Self::Type,
-            _id: usize,
-            value: &glib::Value,
-            pspec: &glib::ParamSpec,
-        ) {
-            match pspec.name() {
-                "type" => self.type_.set(value.get().unwrap()).unwrap(),
-                "sender" => self.sender.set(value.get().unwrap()).unwrap(),
-                "chat" => self.chat.set(Some(&value.get().unwrap())),
-                _ => unimplemented!(),
-            }
         }
 
         fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
@@ -96,15 +81,17 @@ impl ChatAction {
         sender: &enums::MessageSender,
         chat: &Chat,
     ) -> Self {
-        glib::Object::new(&[
-            ("type", &BoxedChatActionType(type_)),
-            (
-                "sender",
-                &MessageSender::from_td_object(sender, &chat.session()),
-            ),
-            ("chat", chat),
-        ])
-        .expect("Failed to create ChatAction")
+        let chat_action: ChatAction = glib::Object::new(&[]).expect("Failed to create ChatAction");
+        let imp = chat_action.imp();
+
+        let type_ = BoxedChatActionType(type_);
+        let sender = MessageSender::from_td_object(sender, &chat.session());
+
+        imp.type_.set(type_).unwrap();
+        imp.sender.set(sender).unwrap();
+        imp.chat.set(Some(chat));
+
+        chat_action
     }
 
     pub(crate) fn type_(&self) -> &BoxedChatActionType {

--- a/src/tdlib/chat_action_list.rs
+++ b/src/tdlib/chat_action_list.rs
@@ -36,23 +36,10 @@ mod imp {
                     "Chat",
                     "The chat relative to this chat action list",
                     Chat::static_type(),
-                    glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                    glib::ParamFlags::READABLE,
                 )]
             });
             PROPERTIES.as_ref()
-        }
-
-        fn set_property(
-            &self,
-            _obj: &Self::Type,
-            _id: usize,
-            value: &glib::Value,
-            pspec: &glib::ParamSpec,
-        ) {
-            match pspec.name() {
-                "chat" => self.chat.set(Some(&value.get().unwrap())),
-                _ => unimplemented!(),
-            }
         }
 
         fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
@@ -89,7 +76,10 @@ glib::wrapper! {
 
 impl From<&Chat> for ChatActionList {
     fn from(chat: &Chat) -> Self {
-        glib::Object::new(&[("chat", chat)]).expect("Failed to create ChatActionList")
+        let chat_action_list: ChatActionList =
+            glib::Object::new(&[]).expect("Failed to create ChatActionList");
+        chat_action_list.imp().chat.set(Some(chat));
+        chat_action_list
     }
 }
 

--- a/src/tdlib/chat_history.rs
+++ b/src/tdlib/chat_history.rs
@@ -40,33 +40,19 @@ mod imp {
                         "Chat",
                         "The chat relative to this history",
                         Chat::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecBoolean::new(
                         "loading",
                         "Loading",
                         "Whether the history is loading messages or not",
                         false,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                        glib::ParamFlags::READABLE,
                     ),
                 ]
             });
 
             PROPERTIES.as_ref()
-        }
-
-        fn set_property(
-            &self,
-            obj: &Self::Type,
-            _id: usize,
-            value: &glib::Value,
-            pspec: &glib::ParamSpec,
-        ) {
-            match pspec.name() {
-                "chat" => self.chat.set(Some(&value.get().unwrap())),
-                "loading" => obj.set_loading(value.get().unwrap()),
-                _ => unimplemented!(),
-            }
         }
 
         fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
@@ -104,7 +90,10 @@ glib::wrapper! {
 
 impl ChatHistory {
     pub(crate) fn new(chat: &Chat) -> Self {
-        glib::Object::new(&[("chat", chat)]).expect("Failed to create ChatHistory")
+        let chat_history: ChatHistory =
+            glib::Object::new(&[]).expect("Failed to create ChatHistory");
+        chat_history.imp().chat.set(Some(chat));
+        chat_history
     }
 
     pub(crate) async fn load_older_messages(&self) {
@@ -354,7 +343,7 @@ impl ChatHistory {
         self.imp().chat.upgrade().unwrap()
     }
 
-    pub(crate) fn set_loading(&self, loading: bool) {
+    fn set_loading(&self, loading: bool) {
         self.imp().loading.set(loading);
         self.notify("loading");
     }

--- a/src/tdlib/chat_list.rs
+++ b/src/tdlib/chat_list.rs
@@ -192,7 +192,7 @@ impl ChatList {
         {
             let mut list = self.imp().list.borrow_mut();
             let chat_id = chat.id;
-            let chat = Chat::new(chat, self.session());
+            let chat = Chat::new(chat, &self.session());
 
             chat.connect_order_notify(clone!(@weak self as obj => move |_, _| {
                 obj.emit_by_name::<()>("positions-changed", &[]);

--- a/src/tdlib/chat_list.rs
+++ b/src/tdlib/chat_list.rs
@@ -57,32 +57,12 @@ mod imp {
                         "Session",
                         "The session",
                         Session::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                        glib::ParamFlags::READABLE,
                     ),
                 ]
             });
 
             PROPERTIES.as_ref()
-        }
-
-        fn set_property(
-            &self,
-            obj: &Self::Type,
-            _id: usize,
-            value: &glib::Value,
-            pspec: &glib::ParamSpec,
-        ) {
-            match pspec.name() {
-                "unread-count" => {
-                    let unread_count = value.get().unwrap();
-                    obj.set_unread_count(unread_count);
-                }
-                "session" => {
-                    let session = value.get().unwrap();
-                    self.session.set(session);
-                }
-                _ => unimplemented!(),
-            }
         }
 
         fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
@@ -120,7 +100,9 @@ glib::wrapper! {
 
 impl ChatList {
     pub(crate) fn new(session: &Session) -> Self {
-        glib::Object::new(&[("session", session)]).expect("Failed to create ChatList")
+        let chat_list: ChatList = glib::Object::new(&[]).expect("Failed to create ChatList");
+        chat_list.imp().session.set(Some(session));
+        chat_list
     }
 
     pub(crate) fn fetch(&self, client_id: i32) {
@@ -215,7 +197,7 @@ impl ChatList {
         self.imp().unread_count.get()
     }
 
-    pub(crate) fn set_unread_count(&self, unread_count: i32) {
+    fn set_unread_count(&self, unread_count: i32) {
         if self.unread_count() == unread_count {
             return;
         }

--- a/src/tdlib/country_info.rs
+++ b/src/tdlib/country_info.rs
@@ -53,46 +53,25 @@ mod imp {
                         "Calling Codes",
                         "List of country calling codes",
                         CallingCodes::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecString::new(
                         "country-code",
                         "Country Code",
                         "A two-letter ISO 3166-1 alpha-2 country code",
                         None,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecString::new(
                         "name",
                         "Name",
                         "Native name of the country",
                         None,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                        glib::ParamFlags::READABLE,
                     ),
                 ]
             });
             PROPERTIES.as_ref()
-        }
-
-        fn set_property(
-            &self,
-            _obj: &Self::Type,
-            _id: usize,
-            value: &glib::Value,
-            pspec: &glib::ParamSpec,
-        ) {
-            match pspec.name() {
-                "calling-codes" => self.calling_codes.set(value.get().unwrap()).unwrap(),
-                "country-code" => self
-                    .country_code
-                    .set(value.get::<Option<String>>().unwrap().unwrap_or_default())
-                    .unwrap(),
-                "name" => self
-                    .name
-                    .set(value.get::<Option<String>>().unwrap().unwrap_or_default())
-                    .unwrap(),
-                _ => unimplemented!(),
-            }
         }
 
         fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
@@ -120,33 +99,42 @@ impl From<types::CountryInfo> for CountryInfo {
     fn from(country_info: types::CountryInfo) -> Self {
         Self::new(
             BTreeSet::from_iter(country_info.calling_codes),
-            &country_info.country_code,
-            &country_info.name,
+            country_info.country_code,
+            country_info.name,
         )
     }
 }
 
 impl CountryInfo {
-    fn new(calling_codes: BTreeSet<String>, country_code: &str, name: &str) -> Self {
-        glib::Object::new(&[
-            ("calling-codes", &CallingCodes(calling_codes)),
-            ("country-code", &country_code),
-            ("name", &name),
-        ])
-        .expect("Failed to create CountryInfo")
+    fn new(calling_codes: BTreeSet<String>, country_code: String, name: String) -> Self {
+        let country_info: CountryInfo =
+            glib::Object::new(&[]).expect("Failed to create CountryInfo");
+        let imp = country_info.imp();
+
+        let calling_codes = CallingCodes(calling_codes);
+
+        imp.calling_codes.set(calling_codes).unwrap();
+        imp.country_code.set(country_code).unwrap();
+        imp.name.set(name).unwrap();
+
+        country_info
     }
 
     /// The invalid `CountryInfo` can be used when no valid calling code was specified by the user.
     pub(crate) fn invalid() -> Self {
-        Self::new(Default::default(), "", &gettext("Invalid Country Code"))
+        Self::new(
+            Default::default(),
+            "".into(),
+            gettext("Invalid Country Code"),
+        )
     }
 
     /// The test `CountryInfo` is used for Telegram test numbers and is set as `99966`.
     pub(crate) fn test() -> Self {
         Self::new(
             BTreeSet::from_iter(Some("99966".to_string())),
-            "",
-            &gettext("Test Account"),
+            "".into(),
+            gettext("Test Account"),
         )
     }
 

--- a/src/tdlib/message.rs
+++ b/src/tdlib/message.rs
@@ -92,7 +92,7 @@ mod imp {
                         "Sender",
                         "The sender of this message",
                         MessageSender::static_type(),
-                        glib::ParamFlags::WRITABLE | glib::ParamFlags::CONSTRUCT_ONLY,
+                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
                     ),
                     glib::ParamSpecBoolean::new(
                         "is-outgoing",
@@ -200,6 +200,7 @@ mod imp {
         fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
             match pspec.name() {
                 "id" => obj.id().to_value(),
+                "sender" => obj.sender().to_value(),
                 "is-outgoing" => obj.is_outgoing().to_value(),
                 "can-be-deleted-only-for-self" => obj.can_be_deleted_only_for_self().to_value(),
                 "can-be-deleted-for-all-users" => obj.can_be_deleted_for_all_users().to_value(),

--- a/src/tdlib/message_forward_info.rs
+++ b/src/tdlib/message_forward_info.rs
@@ -68,32 +68,18 @@ mod imp {
                         0,
                         std::i32::MAX,
                         0,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                        glib::ParamFlags::READABLE,
                     ),
                     glib::ParamSpecBoxed::new(
                         "origin",
                         "Origin",
                         "The origin of the forwarded message",
                         MessageForwardOrigin::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                        glib::ParamFlags::READABLE,
                     ),
                 ]
             });
             PROPERTIES.as_ref()
-        }
-
-        fn set_property(
-            &self,
-            _obj: &Self::Type,
-            _id: usize,
-            value: &glib::Value,
-            pspec: &glib::ParamSpec,
-        ) {
-            match pspec.name() {
-                "date" => self.date.set(value.get().unwrap()),
-                "origin" => self.origin.set(value.get().unwrap()).unwrap(),
-                _ => unimplemented!(),
-            }
         }
 
         fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
@@ -143,8 +129,14 @@ impl MessageForwardInfo {
             }
         };
 
-        glib::Object::new(&[("date", &forward_info.date), ("origin", &origin)])
-            .expect("Failed to create MessageForwardInfo")
+        let message_forward_info: MessageForwardInfo =
+            glib::Object::new(&[]).expect("Failed to create MessageForwardInfo");
+        let imp = message_forward_info.imp();
+
+        imp.date.set(forward_info.date);
+        imp.origin.set(origin).unwrap();
+
+        message_forward_info
     }
 
     pub(crate) fn date(&self) -> i32 {

--- a/src/tdlib/user_list.rs
+++ b/src/tdlib/user_list.rs
@@ -35,24 +35,11 @@ mod imp {
                     "Session",
                     "The session",
                     Session::static_type(),
-                    glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
+                    glib::ParamFlags::READABLE,
                 )]
             });
 
             PROPERTIES.as_ref()
-        }
-
-        fn set_property(
-            &self,
-            _obj: &Self::Type,
-            _id: usize,
-            value: &glib::Value,
-            pspec: &glib::ParamSpec,
-        ) {
-            match pspec.name() {
-                "session" => self.session.set(value.get().unwrap()),
-                _ => unimplemented!(),
-            }
         }
 
         fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
@@ -89,7 +76,9 @@ glib::wrapper! {
 
 impl UserList {
     pub(crate) fn new(session: &Session) -> Self {
-        glib::Object::new(&[("session", session)]).expect("Failed to create UserList")
+        let user_list: UserList = glib::Object::new(&[]).expect("Failed to create UserList");
+        user_list.imp().session.set(Some(session));
+        user_list
     }
 
     /// Return the `User` of the specified `id`. Panics if the user is not present.


### PR DESCRIPTION
A quite big refactoring that I wanted to do for some time.

Since we expect that everything we get from TDLib is also only managed by TDLib, now every property in the tdlib module is read only and the setters are turned into private setters that are only called by TDLib updates.

I've also fixed some smaller thing, e.g. removing some clones and turning some strong refs to weak refs.