### PR TITLE
More reliable chat history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,6 +1106,7 @@ dependencies = [
  "regex",
  "tdlib",
  "temp-dir",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ qrcode-generator = { version = "4.1", default-features = false }
 regex = "1.6"
 tdlib = { version = "0.1", default-features = false }
 temp-dir = "0.1"
+thiserror = "1.0"

--- a/src/tdlib/chat_history.rs
+++ b/src/tdlib/chat_history.rs
@@ -257,7 +257,7 @@ impl ChatHistory {
             .items_changed(position, removed, added);
     }
 
-    pub(crate) fn push_front(&self, message: TelegramMessage) {
+    fn push_front(&self, message: TelegramMessage) {
         let imp = self.imp();
 
         let mut message_map = imp.message_map.borrow_mut();

--- a/src/tdlib/chat_history.rs
+++ b/src/tdlib/chat_history.rs
@@ -148,7 +148,10 @@ impl ChatHistory {
             }
             MessageContent(ref update_) => self.handle_message_update(update_.message_id, update),
             MessageEdited(ref update_) => self.handle_message_update(update_.message_id, update),
-            MessageSendSucceeded(update) => self.remove(update.old_message_id),
+            MessageSendSucceeded(update) => {
+                self.remove(update.old_message_id);
+                self.push_front(update.message);
+            }
             NewMessage(update) => self.push_front(update.message),
             _ => {}
         }

--- a/src/tdlib/chat_history.rs
+++ b/src/tdlib/chat_history.rs
@@ -6,8 +6,17 @@ use std::collections::hash_map::Entry;
 use tdlib::enums::{self, Update};
 use tdlib::functions;
 use tdlib::types::Message as TelegramMessage;
+use thiserror::Error;
 
 use crate::tdlib::{Chat, ChatHistoryItem, ChatHistoryItemType, Message};
+
+#[derive(Error, Debug)]
+pub(crate) enum ChatHistoryError {
+    #[error("The chat history is already loading messages")]
+    AlreadyLoading,
+    #[error("TDLib error: {0:?}")]
+    Tdlib(tdlib::types::Error),
+}
 
 mod imp {
     use super::*;
@@ -19,7 +28,7 @@ mod imp {
     #[derive(Debug, Default)]
     pub(crate) struct ChatHistory {
         pub(super) chat: WeakRef<Chat>,
-        pub(super) loading: Cell<bool>,
+        pub(super) is_loading: Cell<bool>,
         pub(super) list: RefCell<VecDeque<ChatHistoryItem>>,
         pub(super) message_map: RefCell<HashMap<i64, Message>>,
     }
@@ -34,22 +43,13 @@ mod imp {
     impl ObjectImpl for ChatHistory {
         fn properties() -> &'static [glib::ParamSpec] {
             static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
-                vec![
-                    glib::ParamSpecObject::new(
-                        "chat",
-                        "Chat",
-                        "The chat relative to this history",
-                        Chat::static_type(),
-                        glib::ParamFlags::READABLE,
-                    ),
-                    glib::ParamSpecBoolean::new(
-                        "loading",
-                        "Loading",
-                        "Whether the history is loading messages or not",
-                        false,
-                        glib::ParamFlags::READABLE,
-                    ),
-                ]
+                vec![glib::ParamSpecObject::new(
+                    "chat",
+                    "Chat",
+                    "The chat relative to this history",
+                    Chat::static_type(),
+                    glib::ParamFlags::READABLE,
+                )]
             });
 
             PROPERTIES.as_ref()
@@ -58,7 +58,6 @@ mod imp {
         fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
             match pspec.name() {
                 "chat" => obj.chat().to_value(),
-                "loading" => obj.loading().to_value(),
                 _ => unimplemented!(),
             }
         }
@@ -96,12 +95,13 @@ impl ChatHistory {
         chat_history
     }
 
-    pub(crate) async fn load_older_messages(&self) {
-        if self.loading() {
-            return;
+    pub(crate) async fn load_older_messages(&self) -> Result<(), ChatHistoryError> {
+        let imp = self.imp();
+
+        if imp.is_loading.get() {
+            return Err(ChatHistoryError::AlreadyLoading);
         }
 
-        let imp = self.imp();
         let chat = self.chat();
         let client_id = chat.session().client_id();
         let chat_id = chat.id();
@@ -114,17 +114,19 @@ impl ChatHistory {
             .map(|m| m.id())
             .unwrap_or_default();
 
-        self.set_loading(true);
+        imp.is_loading.set(true);
 
         let result =
             functions::get_chat_history(chat_id, oldest_message_id, 0, 20, false, client_id).await;
 
-        if let Ok(enums::Messages::Messages(result)) = result {
-            let messages = result.messages.into_iter().flatten().collect();
-            self.append(messages);
-        }
+        imp.is_loading.set(false);
 
-        self.set_loading(false);
+        let enums::Messages::Messages(data) = result.map_err(ChatHistoryError::Tdlib)?;
+        let messages = data.messages.into_iter().flatten().collect();
+
+        self.append(messages);
+
+        Ok(())
     }
 
     pub(crate) fn message_by_id(&self, id: i64) -> Option<Message> {
@@ -341,14 +343,5 @@ impl ChatHistory {
 
     pub(crate) fn chat(&self) -> Chat {
         self.imp().chat.upgrade().unwrap()
-    }
-
-    fn set_loading(&self, loading: bool) {
-        self.imp().loading.set(loading);
-        self.notify("loading");
-    }
-
-    pub(crate) fn loading(&self) -> bool {
-        self.imp().loading.get()
     }
 }

--- a/src/tdlib/chat_history.rs
+++ b/src/tdlib/chat_history.rs
@@ -95,7 +95,7 @@ impl ChatHistory {
         chat_history
     }
 
-    pub(crate) async fn load_older_messages(&self) -> Result<(), ChatHistoryError> {
+    pub(crate) async fn load_older_messages(&self, limit: i32) -> Result<(), ChatHistoryError> {
         let imp = self.imp();
 
         if imp.is_loading.get() {
@@ -117,7 +117,8 @@ impl ChatHistory {
         imp.is_loading.set(true);
 
         let result =
-            functions::get_chat_history(chat_id, oldest_message_id, 0, 20, false, client_id).await;
+            functions::get_chat_history(chat_id, oldest_message_id, 0, limit, false, client_id)
+                .await;
 
         imp.is_loading.set(false);
 

--- a/src/tdlib/mod.rs
+++ b/src/tdlib/mod.rs
@@ -22,6 +22,7 @@ pub(crate) use self::chat::{Chat, ChatType};
 pub(crate) use self::chat_action::ChatAction;
 pub(crate) use self::chat_action_list::ChatActionList;
 use self::chat_history::ChatHistory;
+pub(crate) use self::chat_history::ChatHistoryError;
 pub(crate) use self::chat_history_item::{ChatHistoryItem, ChatHistoryItemType};
 pub(crate) use self::chat_list::ChatList;
 pub(crate) use self::country_info::CountryInfo;


### PR DESCRIPTION
This is  a set of changes that should make the chat history be more reliable, loading all the messages so that the entire list height is completely filled. Also, this changes how the last messages are handled in chats. We no longer store these inside their respective `ChatHistory`, since TDLib already caches these for us. Also, sometimes this was causing the wrong messages to be loaded, since there were a conflict with the last message update.