### PR TITLE
sidebar-row: Improve contrast of last message status icon

### DIFF
--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -69,14 +69,6 @@
   padding: 6px 0;
 }
 
-.chat-list row .last-message-status-sent {
-  color: @accent_bg_color;
-}
-
-.chat-list row .last-message-status-failed {
-  color: @destructive_color;
-}
-
 .chat-list row .timestamp {
   font-size: smaller;
   font-feature-settings: "tnum";

--- a/src/session/sidebar/row.rs
+++ b/src/session/sidebar/row.rs
@@ -357,12 +357,10 @@ impl Row {
                                     .map(|message| {
                                         vec![match message.sending_state() {
                                             Some(state) => match state.0 {
-                                                MessageSendingState::Failed(_) => {
-                                                    "last-message-status-failed"
-                                                }
+                                                MessageSendingState::Failed(_) => "error",
                                                 MessageSendingState::Pending => "dim-label",
                                             },
-                                            None => "last-message-status-sent",
+                                            None => "accent",
                                         }
                                         .to_string()]
                                     })


### PR DESCRIPTION
This is done using libadwaita's ".accent" and ".error" CSS classes,
which both have improved contrast with the dark style.

