### PR TITLE
chat-history: Add MessageBubble bin widget

### DIFF
--- a/data/resources/style-dark.css
+++ b/data/resources/style-dark.css
@@ -6,10 +6,6 @@
   background-color: @dark_2;
 }
 
-.message-bubble:not(.outgoing) {
-  background-color: alpha(white, 0.1);
-}
-
 .sender-text-red {
   color: #fb6169;
 }

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -131,37 +131,38 @@ sidebarsearchitemrow {
   padding: 3px;
 }
 
-.message-bubble {
-  background-color: alpha(black, 0.07);
-  border-radius: 12px;
+messagebubble {
+  background: alpha(currentColor, 0.08);
+  border-radius: 15px;
 }
 
-.message-bubble.outgoing {
-  background-color: @accent_bg_color;
+messagebubble.outgoing {
+  background: @accent_bg_color;
   color: @accent_fg_color;
 }
 
-.message-bubble.outgoing selection {
-  background-color: alpha(@accent_fg_color, 0.2);
-}
-
-.message-bubble.outgoing link {
+messagebubble.outgoing link {
   color: @accent_fg_color;
 }
 
-messagedocument > label.sender-text {
-  margin-bottom: 3px;
+messagebubble messageindicators {
+  opacity: 0.7;
 }
 
-messagedocument label.file-size {
-  font-size: smaller;
+messagebubble.text > overlay,
+messagebubble.document > overlay {
+  padding: 6px 9px;
 }
 
-messagedocument > box {
-  padding: 9px;
+messagebubble.document {
+  min-width: 220px;
 }
 
-messagedocument > box > image {
+messagebubble.document .file {
+  margin: 6px 0;
+}
+
+messagebubble.document .file > image {
   background: @accent_color;
   color: @window_bg_color;
   transition: opacity 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
@@ -169,27 +170,43 @@ messagedocument > box > image {
   border-radius: 9999px;
 }
 
-messagedocument.outgoing > box > image {
+messagebubble.document.outgoing .file > image {
   background: @accent_fg_color;
   color: @accent_bg_color;
 }
 
-messagedocument> box:hover > image {
+messagebubble.document .file:hover > image {
   opacity: 0.85;
 }
 
-messagedocument > box:active > image {
+messagebubble.document .file:active > image {
   opacity: 0.7;
 }
 
-messagemedia .media-picture {
-  margin: 2px;
-  border-radius: 10px;
+messagebubble.media .media-picture {
+  /* Message bubble border-radius (15px) - margin (1px)  */
+  border-radius: 14px;
+  margin: 1px;
 }
 
-messagemedia.with-caption .media-picture {
-  margin-bottom: 0;
-  border-radius: 10px 10px 4px 4px;
+messagebubble.media.with-label .media-picture {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+  margin: 1px 1px 0;
+}
+
+messagebubble.media messagelabel {
+  margin: 6px 9px;
+}
+
+messagebubble.media:not(.with-label) messageindicators,
+messagesticker messageindicators {
+  background-color: alpha(@view_bg_color, 0.8);
+  color: @view_fg_color;
+  opacity: 1.0; /* Reset opacity from message bubble */
+  border-radius: 9999px;
+  padding: 2px 6px;
+  margin: 6px;
 }
 
 messagemedia progressbar > trough {
@@ -202,36 +219,10 @@ messageindicators {
   font-feature-settings: "tnum";
 }
 
-messagelabel {
-  margin: 6px 9px;
-}
-
-messagelabel > messageindicators, messagedocument > box messageindicators {
-  opacity: 0.7;
-}
-
-messagemedia overlay > messageindicators, messagesticker messageindicators {
-  background-color: alpha(@view_bg_color, 0.8);
-  color: @view_fg_color;
-  border-radius: 9999px;
-  padding: 2px 6px;
-  margin: 6px;
-}
-
 .event-row {
   font-size: smaller;
   font-weight: bold;
   padding: 3px;
-}
-
-.sender-text {
-  margin: 6px 9px 0 9px;
-  font-size: small;
-  font-weight: bold;
-}
-
-.sender-text + messagelabel {
-  margin-top: 0;
 }
 
 .sender-text-red {

--- a/data/resources/ui/content-message-document.ui
+++ b/data/resources/ui/content-message-document.ui
@@ -1,77 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <template class="ContentMessageDocument" parent="ContentMessageBase">
-    <property name="layout-manager">
-      <object class="GtkBoxLayout">
-        <property name="orientation">vertical</property>
-      </object>
-    </property>
-    <style>
-      <class name="message-bubble"/>
-    </style>
     <child>
-      <object class="GtkLabel" id="sender_label">
-        <property name="ellipsize">end</property>
-        <property name="single-line-mode">True</property>
-        <property name="xalign">0</property>
+      <object class="MessageBubble" id="message_bubble">
         <style>
-          <class name="sender-text"/>
+          <class name="document"/>
         </style>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox" id="document_box">
-        <property name="spacing">6</property>
-        <child>
-          <object class="GtkGestureClick" id="click">
-            <property name="button">1</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkImage" id="file_status_image">
-            <property name="valign">start</property>
-          </object>
-        </child>
-        <child>
+        <property name="prefix">
           <object class="GtkBox">
-            <property name="valign">center</property>
-            <property name="hexpand">true</property>
-            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <style>
+              <class name="file"/>
+            </style>
             <child>
-              <object class="GtkLabel" id="file_name_label">
-                <property name="xalign">0</property>
-                <property name="ellipsize">middle</property>
+              <object class="GtkGestureClick" id="click">
+                <property name="button">1</property>
               </object>
             </child>
             <child>
-              <object class="GtkLabel" id="file_size_label">
-                <style>
-                  <class name="numeric"/>
-                  <class name="dim-label"/>
-                  <class name="file-size"/>
-                </style>
-                <property name="xalign">0</property>
-                <property name="width-chars">16</property>
-              </object>
+              <object class="GtkImage" id="file_status_image"/>
             </child>
             <child>
-              <object class="MessageIndicators">
-                <property name="message" bind-source="indicators" bind-property="message"/>
-                <property name="visible" bind-source="content_label" bind-property="visible" bind-flags="sync-create|invert-boolean"/>
-                <property name="halign">end</property>
-                <property name="valign">end</property>
+              <object class="GtkBox">
+                <property name="hexpand">true</property>
+                <property name="valign">center</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel" id="file_name_label">
+                    <property name="xalign">0</property>
+                    <property name="ellipsize">middle</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="file_size_label">
+                    <style>
+                      <class name="numeric"/>
+                      <class name="dim-label"/>
+                      <class name="caption"/>
+                    </style>
+                    <property name="xalign">0</property>
+                  </object>
+                </child>
               </object>
             </child>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
-      <object class="MessageLabel" id="content_label">
-        <property name="indicators">
-          <object class="MessageIndicators" id="indicators">
-            <property name="halign">end</property>
-            <property name="valign">end</property>
           </object>
         </property>
       </object>

--- a/data/resources/ui/content-message-media.ui
+++ b/data/resources/ui/content-message-media.ui
@@ -2,24 +2,19 @@
 <interface>
   <template class="ContentMessageMedia" parent="GtkWidget">
     <child>
-      <object class="GtkBox" id="content">
-        <property name="orientation">vertical</property>
+      <object class="GtkOverlay" id="overlay">
+        <child type="overlay">
+          <object class="GtkProgressBar" id="progress_bar">
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+        </child>
         <child>
-          <object class="GtkOverlay" id="overlay">
-            <child type="overlay">
-              <object class="GtkProgressBar" id="progress_bar">
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-              </object>
-            </child>
-            <child>
-              <object class="ContentMediaPicture" id="picture">
-                <property name="overflow">hidden</property>
-                <style>
-                  <class name="media-picture"/>
-                </style>
-              </object>
-            </child>
+          <object class="ContentMediaPicture" id="picture">
+            <property name="overflow">hidden</property>
+            <style>
+              <class name="media-picture"/>
+            </style>
           </object>
         </child>
       </object>

--- a/data/resources/ui/content-message-photo.ui
+++ b/data/resources/ui/content-message-photo.ui
@@ -4,16 +4,13 @@
     <property name="layout-manager">
       <object class="GtkBinLayout"/>
     </property>
-    <style>
-      <class name="message-bubble"/>
-    </style>
     <child>
-      <object class="ContentMessageMedia" id="media">
-        <property name="indicators">
-          <object class="MessageIndicators" id="indicators">
-            <property name="halign">end</property>
-            <property name="valign">end</property>
-          </object>
+      <object class="MessageBubble" id="message_bubble">
+        <style>
+          <class name="media"/>
+        </style>
+        <property name="prefix">
+          <object class="ContentMessageMedia" id="media"/>
         </property>
       </object>
     </child>

--- a/data/resources/ui/content-message-text.ui
+++ b/data/resources/ui/content-message-text.ui
@@ -1,32 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <template class="ContentMessageText" parent="ContentMessageBase">
-    <property name="layout-manager">
-      <object class="GtkBoxLayout">
-        <property name="orientation">vertical</property>
-      </object>
-    </property>
-    <style>
-      <class name="message-bubble"/>
-    </style>
     <child>
-      <object class="GtkLabel" id="sender_label">
-        <property name="ellipsize">end</property>
-        <property name="single-line-mode">True</property>
-        <property name="xalign">0</property>
+      <object class="MessageBubble" id="message_bubble">
         <style>
-          <class name="sender-text"/>
+          <class name="text"/>
         </style>
-      </object>
-    </child>
-    <child>
-      <object class="MessageLabel" id="content_label">
-        <property name="indicators">
-          <object class="MessageIndicators" id="indicators">
-            <property name="halign">end</property>
-            <property name="valign">end</property>
-          </object>
-        </property>
       </object>
     </child>
   </template>

--- a/src/session/content/message_row/bubble.rs
+++ b/src/session/content/message_row/bubble.rs
@@ -1,0 +1,305 @@
+use adw::prelude::*;
+use gtk::subclass::prelude::*;
+use gtk::{glib, CompositeTemplate};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use crate::session::content::message_row::{MessageIndicators, MessageLabel};
+use crate::tdlib::{Chat, ChatType, Message, MessageSender, SponsoredMessage};
+
+const MAX_WIDTH: i32 = 400;
+const SENDER_COLOR_CLASSES: &[&str] = &[
+    "sender-text-red",
+    "sender-text-orange",
+    "sender-text-violet",
+    "sender-text-green",
+    "sender-text-cyan",
+    "sender-text-blue",
+    "sender-text-pink",
+];
+
+mod imp {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use std::cell::RefCell;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(string = r#"
+    <interface>
+      <template class="MessageBubble" parent="GtkWidget">
+        <child>
+          <object class="GtkOverlay" id="overlay">
+            <child>
+              <object class="GtkBox">
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel" id="sender_label">
+                    <property name="ellipsize">end</property>
+                    <property name="xalign">0</property>
+                    <property name="visible">False</property>
+                    <style>
+                      <class name="caption-heading"/>
+                    </style>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwBin" id="prefix_bin"/>
+                </child>
+                <child>
+                  <object class="MessageLabel" id="message_label">
+                    <property name="visible">False</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="overlay">
+              <object class="MessageIndicators" id="indicators">
+                <property name="halign">end</property>
+                <property name="valign">end</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </template>
+    </interface>
+    "#)]
+    pub(crate) struct MessageBubble {
+        pub(super) sender_color_class: RefCell<Option<String>>,
+        pub(super) sender_binding: RefCell<Option<gtk::ExpressionWatch>>,
+        #[template_child]
+        pub(super) overlay: TemplateChild<gtk::Overlay>,
+        #[template_child]
+        pub(super) sender_label: TemplateChild<gtk::Label>,
+        #[template_child]
+        pub(super) prefix_bin: TemplateChild<adw::Bin>,
+        #[template_child]
+        pub(super) message_label: TemplateChild<MessageLabel>,
+        #[template_child]
+        pub(super) indicators: TemplateChild<MessageIndicators>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MessageBubble {
+        const NAME: &'static str = "MessageBubble";
+        type Type = super::MessageBubble;
+        type ParentType = gtk::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+            klass.set_css_name("messagebubble");
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for MessageBubble {
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+                vec![
+                    glib::ParamSpecObject::builder("prefix", gtk::Widget::static_type())
+                        .flags(glib::ParamFlags::WRITABLE)
+                        .build(),
+                    glib::ParamSpecString::builder("label")
+                        .flags(glib::ParamFlags::WRITABLE)
+                        .build(),
+                ]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn set_property(
+            &self,
+            obj: &Self::Type,
+            _id: usize,
+            value: &glib::Value,
+            pspec: &glib::ParamSpec,
+        ) {
+            match pspec.name() {
+                "prefix" => obj.set_prefix(value.get().unwrap()),
+                "label" => obj.set_label(value.get().unwrap()),
+                _ => unimplemented!(),
+            }
+        }
+
+        fn dispose(&self, _obj: &Self::Type) {
+            self.overlay.unparent();
+        }
+    }
+
+    impl WidgetImpl for MessageBubble {
+        fn measure(
+            &self,
+            _widget: &Self::Type,
+            orientation: gtk::Orientation,
+            for_size: i32,
+        ) -> (i32, i32, i32, i32) {
+            // Limit the widget width
+            if orientation == gtk::Orientation::Horizontal {
+                let (minimum, natural, minimum_baseline, natural_baseline) =
+                    self.overlay.measure(orientation, for_size);
+
+                (
+                    minimum.min(MAX_WIDTH),
+                    natural.min(MAX_WIDTH),
+                    minimum_baseline,
+                    natural_baseline,
+                )
+            } else {
+                let adjusted_for_size = for_size.min(MAX_WIDTH);
+                self.overlay.measure(orientation, adjusted_for_size)
+            }
+        }
+
+        fn size_allocate(&self, _widget: &Self::Type, width: i32, height: i32, baseline: i32) {
+            self.overlay.allocate(width, height, baseline, None);
+        }
+
+        fn request_mode(&self, _widget: &Self::Type) -> gtk::SizeRequestMode {
+            gtk::SizeRequestMode::HeightForWidth
+        }
+    }
+}
+
+glib::wrapper! {
+    pub(crate) struct MessageBubble(ObjectSubclass<imp::MessageBubble>)
+        @extends gtk::Widget;
+}
+
+impl MessageBubble {
+    pub(crate) fn update_from_message(&self, message: &Message, force_hide_sender: bool) {
+        let imp = self.imp();
+
+        imp.indicators.set_message(message.clone().upcast());
+
+        if message.is_outgoing() {
+            self.add_css_class("outgoing");
+        } else {
+            self.remove_css_class("outgoing");
+        }
+
+        if let Some(binding) = imp.sender_binding.take() {
+            binding.unwatch();
+        }
+
+        let show_sender = if force_hide_sender {
+            None
+        } else if message.chat().is_own_chat() {
+            if message.is_outgoing() {
+                None
+            } else {
+                Some(message.forward_info().unwrap().origin().id())
+            }
+        } else if message.is_outgoing() {
+            if matches!(message.sender(), MessageSender::Chat(_)) {
+                Some(Some(message.sender().id()))
+            } else {
+                None
+            }
+        } else if matches!(
+            message.chat().type_(),
+            ChatType::BasicGroup(_) | ChatType::Supergroup(_)
+        ) {
+            Some(Some(message.sender().id()))
+        } else {
+            None
+        };
+
+        // Show sender label, if needed
+        if let Some(maybe_id) = show_sender {
+            let sender_name_expression = message.sender_display_name_expression();
+            let sender_binding =
+                sender_name_expression.bind(&*imp.sender_label, "label", glib::Object::NONE);
+            imp.sender_binding.replace(Some(sender_binding));
+
+            self.update_sender_color(maybe_id);
+
+            imp.sender_label.set_visible(true);
+        } else {
+            if let Some(old_class) = imp.sender_color_class.take() {
+                imp.sender_label.remove_css_class(&old_class);
+            }
+
+            imp.sender_label.set_label("");
+            imp.sender_label.set_visible(false);
+        }
+    }
+
+    pub(crate) fn update_from_sponsored_message(&self, sponsored_message: &SponsoredMessage) {
+        let imp = self.imp();
+
+        imp.indicators
+            .set_message(sponsored_message.clone().upcast());
+
+        self.remove_css_class("outgoing");
+
+        if let Some(binding) = imp.sender_binding.take() {
+            binding.unwatch();
+        }
+
+        let sender_binding = Chat::this_expression("title").bind(
+            &*imp.sender_label,
+            "label",
+            Some(&sponsored_message.sponsor_chat()),
+        );
+        imp.sender_binding.replace(Some(sender_binding));
+
+        self.update_sender_color(Some(sponsored_message.sponsor_chat().id()));
+
+        imp.sender_label.set_visible(true);
+    }
+
+    pub(crate) fn set_prefix(&self, prefix: Option<&gtk::Widget>) {
+        self.imp().prefix_bin.set_child(prefix);
+    }
+
+    pub(crate) fn set_label(&self, label: String) {
+        let imp = self.imp();
+
+        if label.is_empty() {
+            imp.message_label.set_label(String::new());
+            imp.message_label.set_visible(false);
+
+            self.remove_css_class("with-label");
+        } else {
+            imp.message_label.set_label(label);
+            imp.message_label.set_visible(true);
+
+            self.add_css_class("with-label");
+        }
+
+        self.update_indicators_position();
+    }
+
+    fn update_sender_color(&self, sender_id: Option<i64>) {
+        let imp = self.imp();
+
+        if let Some(old_class) = imp.sender_color_class.take() {
+            imp.sender_label.remove_css_class(&old_class);
+        }
+
+        let color_class =
+            SENDER_COLOR_CLASSES[sender_id.map(|id| id as usize).unwrap_or_else(|| {
+                let mut s = DefaultHasher::new();
+                imp.sender_label.label().hash(&mut s);
+                s.finish() as usize
+            }) % SENDER_COLOR_CLASSES.len()];
+
+        imp.sender_label.add_css_class(color_class);
+        imp.sender_color_class.replace(Some(color_class.into()));
+    }
+
+    fn update_indicators_position(&self) {
+        let imp = self.imp();
+
+        if imp.message_label.label().is_empty() && imp.message_label.indicators().is_some() {
+            imp.message_label.set_indicators(None);
+            imp.overlay.add_overlay(&*imp.indicators);
+        } else if imp.message_label.indicators().is_none() {
+            imp.overlay.remove_overlay(&*imp.indicators);
+            imp.message_label
+                .set_indicators(Some(imp.indicators.clone()));
+        }
+    }
+}

--- a/src/session/content/message_row/label.rs
+++ b/src/session/content/message_row/label.rs
@@ -171,11 +171,6 @@ glib::wrapper! {
 }
 
 impl MessageLabel {
-    pub(crate) fn new(label: &str, indicators: Option<&MessageIndicators>) -> Self {
-        glib::Object::new(&[("label", &label), ("indicators", &indicators)])
-            .expect("Failed to create MessageLabel")
-    }
-
     fn update_label_attributes(&self, indicators_size: &gtk::Requisition) {
         let imp = self.imp();
         if let Some(start_index) = imp.label.text().find(OBJECT_REPLACEMENT_CHARACTER) {

--- a/src/session/content/message_row/media.rs
+++ b/src/session/content/message_row/media.rs
@@ -208,7 +208,7 @@ impl Media {
                 // Unparent the indicators from the picture overlay
                 imp.overlay.remove_overlay(indicators);
 
-                let caption_label = MessageLabel::new(&caption, indicators);
+                let caption_label = MessageLabel::new(&caption, Some(indicators));
                 imp.content.append(&caption_label);
 
                 *caption_label_ref = Some(caption_label);

--- a/src/session/content/message_row/media.rs
+++ b/src/session/content/message_row/media.rs
@@ -2,21 +2,15 @@ use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gdk, glib, CompositeTemplate};
 
-use crate::session::content::message_row::{MediaPicture, MessageIndicators, MessageLabel};
+use crate::session::content::message_row::MediaPicture;
 
 mod imp {
     use super::*;
     use once_cell::sync::Lazy;
-    use once_cell::unsync::OnceCell;
-    use std::cell::RefCell;
 
     #[derive(Debug, Default, CompositeTemplate)]
     #[template(resource = "/com/github/melix99/telegrand/ui/content-message-media.ui")]
     pub(crate) struct Media {
-        pub(super) caption_label: RefCell<Option<MessageLabel>>,
-        pub(super) indicators: OnceCell<MessageIndicators>,
-        #[template_child]
-        pub(super) content: TemplateChild<gtk::Box>,
         #[template_child]
         pub(super) overlay: TemplateChild<gtk::Overlay>,
         #[template_child]
@@ -34,6 +28,7 @@ mod imp {
         fn class_init(klass: &mut Self::Class) {
             Self::bind_template(klass);
             klass.set_css_name("messagemedia");
+            klass.set_layout_manager_type::<gtk::BinLayout>();
         }
 
         fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
@@ -44,31 +39,15 @@ mod imp {
     impl ObjectImpl for Media {
         fn properties() -> &'static [glib::ParamSpec] {
             static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
-                vec![
-                    glib::ParamSpecString::new(
-                        "caption",
-                        "Caption",
-                        "The caption",
-                        None,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
-                    ),
-                    glib::ParamSpecDouble::new(
-                        "download-progress",
-                        "Download Progress",
-                        "The download progress",
-                        0.0,
-                        1.0,
-                        0.0,
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
-                    ),
-                    glib::ParamSpecObject::new(
-                        "indicators",
-                        "Indicators",
-                        "The message indicators of the widget",
-                        MessageIndicators::static_type(),
-                        glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT_ONLY,
-                    ),
-                ]
+                vec![glib::ParamSpecDouble::new(
+                    "download-progress",
+                    "Download Progress",
+                    "The download progress",
+                    0.0,
+                    1.0,
+                    0.0,
+                    glib::ParamFlags::READWRITE | glib::ParamFlags::EXPLICIT_NOTIFY,
+                )]
             });
             PROPERTIES.as_ref()
         }
@@ -81,74 +60,24 @@ mod imp {
             pspec: &glib::ParamSpec,
         ) {
             match pspec.name() {
-                "caption" => obj.set_caption(value.get().unwrap()),
                 "download-progress" => obj.set_download_progress(value.get().unwrap()),
-                "indicators" => {
-                    let indicators: MessageIndicators = value.get().unwrap();
-
-                    // Add the indicators to the picture overlay by default because we don't
-                    // expect to have a caption text in the construct phase
-                    self.overlay.add_overlay(&indicators);
-                    self.indicators.set(indicators).unwrap();
-                }
                 _ => unimplemented!(),
             }
         }
 
         fn property(&self, obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
             match pspec.name() {
-                "caption" => obj.caption().to_value(),
                 "download-progress" => obj.download_progress().to_value(),
-                "indicators" => obj.indicators().to_value(),
                 _ => unimplemented!(),
             }
         }
 
         fn dispose(&self, _obj: &Self::Type) {
-            self.content.unparent();
+            self.overlay.unparent();
         }
     }
 
-    impl WidgetImpl for Media {
-        fn measure(
-            &self,
-            _widget: &Self::Type,
-            orientation: gtk::Orientation,
-            for_size: i32,
-        ) -> (i32, i32, i32, i32) {
-            if let gtk::Orientation::Horizontal = orientation {
-                let (mut minimum, mut natural, minimum_baseline, natural_baseline) =
-                    self.content.measure(orientation, for_size);
-
-                if for_size == -1 {
-                    let (_, media_default_width, _, _) =
-                        self.picture.measure(gtk::Orientation::Horizontal, -1);
-                    minimum = minimum.min(media_default_width);
-                    natural = media_default_width;
-                }
-
-                (minimum, natural, minimum_baseline, natural_baseline)
-            } else {
-                let for_size = if for_size == -1 {
-                    let (_, media_default_width, _, _) =
-                        self.picture.measure(gtk::Orientation::Horizontal, -1);
-                    media_default_width
-                } else {
-                    for_size
-                };
-
-                self.content.measure(orientation, for_size)
-            }
-        }
-
-        fn size_allocate(&self, _widget: &Self::Type, width: i32, height: i32, baseline: i32) {
-            self.content.allocate(width, height, baseline, None);
-        }
-
-        fn request_mode(&self, _widget: &Self::Type) -> gtk::SizeRequestMode {
-            gtk::SizeRequestMode::HeightForWidth
-        }
-    }
+    impl WidgetImpl for Media {}
 }
 
 glib::wrapper! {
@@ -175,51 +104,6 @@ impl Media {
         self.imp().picture.set_paintable(paintable);
     }
 
-    pub(crate) fn caption(&self) -> String {
-        self.imp()
-            .caption_label
-            .borrow()
-            .as_ref()
-            .map(|c| c.label())
-            .unwrap_or_default()
-    }
-
-    pub(crate) fn set_caption(&self, caption: String) {
-        if self.caption() == caption {
-            return;
-        }
-
-        let imp = self.imp();
-        let indicators = self.indicators();
-
-        if caption.is_empty() {
-            // This will also drop the label and consequently unparent the indicators from it
-            imp.content.remove(&imp.caption_label.take().unwrap());
-
-            imp.overlay.add_overlay(indicators);
-
-            self.remove_css_class("with-caption");
-        } else {
-            let mut caption_label_ref = imp.caption_label.borrow_mut();
-
-            if let Some(caption_label) = caption_label_ref.as_ref() {
-                caption_label.set_label(caption);
-            } else {
-                // Unparent the indicators from the picture overlay
-                imp.overlay.remove_overlay(indicators);
-
-                let caption_label = MessageLabel::new(&caption, Some(indicators));
-                imp.content.append(&caption_label);
-
-                *caption_label_ref = Some(caption_label);
-
-                self.add_css_class("with-caption");
-            }
-        }
-
-        self.notify("caption");
-    }
-
     pub(crate) fn download_progress(&self) -> f64 {
         self.imp().progress_bar.fraction()
     }
@@ -234,9 +118,5 @@ impl Media {
         imp.progress_bar.set_visible(progress < 1.0);
 
         self.notify("download-progress");
-    }
-
-    pub(crate) fn indicators(&self) -> &MessageIndicators {
-        self.imp().indicators.get().unwrap()
     }
 }

--- a/src/session/content/message_row/mod.rs
+++ b/src/session/content/message_row/mod.rs
@@ -1,4 +1,5 @@
 mod base;
+mod bubble;
 mod document;
 mod indicators;
 mod indicators_model;
@@ -11,6 +12,7 @@ mod sticker_picture;
 mod text;
 
 use self::base::{MessageBase, MessageBaseExt, MessageBaseImpl};
+use self::bubble::MessageBubble;
 use self::document::MessageDocument;
 use self::indicators::MessageIndicators;
 use self::label::MessageLabel;
@@ -295,12 +297,10 @@ impl MessageRow {
             content.set_halign(gtk::Align::End);
             content.set_margin_start(AVATAR_SIZE + SPACING);
             content.set_margin_end(0);
-            content.add_css_class("outgoing");
         } else {
             content.set_halign(gtk::Align::Start);
             content.set_margin_start(0);
             content.set_margin_end(AVATAR_SIZE + SPACING);
-            content.remove_css_class("outgoing");
         }
     }
 

--- a/src/session/content/message_row/photo.rs
+++ b/src/session/content/message_row/photo.rs
@@ -5,9 +5,7 @@ use gtk::{gdk, glib, CompositeTemplate};
 use tdlib::enums::MessageContent;
 use tdlib::types::File;
 
-use crate::session::content::message_row::{
-    Media, MessageBase, MessageBaseImpl, MessageIndicators,
-};
+use crate::session::content::message_row::{Media, MessageBase, MessageBaseImpl, MessageBubble};
 use crate::tdlib::{BoxedMessageContent, Message};
 use crate::utils::parse_formatted_text;
 use crate::Session;
@@ -26,9 +24,9 @@ mod imp {
         pub(super) handler_id: RefCell<Option<glib::SignalHandlerId>>,
         pub(super) message: RefCell<Option<Message>>,
         #[template_child]
-        pub(super) media: TemplateChild<Media>,
+        pub(super) message_bubble: TemplateChild<MessageBubble>,
         #[template_child]
-        pub(super) indicators: TemplateChild<MessageIndicators>,
+        pub(super) media: TemplateChild<Media>,
     }
 
     #[glib::object_subclass]
@@ -117,7 +115,7 @@ impl MessageBaseExt for MessagePhoto {
             old_message.disconnect(handler_id);
         }
 
-        imp.indicators.set_message(message.clone().upcast());
+        imp.message_bubble.update_from_message(&message, true);
 
         // Setup caption expression
         let caption_binding = Message::this_expression("content")
@@ -128,7 +126,7 @@ impl MessageBaseExt for MessagePhoto {
                     unreachable!();
                 }
             }))
-            .bind(&*imp.media, "caption", Some(&message));
+            .bind(&*imp.message_bubble, "label", Some(&message));
         imp.binding.replace(Some(caption_binding));
 
         // Load photo


### PR DESCRIPTION
This widget shares a lot of logic and styles that were scattared ascross
the other message widgets. It will take care of setting and updating the
sender label, it can have a prefix widget and it will take care of the
indicators position based on the presence of text. The widget also sizes
itself with a max width, so that the bubbles doesn't take too much space
when the view is wide.

This also contains some style changes, so that it's more on par with
other clients.