### PR TITLE
WIP: Add chat photo to the header bar in mobile view

### DIFF
--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -302,3 +302,7 @@ window.chat-info .main-page > list {
 .squared {
   border-radius: 0;
 }
+
+.no-hover:hover {
+  background: initial;
+}

--- a/data/resources/ui/content-chat-history.ui
+++ b/data/resources/ui/content-chat-history.ui
@@ -17,7 +17,29 @@
                   </object>
                 </child>
                 <child type="title">
-                  <object class="AdwWindowTitle" id="window_title"/>
+                  <object class="GtkButton">
+                    <style>
+                      <class name="image-button"/>
+                      <class name="no-hover"/>
+                    </style>
+                    <property name="action-name">chat-history.view-info</property>
+                    <property name="child">
+                      <object class="GtkBox" id="title_box">
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="ComponentsAvatar" id="chat_avatar">
+                            <property name="size">32</property>
+                            <binding name="item">
+                              <lookup name="chat">ContentChatHistory</lookup>
+                            </binding>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="chat_title"/>
+                        </child>
+                      </object>
+                    </property>
+                  </object>
                 </child>
                 <child type="end">
                   <object class="GtkMenuButton">

--- a/src/session/content/chat_history.rs
+++ b/src/session/content/chat_history.rs
@@ -15,6 +15,7 @@ const MIN_N_ITEMS: u32 = 20;
 
 mod imp {
     use super::*;
+    use crate::components::Avatar as ComponentsAvatar;
     use adw::subclass::prelude::BinImpl;
     use once_cell::sync::Lazy;
     use once_cell::unsync::OnceCell;
@@ -29,7 +30,11 @@ mod imp {
         pub(super) is_auto_scrolling: Cell<bool>,
         pub(super) sticky: Cell<bool>,
         #[template_child]
-        pub(super) window_title: TemplateChild<adw::WindowTitle>,
+        pub(super) title_box: TemplateChild<gtk::Box>,
+        #[template_child]
+        pub(super) chat_title: TemplateChild<gtk::Label>,
+        #[template_child]
+        pub(super) chat_avatar: TemplateChild<ComponentsAvatar>,
         #[template_child]
         pub(super) scrolled_window: TemplateChild<gtk::ScrolledWindow>,
         #[template_child]
@@ -46,7 +51,9 @@ mod imp {
                 message_menu: Default::default(),
                 is_auto_scrolling: Default::default(),
                 sticky: Cell::new(false),
-                window_title: Default::default(),
+                title_box: Default::default(),
+                chat_title: Default::default(),
+                chat_avatar: Default::default(),
                 scrolled_window: Default::default(),
                 list_view: Default::default(),
                 chat_action_bar: Default::default(),
@@ -208,13 +215,27 @@ impl ChatHistory {
 
     fn setup_expressions(&self) {
         let chat_expression = Self::this_expression("chat");
+        let mobile_view_expression = Self::this_expression("compact");
 
-        // Chat title
+        /* Chat title*/
         expressions::chat_display_name(&chat_expression).bind(
-            &*self.imp().window_title,
-            "title",
+            &*self.imp().chat_title,
+            "label",
             Some(self),
         );
+
+        // Chat title alignment
+        /*mobile_view_expression
+        .chain_closure::<gtk::Align>(closure!(|_: Self, compact: bool| {
+            if compact {
+                gtk::Align::Start
+            } else {
+                gtk::Align::Center
+            }
+        }))
+        .upcast()
+        .bind(&*self.imp().title_box, "halign", Some(self));*/
+        mobile_view_expression.bind(&*self.imp().chat_avatar, "visible", Some(self));
     }
 
     fn load_older_messages(&self, adj: &gtk::Adjustment) {


### PR DESCRIPTION
This pr aims to add chat photo to the header bar in the mobile view and make it similar to other mobile clients
![Screenshot](https://user-images.githubusercontent.com/110191114/191361942-5c65b0a0-def2-4b4a-b4aa-e89e3ec03845.png)

Android reference:
![photo_2022-09-20_22-44-59](https://user-images.githubusercontent.com/110191114/191363394-411fdd68-b4f7-4d6e-88dd-7ed7a95ea334.jpg)

PS: this is my new github account, I'll finish all existing pr on the old one and any new contributions will be made from this account
