### PR TITLE
strings: Add missed `file_name` to `message_document`

### DIFF
--- a/src/strings.rs
+++ b/src/strings.rs
@@ -154,7 +154,10 @@ fn message_document(file_name: &str, caption: &str) -> String {
         file_name.into()
     } else {
         // Translators: This is a file with the caption
-        gettext_f("{file_name}, {caption}", &[("caption", caption)])
+        gettext_f(
+            "{file_name}, {caption}",
+            &[("file_name", file_name), ("caption", caption)],
+        )
     }
 }
 


### PR DESCRIPTION
I also did a quick search for similar cases in `strings.rs`, but apparently this is the only one.