### PR TITLE
sidebar-row: Align message text with sender label

### DIFF
--- a/data/resources/ui/sidebar-row.ui
+++ b/data/resources/ui/sidebar-row.ui
@@ -85,6 +85,7 @@
                 <child>
                   <object class="GtkInscription" id="bottom_label">
                     <property name="hexpand">True</property>
+                    <property name="valign">center</property>
                     <property name="text-overflow">ellipsize-end</property>
                     <style>
                       <class name="small-body"/>


### PR DESCRIPTION
The message text is shifted upwards a few pixels if it becomes ellipsized. We have to center the `GtkInscription` to keep the message text vertically aligned with the sender label.

![Bildschirmfoto vom 2023-01-29 22-29-40](https://user-images.githubusercontent.com/3630213/215356730-b64b2761-a739-4b1a-899f-f0bb7b82af63.png)
![Bildschirmfoto vom 2023-01-29 22-29-53](https://user-images.githubusercontent.com/3630213/215356732-9d0ce234-6dbe-48e3-94e8-933753fe592b.png)
