### PR TITLE
message-bubble: Do not mark channel messages as outgoing v2

### DIFF
--- a/src/session/content/message_row/bubble.rs
+++ b/src/session/content/message_row/bubble.rs
@@ -163,7 +163,10 @@ impl MessageBubble {
 
         imp.indicators.set_message(message.clone().upcast());
 
-        if message.is_outgoing() {
+        if message.is_outgoing()
+            // Do not mark channel posts as outgoing
+            && matches!(message.chat().type_(), ChatType::Supergroup(data) if !data.is_channel())
+        {
             self.add_css_class("outgoing");
         } else {
             self.remove_css_class("outgoing");


### PR DESCRIPTION
Looks like the message is still marked as outgoing in the message bubble. I
believe this issue was introduced after my first commit