### PR TITLE
Add support for screenshot taken and game highscore service messages

### DIFF
--- a/src/session/content/item_row.rs
+++ b/src/session/content/item_row.rs
@@ -107,6 +107,7 @@ impl ItemRow {
                             | MessageChatDeleteMember(_)
                             | MessagePinMessage(_)
                             | MessageScreenshotTaken
+                            | MessageGameScore(_)
                             | MessageContactRegistered => {
                                 self.get_or_create_event_row()
                                     .set_label(&strings::message_content(message));

--- a/src/session/content/item_row.rs
+++ b/src/session/content/item_row.rs
@@ -106,6 +106,7 @@ impl ItemRow {
                             | MessageChatJoinByRequest
                             | MessageChatDeleteMember(_)
                             | MessagePinMessage(_)
+                            | MessageScreenshotTaken
                             | MessageContactRegistered => {
                                 self.get_or_create_event_row()
                                     .set_label(&strings::message_content(message));

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -116,6 +116,10 @@ pub(crate) fn message_content(message: &Message) -> String {
             message_chat_delete_member(&deleted_user, sender)
         }
         MessagePinMessage(data) => message_pin_message(data.message_id, &chat, sender),
+        MessageScreenshotTaken => gettext_f(
+            "{sender} took a screenshot!",
+            &[("sender", &message_sender(sender, true))],
+        ),
         MessageContactRegistered => message_contact_registered(sender),
         _ => gettext("Unsupported Message"),
     }


### PR DESCRIPTION
This PR adds support for the "{sender} took a screenshot!" and "{sender} scored {points} in {game}" service messages.

Please note that the title of the game is only retrieved when it is stored locally by tdlib. As a result, the game title may not be displayed if the game message isn't locally cached. This issue can be addressed in a future PR.
