### PR TITLE
Revert "message-bubble: Do not mark channel messages as outgoing v2"

### DIFF
--- a/src/session/content/message_row/bubble.rs
+++ b/src/session/content/message_row/bubble.rs
@@ -163,10 +163,7 @@ impl MessageBubble {
 
         imp.indicators.set_message(message.clone().upcast());
 
-        if message.is_outgoing()
-            // Do not mark channel posts as outgoing
-            && matches!(message.chat().type_(), ChatType::Supergroup(data) if !data.is_channel())
-        {
+        if message.is_outgoing() {
             self.add_css_class("outgoing");
         } else {
             self.remove_css_class("outgoing");


### PR DESCRIPTION
Reverts melix99/telegrand#449

I didn't pay enough attention, it broke .outgoing style for all the other chat types.