### PR TITLE
Message edit and reply fixes

### DIFF
--- a/src/session/content/message_row/mod.rs
+++ b/src/session/content/message_row/mod.rs
@@ -300,7 +300,7 @@ impl MessageRow {
             let is_text_message = matches!(message.content().0, MessageContent::MessageText(_));
 
             // TODO: Support more message types in the future
-            is_text_message && message.is_outgoing() && can_send_messages_in_chat(&message.chat())
+            is_text_message && message.can_be_edited() && can_send_messages_in_chat(&message.chat())
         } else {
             false
         }

--- a/src/session/content/message_row/mod.rs
+++ b/src/session/content/message_row/mod.rs
@@ -406,16 +406,16 @@ fn can_send_messages_in_chat(chat: &Chat) -> bool {
         ChatType::BasicGroup(supergroup) => Some(supergroup.status()),
         _ => None,
     };
-    let can_send_message_as_member = member_status
+    member_status
         .map(|s| match s.0 {
             Creator(_) => true,
             Administrator(_) => true,
-            Member => true,
-            Restricted(data) => data.permissions.can_send_messages,
+            Member => chat.permissions().0.can_send_messages,
+            Restricted(data) => {
+                chat.permissions().0.can_send_messages && data.permissions.can_send_messages
+            }
             Left => false,
             Banned(_) => false,
         })
-        .unwrap_or(true);
-
-    chat.permissions().0.can_send_messages && can_send_message_as_member
+        .unwrap_or(true)
 }

--- a/src/tdlib/message.rs
+++ b/src/tdlib/message.rs
@@ -58,6 +58,7 @@ mod imp {
         pub(super) id: Cell<i64>,
         pub(super) sender: OnceCell<MessageSender>,
         pub(super) is_outgoing: Cell<bool>,
+        pub(super) can_be_edited: Cell<bool>,
         pub(super) can_be_deleted_only_for_self: Cell<bool>,
         pub(super) can_be_deleted_for_all_users: Cell<bool>,
         pub(super) sending_state: RefCell<Option<BoxedMessageSendingState>>,
@@ -83,6 +84,9 @@ mod imp {
                         .read_only()
                         .build(),
                     glib::ParamSpecBoolean::builder("is-outgoing")
+                        .read_only()
+                        .build(),
+                    glib::ParamSpecBoolean::builder("can-be-edited")
                         .read_only()
                         .build(),
                     glib::ParamSpecBoolean::builder("can-be-deleted-only-for-self")
@@ -119,6 +123,7 @@ mod imp {
                 "id" => obj.id().to_value(),
                 "sender" => obj.sender().to_value(),
                 "is-outgoing" => obj.is_outgoing().to_value(),
+                "can-be-edited" => obj.can_be_edited().to_value(),
                 "can-be-deleted-only-for-self" => obj.can_be_deleted_only_for_self().to_value(),
                 "can-be-deleted-for-all-users" => obj.can_be_deleted_for_all_users().to_value(),
                 "sending-state" => obj.sending_state().to_value(),
@@ -153,6 +158,7 @@ impl Message {
         imp.id.set(td_message.id);
         imp.sender.set(sender).unwrap();
         imp.is_outgoing.set(td_message.is_outgoing);
+        imp.can_be_edited.set(td_message.can_be_edited);
         imp.can_be_deleted_only_for_self
             .set(td_message.can_be_deleted_only_for_self);
         imp.can_be_deleted_for_all_users
@@ -198,6 +204,10 @@ impl Message {
 
     pub(crate) fn is_outgoing(&self) -> bool {
         self.imp().is_outgoing.get()
+    }
+
+    pub(crate) fn can_be_edited(&self) -> bool {
+        self.imp().can_be_edited.get()
     }
 
     pub(crate) fn can_be_deleted_only_for_self(&self) -> bool {


### PR DESCRIPTION
This PR fixes two issues related to reply and edit buttons:
 - Edit and reply buttons not appearing on supergroups with muted default permissions and channels, even for admins.
 - Use `can_be_edited()` instead of `is_outgoing()` to mark editable messages (thus avoiding false-positives and false-negatives).
