### PR TITLE
sidebar-row: Port to glib's SignalGroup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0"
 ellipse = "0.2"
 futures = { version = "0.3", default-features = false }
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
-gtk = { version = "0.6", package = "gtk4", features = ["v4_8", "blueprint"] }
+gtk = { version = "0.6", package = "gtk4", features = ["gnome_43", "blueprint"] }
 image = { version = "0.24", default-features = false, features = ["webp"] }
 indexmap = "1.9"
 locale_config = "0.3"

--- a/data/resources/ui/sidebar-row.blp
+++ b/data/resources/ui/sidebar-row.blp
@@ -63,7 +63,7 @@ template SidebarRow {
           styles ["small-body"]
         }
 
-        .SidebarMiniThumbnail message_thumbnail {
+        .SidebarMiniThumbnail minithumbnail {
           visible: "False";
           valign: "center";
         }

--- a/data/resources/ui/sidebar-row.blp
+++ b/data/resources/ui/sidebar-row.blp
@@ -80,9 +80,6 @@ template SidebarRow {
       }
 
       Stack status_stack {
-        Adw.Bin empty_status_bin {
-        }
-
         Image pin_icon {
           halign: center;
           valign: center;

--- a/data/resources/ui/sidebar-row.blp
+++ b/data/resources/ui/sidebar-row.blp
@@ -68,7 +68,7 @@ template SidebarRow {
           valign: "center";
         }
 
-        Inscription bottom_label {
+        Inscription subtitle_label {
           hexpand: true;
           text-overflow: ellipsize_end;
           valign: center;

--- a/data/resources/ui/sidebar-row.blp
+++ b/data/resources/ui/sidebar-row.blp
@@ -56,9 +56,7 @@ template SidebarRow {
       Box {
         spacing: 3;
 
-        Label message_prefix_label {
-          single-line-mode: true;
-          use-markup: true;
+        Label subtitle_prefix_label {
           ellipsize: end;
           xalign: 0;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,15 +35,6 @@ pub(crate) fn freplace(s: String, args: &[(&str, &str)]) -> String {
     s
 }
 
-pub(crate) fn dim(text: &str) -> String {
-    // The alpha value should be kept in sync with Adwaita's dim-label alpha value
-    format!("<span alpha=\"55%\">{text}</span>")
-}
-
-pub(crate) fn dim_and_escape(text: &str) -> String {
-    dim(&escape(text))
-}
-
 pub(crate) fn linkify(text: &str) -> String {
     if !PROTOCOL_RE.is_match(text) {
         format!("http://{text}")


### PR DESCRIPTION
`SidebarRow` code is probably one of the most complicated widgets in
Telegrand, both because there are a lot of bindings needed to ensure we
update everything inside it correctly and also because we used GTK's
expressions to make this bindings, which was ultimately not a good
choice. Even though they are a fairly good addition to GTK for more
declarative UIs, they are not powerful enough for more complex
scenarios, and `SidebarRow` is full of these, and they only made the
code much more complex than it should be.

Glib's new `SignalGroup` is an object that can hold signals of an object
and it automatically disconnects them on dispose. This is a different
approach for binding stuff compared to GTK's expressions (they are not
really declarative), but at least they are more powerful so in the end
they are much better for complex scenarios like `SidebarRow`.

This also allowed to fix #377 and #376.

See each commit for a more guided review.