### PR TITLE
feat(message-row): Add initial support for replies chat

### DIFF
--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -18,6 +18,8 @@ pub(crate) fn chat_display_name(chat_expression: &gtk::Expression) -> gtk::Expre
             let is_deleted = args[3].get::<bool>().unwrap();
             if chat.is_own_chat() {
                 gettext("Saved Messages")
+            } else if chat.is_replies_chat() {
+                gettext("Replies")
             } else if is_deleted {
                 gettext("Deleted Account")
             } else {

--- a/src/model/chat.rs
+++ b/src/model/chat.rs
@@ -388,6 +388,10 @@ impl Chat {
         self.chat_type().user() == Some(self.session_().me_())
     }
 
+    pub(crate) fn is_replies_chat(&self) -> bool {
+        self.id() == 1271266957 || self.id() == 708513
+    }
+
     fn set_permissions(&self, permissions: model::BoxedChatPermissions) {
         if self.permissions() == permissions {
             return;

--- a/src/model/message.rs
+++ b/src/model/message.rs
@@ -215,7 +215,7 @@ impl Message {
     }
 
     pub(crate) fn sender_display_name_expression(&self) -> gtk::Expression {
-        if self.chat_().is_own_chat() {
+        if self.chat_().is_own_chat() || self.chat_().is_replies_chat() {
             self.forward_info()
                 .map(|forward_info| forward_info.origin())
                 .map(|forward_origin| match forward_origin {

--- a/src/ui/components/avatar.rs
+++ b/src/ui/components/avatar.rs
@@ -194,6 +194,9 @@ impl Avatar {
                 if chat.is_own_chat() {
                     imp.avatar.set_icon_name(Some("user-bookmarks-symbolic"));
                     imp.avatar.set_show_initials(false);
+                } else if chat.is_replies_chat() {
+                    imp.avatar.set_icon_name(Some("mail-reply-sender-symbolic"));
+                    imp.avatar.set_show_initials(false);
                 } else {
                     self.load_image(chat.avatar(), chat.session_());
                 }
@@ -209,7 +212,7 @@ impl Avatar {
                 imp.avatar
                     .set_text(Some(&strings::user_display_name(user, true)));
             } else if let Some(chat) = item.downcast_ref::<model::Chat>() {
-                if chat.is_own_chat() {
+                if chat.is_own_chat() || chat.is_replies_chat() {
                     imp.avatar.set_text(Some("-"));
                 } else {
                     imp.avatar.set_text(Some(chat.title().as_ref()));

--- a/src/ui/session/content/chat_action_bar.rs
+++ b/src/ui/session/content/chat_action_bar.rs
@@ -767,6 +767,14 @@ impl ChatActionBar {
                         imp.action_bar_stack.set_visible_child_name("entry");
                     } else if is_blocked {
                         imp.action_bar_stack.set_visible_child_name("unblock");
+                    } else if chat.is_replies_chat() {
+                        imp.action_bar_stack.set_visible_child_name("mute");
+
+                        if self.is_chat_muted() {
+                            imp.mute_button.set_label(&gettext("Unmute"));
+                        } else {
+                            imp.mute_button.set_label(&gettext("Mute"));
+                        }
                     } else {
                         imp.action_bar_stack.set_visible_child_name("entry");
                     }

--- a/src/ui/session/content/message_row/bubble.rs
+++ b/src/ui/session/content/message_row/bubble.rs
@@ -147,7 +147,7 @@ impl MessageBubble {
 
         let show_sender = if force_hide_sender {
             None
-        } else if message.chat_().is_own_chat() {
+        } else if message.chat_().is_own_chat() || message.chat_().is_replies_chat() {
             if message.is_outgoing() {
                 None
             } else {

--- a/src/ui/session/content/message_row/mod.rs
+++ b/src/ui/session/content/message_row/mod.rs
@@ -208,7 +208,7 @@ impl Row {
         if let Some(message) = message.downcast_ref::<model::Message>() {
             let show_avatar = if message.is_outgoing() {
                 false
-            } else if message.chat_().is_own_chat() {
+            } else if message.chat_().is_own_chat() || message.chat_().is_replies_chat() {
                 message.forward_info().is_some()
             } else {
                 match message.chat_().chat_type() {
@@ -236,7 +236,7 @@ impl Row {
                     }
                 };
 
-                if message.chat_().is_own_chat() {
+                if message.chat_().is_own_chat() || message.chat_().is_replies_chat() {
                     match message.forward_info().unwrap().origin() {
                         model::MessageForwardOrigin::User(user) => {
                             avatar.set_custom_text(None);

--- a/src/ui/session/sidebar/row.rs
+++ b/src/ui/session/sidebar/row.rs
@@ -567,7 +567,7 @@ fn sender_label(message: model::Message) -> Option<String> {
         _ => return None,
     }
 
-    if message.chat_().is_own_chat() {
+    if message.chat_().is_own_chat() || message.chat_().is_replies_chat() {
         if message.is_outgoing() {
             None
         } else {


### PR DESCRIPTION
This PR adds basic support for the "Replies" chat.

Things like ~showing replied messages and~ a button to view the original message should be addressed in other issues.

Closes #465.
