### PR TITLE
chat-history: Add basic message grouping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "ellipse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,6 +748,15 @@ dependencies = [
  "autocfg",
  "hashbrown",
  "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1276,6 +1291,7 @@ dependencies = [
  "gtk4",
  "image",
  "indexmap",
+ "itertools",
  "libadwaita",
  "locale_config",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ gettext-rs = { version = "0.7", features = ["gettext-system"] }
 gtk = { version = "0.6", package = "gtk4", features = ["v4_8", "blueprint"] }
 image = { version = "0.24", default-features = false, features = ["webp"] }
 indexmap = "1.9"
+itertools = "0.10.5"
 locale_config = "0.3"
 log = "0.4"
 once_cell = "1.17"

--- a/src/session/content/mod.rs
+++ b/src/session/content/mod.rs
@@ -10,7 +10,7 @@ mod send_photo_dialog;
 
 use self::chat_action_bar::ChatActionBar;
 use self::chat_history::ChatHistory;
-use self::chat_history_item::{ChatHistoryItem, ChatHistoryItemType};
+use self::chat_history_item::{ChatHistoryItem, ChatHistoryItemType, MessageStyle};
 use self::chat_history_model::{ChatHistoryError, ChatHistoryModel};
 use self::chat_history_row::ChatHistoryRow;
 use self::chat_info_window::ChatInfoWindow;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/63008755/219324165-e544992e-c7a2-4faa-b201-43029038a5b8.png)

Currently it doesn't group messages by time, only by sender