### PR TITLE
Add loading indicator

### DIFF
--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -197,6 +197,25 @@ messagebubble.document.outgoing .file > overlay > image {
   color: @accent_bg_color;
 }
 
+messagebubble.document .file loadingindicator {
+  margin: 2px;
+  color: @window_bg_color;
+}
+
+messagebubble.document.outgoing .file loadingindicator {
+  color: @accent_bg_color;
+}
+
+messagebubble.document .file.with-thumbnail > overlay > image {
+  background: alpha(black, 0.6);
+  color: white;
+}
+
+messagebubble.document .file.with-thumbnail loadingindicator {
+  margin: 12px;
+  color: white;
+}
+
 messagebubble.document .file:hover > overlay > image {
   opacity: 0.85;
 }

--- a/data/resources/ui/content-message-document.blp
+++ b/data/resources/ui/content-message-document.blp
@@ -26,6 +26,9 @@ template MessageDocument : .MessageBase {
           halign: center;
           valign: center;
         }
+
+        [overlay]
+        .ComponentsLoadingIndicator loading_indicator {}
       }
 
 

--- a/src/components/loading_indicator.rs
+++ b/src/components/loading_indicator.rs
@@ -1,0 +1,104 @@
+use gtk::glib;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+
+mod imp {
+    use super::*;
+    use gtk::graphene;
+    use std::cell::Cell;
+
+    #[derive(Debug, Default, glib::Properties)]
+    #[properties(wrapper_type = super::LoadingIndicator)]
+    pub(crate) struct LoadingIndicator {
+        pub(super) start_time: Cell<i64>,
+
+        #[property(get, set, minimum = 0.0, maximum = 1.0)]
+        pub(super) progress: Cell<f64>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for LoadingIndicator {
+        const NAME: &'static str = "ComponentsLoadingIndicator";
+        type Type = super::LoadingIndicator;
+        type ParentType = gtk::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.set_css_name("loadingindicator");
+        }
+    }
+
+    impl ObjectImpl for LoadingIndicator {
+        fn constructed(&self) {
+            self.obj().connect_visible_notify(|widget| {
+                if widget.is_visible() {
+                    widget.imp().start_time.set(widget.time());
+                    widget.add_tick_callback(|widget, _clock| {
+                        widget.queue_draw();
+                        Continue(widget.is_visible())
+                    });
+                }
+            });
+        }
+
+        fn properties() -> &'static [glib::ParamSpec] {
+            Self::derived_properties()
+        }
+
+        fn set_property(&self, id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+            Self::derived_set_property(self, id, value, pspec)
+        }
+
+        fn property(&self, id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            Self::derived_property(self, id, pspec)
+        }
+    }
+
+    impl WidgetImpl for LoadingIndicator {
+        fn measure(&self, _orientation: gtk::Orientation, for_size: i32) -> (i32, i32, i32, i32) {
+            (0, for_size, -1, -1)
+        }
+
+        fn snapshot(&self, snapshot: &gtk::Snapshot) {
+            let widget = self.obj();
+            let size = widget.width() as f32;
+            let bounds = graphene::Rect::new(0.0, 0.0, size, size);
+
+            let context = snapshot.append_cairo(&bounds);
+            let color = widget.color();
+            context.set_source_rgba(
+                color.red() as _,
+                color.green() as _,
+                color.blue() as _,
+                color.alpha() as _,
+            );
+            let half_size = size as f64 / 2.0;
+
+            let pi = std::f64::consts::PI;
+
+            context.set_line_width(2.0);
+
+            let time = widget.time() - self.start_time.get();
+            let shift = (time as f64 / 300000.0) % (2.0 * pi);
+
+            let start = shift - 0.5 * pi;
+            let diff = self.progress.get().max(0.04) * 2.0 * pi;
+
+            context.arc(half_size, half_size, half_size - 2.0, start, start + diff);
+            context.stroke().unwrap();
+        }
+    }
+}
+
+glib::wrapper! {
+    pub(crate) struct LoadingIndicator(ObjectSubclass<imp::LoadingIndicator>)
+        @extends gtk::Widget;
+}
+
+impl LoadingIndicator {
+    fn time(&self) -> i64 {
+        self.frame_clock()
+            .and_then(|clk| clk.current_timings())
+            .map(|t| t.frame_time())
+            .unwrap_or_default()
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,7 +1,9 @@
 mod avatar;
+mod loading_indicator;
 mod message_entry;
 mod snow;
 
 pub(crate) use self::avatar::Avatar;
+pub(crate) use self::loading_indicator::LoadingIndicator;
 pub(crate) use self::message_entry::MessageEntry;
 pub(crate) use self::snow::Snow;

--- a/src/session/content/message_row/document.rs
+++ b/src/session/content/message_row/document.rs
@@ -5,6 +5,7 @@ use gtk::{gdk, gio, glib, CompositeTemplate};
 use tdlib::enums::MessageContent;
 use tdlib::types::File;
 
+use crate::components::LoadingIndicator;
 use crate::session::content::message_row::{MessageBase, MessageBaseImpl, MessageBubble};
 use crate::tdlib::Message;
 use crate::utils::{parse_formatted_text, spawn};
@@ -32,6 +33,8 @@ mod imp {
         pub(super) click: TemplateChild<gtk::GestureClick>,
         #[template_child]
         pub(super) file_thumbnail_picture: TemplateChild<gtk::Picture>,
+        #[template_child]
+        pub(super) loading_indicator: TemplateChild<LoadingIndicator>,
         #[template_child]
         pub(super) file_status_image: TemplateChild<gtk::Image>,
         #[template_child]
@@ -190,12 +193,13 @@ impl MessageDocument {
         let file_id = file.id;
 
         let handler_id = match *status {
-            Downloading(_progress) | Uploading(_progress) => {
+            Downloading(progress) | Uploading(progress) => {
+                imp.loading_indicator.set_progress(progress);
                 return;
-                // Show loading indicator
             }
             CanBeDownloaded => {
                 // Download file
+                imp.loading_indicator.set_visible(false);
                 image.set_icon_name(Some("document-save-symbolic"));
                 click.connect_released(clone!(@weak self as obj, @weak session => move |click, _, _, _| {
                     // TODO: Fix bug mentioned here
@@ -204,6 +208,7 @@ impl MessageDocument {
                         obj.update_status(file, session);
                     }));
 
+                    obj.imp().loading_indicator.set_visible(true);
                     obj.imp().file_status_image.set_icon_name(Some("media-playback-stop-symbolic"));
                     let handler_id = click.connect_released(clone!(@weak session => move |_, _, _, _| {
                         session.cancel_download_file(file_id);
@@ -215,6 +220,7 @@ impl MessageDocument {
             }
             Downloaded => {
                 // Open file
+                imp.loading_indicator.set_visible(false);
                 image.set_icon_name(Some("folder-documents-symbolic"));
                 if imp.file_thumbnail_picture.file().is_some() {
                     image.set_visible(false);


### PR DESCRIPTION
Adds loading indicator to MessageDocument, I plan to use the same indicator for other media messages

Indicator drawn with cairo because I want arc to have rounded end points.
Rotation done inside widget instead of css because otherwise it rotates texture and it doesn't look good
