### PR TITLE
style: Unread counter can now display five digits

### DIFF
--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -131,7 +131,7 @@ listview.chat-history > row {
 button.scroll-to-bottom {
   background-color: @window_bg_color;
   box-shadow: inset 0 0 0 1px @borders;
-  margin: 6px;
+  margin: 6px 9px;
 }
 
 messagebubble {


### PR DESCRIPTION

* Unread counter could previously display only two digits which wasn't really useful, so I've added more space so it can now display five digits.
Before
![before](https://user-images.githubusercontent.com/110191114/224182913-7f2ecfe7-15da-49fd-bb84-f218663e01c7.png)
After
![after](https://user-images.githubusercontent.com/110191114/224182925-bec37461-68d1-4ee3-8a0d-85af17a33b2a.png)

* Do not add sender css classes for outgoing message, because it make the contrast really weak.
![example](https://user-images.githubusercontent.com/110191114/224182951-c780445e-cd35-4b80-bce1-3f8fac9ec976.png)
