### PR TITLE
 Recolor stickers using color matrix instead of css invert

### DIFF
--- a/data/resources/style-dark.css
+++ b/data/resources/style-dark.css
@@ -2,11 +2,6 @@
   background-color: @dark_2;
 }
 
-/* sticker must be repainted to a text color in messages */
-messagesticker.needs-repainting > overlay > widget > widget {
-  filter: invert(1);
-}
-
 vectorpath {
   color: alpha(#404040, 0.8);
 }

--- a/data/resources/style-dark.css
+++ b/data/resources/style-dark.css
@@ -7,6 +7,10 @@ messagesticker.needs-repainting > overlay > widget > widget {
   filter: invert(1);
 }
 
+vectorpath {
+  color: alpha(#404040, 0.8);
+}
+
 .chat-list row .unread-count-muted {
   background-color: @dark_2;
 }

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -318,6 +318,10 @@ messagesticker {
   border-spacing: 6px;
 }
 
+vectorpath {
+  color: alpha(black, 0.2);
+}
+
 .event-row {
   font-size: smaller;
   font-weight: bold;

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -2,8 +2,10 @@ mod avatar;
 mod message_entry;
 mod snow;
 mod sticker;
+mod vector_path;
 
 pub(crate) use self::avatar::Avatar;
 pub(crate) use self::message_entry::MessageEntry;
 pub(crate) use self::snow::Snow;
 pub(crate) use self::sticker::Sticker;
+use self::vector_path::VectorPath;

--- a/src/components/sticker.rs
+++ b/src/components/sticker.rs
@@ -6,6 +6,7 @@ use gtk::{gio, glib};
 use tdlib::enums::StickerFormat;
 use tdlib::types::Sticker as TdSticker;
 
+use super::VectorPath;
 use crate::session::Session;
 use crate::utils::{decode_image_from_path, spawn};
 
@@ -52,11 +53,15 @@ mod imp {
     }
 
     impl WidgetImpl for Sticker {
-        fn measure(&self, orientation: gtk::Orientation, _for_size: i32) -> (i32, i32, i32, i32) {
+        fn measure(&self, orientation: gtk::Orientation, for_size: i32) -> (i32, i32, i32, i32) {
             let size = self.longer_side_size.get();
             let aspect_ratio = self.aspect_ratio.get();
 
-            let min_size = 1;
+            let min_size = if let Some(child) = &*self.child.borrow_mut() {
+                child.measure(orientation, for_size).0
+            } else {
+                1
+            };
 
             let size = if let gtk::Orientation::Horizontal = orientation {
                 if aspect_ratio >= 1.0 {
@@ -103,8 +108,7 @@ impl Sticker {
             return;
         }
 
-        // TODO: draw sticker outline with cairo
-        self.set_child(None);
+        self.set_child(Some(VectorPath::new(&sticker.outline).upcast()));
 
         let aspect_ratio = sticker.width as f64 / sticker.height as f64;
         imp.aspect_ratio.set(aspect_ratio);

--- a/src/components/sticker.rs
+++ b/src/components/sticker.rs
@@ -8,7 +8,7 @@ use tdlib::types::Sticker as TdSticker;
 
 use super::VectorPath;
 use crate::session::Session;
-use crate::utils::{decode_image_from_path, spawn};
+use crate::utils::{color_matrix_from_color, decode_image_from_path, spawn};
 
 mod imp {
     use super::*;
@@ -19,6 +19,8 @@ mod imp {
     pub(crate) struct Sticker {
         pub(super) file_id: Cell<i32>,
         pub(super) aspect_ratio: Cell<f64>,
+        pub(super) recolor: Cell<bool>,
+        pub(super) is_loaded: Cell<bool>,
         pub(super) child: RefCell<Option<gtk::Widget>>,
 
         #[property(get, set = Self::set_longer_side_size)]
@@ -84,6 +86,17 @@ mod imp {
                 child.allocate(width, height, baseline, None);
             }
         }
+
+        fn snapshot(&self, snapshot: &gtk::Snapshot) {
+            if self.recolor.get() && self.is_loaded.get() {
+                let (color_matrix, color_offset) = color_matrix_from_color(self.obj().color());
+                snapshot.push_color_matrix(&color_matrix, &color_offset);
+                self.parent_snapshot(snapshot);
+                snapshot.pop();
+            } else {
+                self.parent_snapshot(snapshot);
+            }
+        }
     }
 
     impl Sticker {
@@ -108,10 +121,14 @@ impl Sticker {
             return;
         }
 
-        self.set_child(Some(VectorPath::new(&sticker.outline).upcast()));
+        self.set_child(VectorPath::new(&sticker.outline).upcast(), false);
 
         let aspect_ratio = sticker.width as f64 / sticker.height as f64;
         imp.aspect_ratio.set(aspect_ratio);
+
+        let recolor = matches!(&sticker.full_type,
+            tdlib::enums::StickerFullType::CustomEmoji(data) if data.needs_repainting);
+        imp.recolor.set(recolor);
 
         let format = sticker.format;
 
@@ -185,18 +202,17 @@ impl Sticker {
 
         // Skip if widget was recycled by ListView
         if self.imp().file_id.get() == file_id {
-            self.set_child(Some(widget));
+            self.set_child(widget, true);
         }
     }
 
-    fn set_child(&self, child: Option<gtk::Widget>) {
+    fn set_child(&self, child: gtk::Widget, is_loaded: bool) {
         let imp = self.imp();
+        imp.is_loaded.set(is_loaded);
 
-        if let Some(ref child) = child {
-            child.set_parent(self);
-        }
+        child.set_parent(self);
 
-        if let Some(old) = imp.child.replace(child) {
+        if let Some(old) = imp.child.replace(Some(child)) {
             old.unparent()
         }
     }

--- a/src/components/vector_path.rs
+++ b/src/components/vector_path.rs
@@ -1,0 +1,95 @@
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use gtk::{glib, graphene, gsk};
+use tdlib::types::ClosedVectorPath;
+
+use crate::utils::color_matrix_from_color;
+
+mod imp {
+    use super::*;
+    use std::cell::RefCell;
+
+    #[derive(Default)]
+    pub(crate) struct VectorPath {
+        pub(super) node: RefCell<Option<gsk::RenderNode>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for VectorPath {
+        const NAME: &'static str = "ComponentsVectorPath";
+        type Type = super::VectorPath;
+        type ParentType = gtk::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.set_css_name("vectorpath");
+        }
+    }
+
+    impl ObjectImpl for VectorPath {}
+
+    impl WidgetImpl for VectorPath {
+        fn snapshot(&self, snapshot: &gtk::Snapshot) {
+            let widget = self.obj();
+
+            let factor = (widget.width() as f32).max(widget.height() as f32) / 512.0;
+            snapshot.scale(factor, factor);
+
+            let (color_matrix, color_offset) = color_matrix_from_color(widget.color());
+            snapshot.push_color_matrix(&color_matrix, &color_offset);
+            if let Some(node) = &*self.node.borrow() {
+                snapshot.append_node(node);
+            }
+            snapshot.pop();
+        }
+    }
+}
+
+glib::wrapper! {
+    pub(crate) struct VectorPath(ObjectSubclass<imp::VectorPath>)
+        @extends gtk::Widget;
+}
+
+impl VectorPath {
+    pub fn new(outline: &[ClosedVectorPath]) -> Self {
+        let obj: Self = glib::Object::new();
+        obj.imp().node.replace(path_node(outline));
+        obj
+    }
+}
+
+fn path_node(outline: &[ClosedVectorPath]) -> Option<gsk::RenderNode> {
+    use tdlib::enums::VectorPathCommand::{CubicBezierCurve, Line};
+    use tdlib::types::VectorPathCommandCubicBezierCurve as Curve;
+
+    let snapshot = gtk::Snapshot::new();
+    let context = snapshot.append_cairo(&graphene::Rect::new(0.0, 0.0, 512.0, 512.0));
+
+    for closed_path in outline {
+        let e = match closed_path.commands.iter().last().unwrap() {
+            Line(line) => &line.end_point,
+            CubicBezierCurve(curve) => &curve.end_point,
+        };
+        context.move_to(e.x, e.y);
+
+        for command in &closed_path.commands {
+            match command {
+                Line(line) => {
+                    let e = &line.end_point;
+                    context.line_to(e.x, e.y);
+                }
+                CubicBezierCurve(curve) => {
+                    let Curve {
+                        start_control_point: sc,
+                        end_control_point: ec,
+                        end_point: e,
+                    } = curve;
+
+                    context.curve_to(sc.x, sc.y, ec.x, ec.y, e.x, e.y);
+                }
+            }
+        }
+    }
+    _ = context.fill();
+
+    snapshot.to_node()
+}

--- a/src/session/content/message_row/sticker.rs
+++ b/src/session/content/message_row/sticker.rs
@@ -162,14 +162,6 @@ impl MessageBaseExt for MessageSticker {
             _ => unreachable!(),
         };
 
-        // TODO: that should be handled a bit better in the future
-        match &sticker.full_type {
-            StickerFullType::CustomEmoji(data) if data.needs_repainting => {
-                self.add_css_class("needs-repainting")
-            }
-            _ => self.remove_css_class("needs-repainting"),
-        }
-
         let (size, margin_bottom) = if is_emoji {
             (EMOJI_SIZE, 8)
         } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use gettextrs::gettext;
-use gtk::{gdk, glib};
+use gtk::{gdk, glib, graphene};
 use image::io::Reader as ImageReader;
 use locale_config::Locale;
 use once_cell::sync::Lazy;
@@ -277,4 +277,13 @@ pub(crate) fn decode_image_from_path(path: &str) -> Result<gdk::MemoryTexture, D
     );
 
     Ok(texture)
+}
+
+pub fn color_matrix_from_color(color: gdk::RGBA) -> (graphene::Matrix, graphene::Vec4) {
+    let color_offset = graphene::Vec4::new(color.red(), color.green(), color.blue(), 0.0);
+    let mut matrix = [0.0; 16];
+    matrix[15] = color.alpha();
+    let color_matrix = graphene::Matrix::from_float(matrix);
+
+    (color_matrix, color_offset)
 }


### PR DESCRIPTION
That's more correct and allows to use any colors (text color is used by default)

![image](https://user-images.githubusercontent.com/63008755/227861259-3460859c-d790-4de1-a978-fb9e5a001bf7.png)

I don't want to recolor vector path, so that PR depends on #470 