### PR TITLE
chore(blueprint): Use $ prefix to satisfy compiler

### DIFF
--- a/data/resources/ui/content-message-document.blp
+++ b/data/resources/ui/content-message-document.blp
@@ -1,6 +1,6 @@
 using Gtk 4.0;
 
-template $MessageDocument : .MessageBase {
+template $MessageDocument : $MessageBase {
   $MessageBubble message_bubble {
     styles ["document"]
 

--- a/data/resources/ui/session-entry-row.blp
+++ b/data/resources/ui/session-entry-row.blp
@@ -8,7 +8,7 @@ template $SessionEntryRow {
   margin-start: 3;
   margin-end: 3;
 
-  .AvatarWithSelection account_avatar {
+  $AvatarWithSelection account_avatar {
     size: 40;
     item: bind SessionEntryRow.session as <$Session>.me;
   }

--- a/data/resources/ui/session-manager.blp
+++ b/data/resources/ui/session-manager.blp
@@ -7,7 +7,7 @@ template $SessionManager {
     visible-child: login;
     transition-type: crossfade;
 
-    .Login login {}
+    $Login login {}
 
     Stack sessions {}
   }

--- a/data/resources/ui/session.blp
+++ b/data/resources/ui/session.blp
@@ -5,7 +5,7 @@ template $Session : Adw.Bin {
   Adw.Leaflet leaflet {
     can-navigate-back: true;
 
-    .Sidebar sidebar {
+    $Sidebar sidebar {
       compact: bind leaflet.folded;
       selected-chat: bind content.chat bidirectional;
       session: "Session";
@@ -16,7 +16,7 @@ template $Session : Adw.Bin {
       child: Separator {};
     }
 
-    .Content content {
+    $Content content {
       compact: bind leaflet.folded;
     }
   }

--- a/data/resources/ui/sidebar-row.blp
+++ b/data/resources/ui/sidebar-row.blp
@@ -16,7 +16,7 @@ template $SidebarRow {
     pressed => $on_long_pressed() swapped;
   }
 
-  .SidebarAvatar {
+  $SidebarAvatar {
     item: bind SidebarRow.item as <$ChatListItem>.chat;
   }
 
@@ -63,7 +63,7 @@ template $SidebarRow {
           styles ["small-body"]
         }
 
-        .SidebarMiniThumbnail minithumbnail {
+        $SidebarMiniThumbnail minithumbnail {
           visible: "False";
           valign: "center";
         }

--- a/data/resources/ui/window.blp
+++ b/data/resources/ui/window.blp
@@ -6,5 +6,5 @@ template $Window : Adw.ApplicationWindow {
   default-height: 600;
   width-request: 360;
 
-  content: .SessionManager session_manager {};
+  content: $SessionManager session_manager {};
 }


### PR DESCRIPTION
This eliminates some blueprint compiler warnings. But there are still some warnings probably caused by a compiler bug.