### PR TITLE
fix(session): Create chat if not existing

### DIFF
--- a/src/session/sidebar/search/mod.rs
+++ b/src/session/sidebar/search/mod.rs
@@ -375,19 +375,7 @@ impl Search {
                 log::warn!("Failed to add recently found chat: {:?}", e);
             }
         } else if let Some(user) = item.downcast_ref::<User>() {
-            // Check if a private chat with this user already exists
-            if let Some(chat) = session.try_chat(user.id()) {
-                sidebar.select_chat(chat);
-            } else {
-                match functions::create_private_chat(user.id(), true, session.client_id()).await {
-                    Ok(enums::Chat::Chat(data)) => {
-                        sidebar.select_chat(session.chat(data.id));
-                    }
-                    Err(e) => {
-                        log::warn!("Failed to create private chat: {:?}", e);
-                    }
-                }
-            }
+            session.select_chat(user.id());
 
             if let Err(e) = functions::add_recently_found_chat(user.id(), session.client_id()).await
             {


### PR DESCRIPTION
This PR fixes #507 (and probably #545) by creating the chat if it doesn't exist.

There's another problem, but it seems to be unrelated, as it also happens in the search code (I can open an issue if it's not something trivial to fix).
After opening the chat (empty), send a message and the app will crash with this, although the message is sent successfully:
```
Gtk:ERROR:../gtk/gtklistitemmanager.c:828:gtk_list_item_manager_ensure_items: assertion failed: (tile != NULL)
Bail out! Gtk:ERROR:../gtk/gtklistitemmanager.c:828:gtk_list_item_manager_ensure_items: assertion failed: (tile != NULL)
```