### PR TITLE
feat(message-document): Use mask for status indicator

### DIFF
--- a/data/resources/style-dark.css
+++ b/data/resources/style-dark.css
@@ -19,6 +19,10 @@ messagebubble.outgoing {
   background-color: #2c52ac;
 }
 
+messagebubble.document.outgoing .file > overlay > statusindicator {
+  color: white;
+}
+
 .event-row {
   background-color: alpha(#404040, 0.8);
 }

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -196,32 +196,30 @@ messagebubble.document .file > overlay {
   min-height: 40px;
 }
 
-messagebubble.document .file > overlay > image {
-  background: @accent_color;
-  color: @window_bg_color;
-  transition: opacity 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+messagebubble.document .file > overlay > statusindicator > image {
   padding: 12px;
+}
+
+messagebubble.document .file > overlay > statusindicator {
+  color: @accent_color;
+  transition: opacity 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
   border-radius: 9999px;
 }
 
-messagebubble.document.outgoing .file > overlay > image {
-  background: @accent_fg_color;
-  color: @accent_bg_color;
+messagebubble.document.outgoing .file > overlay > statusindicator {
+  /* depends on bubble color */
+  color: #79c271;
 }
 
-messagebubble.document .file:hover > overlay > image {
+messagebubble.document .file:hover > overlay > statusindicator {
   opacity: 0.85;
 }
 
-messagebubble.document .file:active > overlay > image {
+messagebubble.document .file:active > overlay > statusindicator {
   opacity: 0.7;
 }
-messagebubble.document .file.with-thumbnail > overlay > image {
-  background-color: alpha(black, 0.6);
-  color: white;
-}
 
-messagebubble.document .file.with-thumbnail > overlay > image {
+messagebubble.document .file.with-thumbnail > overlay > statusindicator {
   background-color: alpha(black, 0.6);
   color: white;
 }
@@ -249,16 +247,6 @@ messagebubble.media.with-reply mediapicture {
   border-top-right-radius: 0;
   border-top-left-radius: 0;
   margin-top: 3px;
-}
-
-messagebubble.document .file.with-thumbnail > overlay > image {
-  background-color: alpha(black, 0.6);
-  color: white;
-}
-
-messagebubble.document .file.with-thumbnail > overlay {
-  min-width: 60px;
-  min-height: 60px;
 }
 
 messagebubble.document .file.with-thumbnail > overlay > picture {

--- a/data/resources/ui/content-message-document.blp
+++ b/data/resources/ui/content-message-document.blp
@@ -22,7 +22,7 @@ template $MessageDocument : $MessageBase {
         }
 
         [overlay]
-        Image file_status_image {
+        $MessageDocumentStatusIndicator status_indicator {
           halign: center;
           valign: center;
         }

--- a/src/session/content/message_row/document/file_status.rs
+++ b/src/session/content/message_row/document/file_status.rs
@@ -1,0 +1,34 @@
+use tdlib::types::File;
+use FileStatus::*;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum FileStatus {
+    Downloading(f64),
+    Uploading(f64),
+    CanBeDownloaded,
+    Downloaded,
+}
+
+impl From<&File> for FileStatus {
+    fn from(file: &File) -> Self {
+        let local = &file.local;
+        let remote = &file.remote;
+
+        let size = file.size.max(file.expected_size) as u64;
+
+        if local.is_downloading_active {
+            let progress = local.downloaded_size as f64 / size as f64;
+            Downloading(progress)
+        } else if remote.is_uploading_active {
+            let progress = remote.uploaded_size as f64 / size as f64;
+            Uploading(progress)
+        } else if local.is_downloading_completed {
+            Downloaded
+        } else if local.can_be_downloaded {
+            CanBeDownloaded
+        } else {
+            dbg!(file);
+            unimplemented!("unknown file status");
+        }
+    }
+}

--- a/src/session/content/message_row/document/status_indicator.rs
+++ b/src/session/content/message_row/document/status_indicator.rs
@@ -1,0 +1,115 @@
+use std::cell::Cell;
+
+use gtk::glib;
+use gtk::gsk;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use gtk::CompositeTemplate;
+
+use super::file_status::FileStatus;
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug, Default, CompositeTemplate, glib::Properties)]
+    #[template(string = r#"
+        template $MessageDocumentStatusIndicator {
+            layout-manager: BinLayout {};
+            overflow: hidden;
+
+            Image status_image {}
+        }
+    "#)]
+    #[properties(wrapper_type = super::StatusIndicator)]
+    pub(crate) struct StatusIndicator {
+        #[property(get, set = Self::set_masked, explicit_notify)]
+        pub(super) masked: Cell<bool>,
+        #[template_child]
+        pub(super) status_image: TemplateChild<gtk::Image>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for StatusIndicator {
+        const NAME: &'static str = "MessageDocumentStatusIndicator";
+        type Type = super::StatusIndicator;
+        type ParentType = gtk::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.set_css_name("statusindicator");
+            klass.bind_template();
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for StatusIndicator {
+        fn properties() -> &'static [glib::ParamSpec] {
+            Self::derived_properties()
+        }
+
+        fn set_property(&self, id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+            self.derived_set_property(id, value, pspec)
+        }
+
+        fn property(&self, id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+            self.derived_property(id, pspec)
+        }
+    }
+
+    impl WidgetImpl for StatusIndicator {
+        fn snapshot(&self, snapshot: &gtk::Snapshot) {
+            if self.masked.get() {
+                let widget = self.obj();
+
+                snapshot.push_mask(gsk::MaskMode::InvertedAlpha);
+
+                self.parent_snapshot(snapshot);
+
+                snapshot.pop();
+
+                snapshot.append_color(
+                    &widget.color(),
+                    &gtk::graphene::Rect::new(
+                        0.0,
+                        0.0,
+                        widget.width() as f32,
+                        widget.height() as f32,
+                    ),
+                );
+
+                snapshot.pop();
+            } else {
+                self.parent_snapshot(snapshot);
+            }
+        }
+    }
+
+    impl StatusIndicator {
+        fn set_masked(&self, masked: bool) {
+            if self.masked.replace(masked) != masked {
+                let obj = self.obj();
+                obj.queue_draw();
+                obj.notify_masked();
+            }
+        }
+    }
+}
+
+glib::wrapper! {
+    pub(crate) struct StatusIndicator(ObjectSubclass<imp::StatusIndicator>)
+        @extends gtk::Widget;
+}
+
+impl StatusIndicator {
+    pub(crate) fn set_status(&self, status: FileStatus) {
+        let icon_name = match status {
+            FileStatus::Downloading(_) | FileStatus::Uploading(_) => "media-playback-stop-symbolic",
+            FileStatus::CanBeDownloaded => "document-save-symbolic",
+            FileStatus::Downloaded => "folder-documents-symbolic",
+        };
+
+        self.imp().status_image.set_icon_name(Some(icon_name));
+    }
+}


### PR DESCRIPTION
With mask it correctly matches message background

![Screenshot from 2023-06-11 15-34-42](https://github.com/paper-plane-developers/paper-plane/assets/63008755/7c9fcf5c-e244-4398-9532-1967675fcc3a)
![Screenshot from 2023-06-11 15-34-22](https://github.com/paper-plane-developers/paper-plane/assets/63008755/1758be64-83fe-46db-bec7-2dfee374565d)

That PR doesn't include gradient bubbles