### PR TITLE
chore: Update tdlib-rs to 0.10.0 and migrate to tdlib 1.8.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "bindgen"
@@ -824,6 +824,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -1401,14 +1402,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "serde",
  "serde_json",
  "serde_with_macros",
@@ -1417,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.3.3"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1503,9 +1505,9 @@ checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
 name = "tdlib"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c8c6fb27a718557d8c3fd9afe01d5a293b7c159de6717526183b31eadf94d8"
+checksum = "eb79550a8d720b04a711e04d83b5edf057c7d968d5e636130ac743b936e27dcf"
 dependencies = [
  "futures-channel",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ qrcode-generator = { version = "4", default-features = false }
 regex = "1"
 rlt = { package = "gtk-rlottie", git = "https://github.com/YuraIz/gtk-rlottie-rs", tag = "aug6" }
 shumate = { version = "0.4", package = "libshumate" }
-tdlib = { version = "0.7", default-features = false }
+tdlib = { version = "0.10", default-features = false }
 temp-dir = "0.1"
 thiserror = "1"
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The following packages are required to build Paper Plane:
 - GTK >= 4.10 (with the patch included in the build-aux directory)
 - libadwaita >= 1.4
 - libshumate >= 1.0.0
-- [TDLib 1.8.14](https://github.com/tdlib/td/commit/8517026415e75a8eec567774072cbbbbb52376c1)
+- [TDLib 1.8.19](https://github.com/tdlib/td/commit/2589c3fd46925f5d57e4ec79233cd1bd0f5d0c09)
 - [Telegram API Credentials](https://my.telegram.org/) (optional, but recommended)
 
 Additionally, Paper Plane requires the following GStreamer plugins installed in your system to correctly show all media files:

--- a/build-aux/app.drey.PaperPlane.Devel.json
+++ b/build-aux/app.drey.PaperPlane.Devel.json
@@ -104,8 +104,8 @@
                         "x86_64"
                     ],
                     "type": "archive",
-                    "url": "https://github.com/melix99/tdjson-ci/releases/download/1.8.14/tdjson-x86_64.zip",
-                    "sha256": "7c630d2330c9736abcd11821f73a8d37245cfc0812ccb749d4180af7feb6d3fc",
+                    "url": "https://github.com/melix99/tdjson-ci/releases/download/1.8.19/tdjson-x86_64.zip",
+                    "sha256": "55af3cb2cd5d9616c96d3fa6529c90cd66bebd9943f6b6c9aa41ec792067ccef",
                     "strip-components": 0
                 },
                 {
@@ -113,8 +113,8 @@
                         "aarch64"
                     ],
                     "type": "archive",
-                    "url": "https://github.com/melix99/tdjson-ci/releases/download/1.8.14/tdjson-aarch64.zip",
-                    "sha256": "229bab16ea249e883c2bad0d0f3da9bb4d1da172cc8b8a4a83b84c6a8b76661d",
+                    "url": "https://github.com/melix99/tdjson-ci/releases/download/1.8.19/tdjson-aarch64.zip",
+                    "sha256": "e5f5bfbae1c0617fe06ec7f9d74d65569d4a5a1ca4567f067e9d66d2292edb26",
                     "strip-components": 0
                 }
             ]

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ dependency('gio-2.0', version: '>= 2.72')
 dependency('gtk4', version: '>= 4.12')
 dependency('libadwaita-1', version: '>= 1.4')
 dependency('shumate-1.0', version: '>= 1')
-dependency('tdjson', version: '== 1.8.14')
+dependency('tdjson', version: '== 1.8.19')
 
 glib_compile_resources = find_program('glib-compile-resources', required: true)
 glib_compile_schemas = find_program('glib-compile-schemas', required: true)

--- a/src/model/client_state_session.rs
+++ b/src/model/client_state_session.rs
@@ -422,7 +422,7 @@ impl ClientStateSession {
             }
             ChatNotificationSettings(ref data) => self.chat(data.chat_id).handle_update(update),
             ChatUnreadMentionCount(ref data) => self.chat(data.chat_id).handle_update(update),
-            ChatIsBlocked(ref data) => self.chat(data.chat_id).handle_update(update),
+            ChatBlockList(ref data) => self.chat(data.chat_id).handle_update(update),
             ChatIsMarkedAsUnread(ref data) => self.chat(data.chat_id).handle_update(update),
             DeleteMessages(ref data) => self.chat(data.chat_id).handle_update(update),
             ChatAction(ref data) => self.chat(data.chat_id).handle_update(update),

--- a/src/model/message.rs
+++ b/src/model/message.rs
@@ -74,9 +74,7 @@ mod imp {
         #[property(get, set, construct_only)]
         pub(super) forward_info: OnceCell<Option<model::MessageForwardInfo>>,
         #[property(get, set, construct_only)]
-        pub(super) reply_in_chat_id: OnceCell<i64>,
-        #[property(get, set, construct_only)]
-        pub(super) reply_to_message_id: OnceCell<i64>,
+        pub(super) reply_to: OnceCell<Option<model::BoxedMessageReplyTo>>,
         #[property(get)]
         pub(super) content: RefCell<model::BoxedMessageContent>,
         #[property(get)]
@@ -144,8 +142,10 @@ impl Message {
                     .forward_info
                     .map(|forward_info| model::MessageForwardInfo::new(chat, forward_info)),
             )
-            .property("reply-in-chat-id", td_message.reply_in_chat_id)
-            .property("reply-to-message-id", td_message.reply_to_message_id)
+            .property(
+                "reply-to",
+                td_message.reply_to.map(model::BoxedMessageReplyTo),
+            )
             .build();
 
         let imp = obj.imp();

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -28,8 +28,10 @@ mod supergroup;
 mod user;
 
 use gtk::glib;
+use tdlib::enums::BlockList;
 use tdlib::enums::ChatMemberStatus;
 use tdlib::enums::MessageContent;
+use tdlib::enums::MessageReplyTo;
 use tdlib::enums::MessageSendingState;
 use tdlib::enums::UserStatus;
 use tdlib::enums::UserType;
@@ -136,6 +138,10 @@ pub(crate) struct BoxedChatPermissions(pub(crate) ChatPermissions);
 pub(crate) struct BoxedDraftMessage(pub(crate) DraftMessage);
 
 #[derive(Clone, Debug, PartialEq, glib::Boxed)]
+#[boxed_type(name = "BoxedBlockList", nullable)]
+pub(crate) struct BoxedBlockList(pub(crate) BlockList);
+
+#[derive(Clone, Debug, PartialEq, glib::Boxed)]
 #[boxed_type(name = "BoxedFormattedText", nullable)]
 pub(crate) struct BoxedFormattedText(pub(crate) FormattedText);
 
@@ -147,6 +153,10 @@ impl Default for BoxedMessageContent {
         Self(MessageContent::MessageUnsupported)
     }
 }
+
+#[derive(Clone, Debug, PartialEq, glib::Boxed)]
+#[boxed_type(name = "BoxedMessageReplyTo", nullable)]
+pub(crate) struct BoxedMessageReplyTo(pub(crate) MessageReplyTo);
 
 #[derive(Clone, Debug, Default, PartialEq, glib::Boxed)]
 #[boxed_type(name = "BoxedScopeNotificationSettings", nullable)]

--- a/src/ui/session/content/message_row/sticker.rs
+++ b/src/ui/session/content/message_row/sticker.rs
@@ -107,7 +107,12 @@ impl ui::MessageBaseExt for MessageSticker {
 
         imp.indicators.set_message(message.upcast_ref());
 
-        if message.reply_to_message_id() != 0 {
+        if matches!(
+            message.reply_to(),
+            Some(model::BoxedMessageReplyTo(
+                tdlib::enums::MessageReplyTo::Message(_)
+            ))
+        ) {
             let reply = ui::MessageReply::new(message);
             reply.set_valign(gtk::Align::Start);
             reply.set_max_char_width(MAX_REPLY_CHAR_WIDTH);

--- a/src/ui/session/content/send_media_window.rs
+++ b/src/ui/session/content/send_media_window.rs
@@ -137,6 +137,9 @@ impl SendMediaWindow {
         let width = paintable.intrinsic_width();
         let height = paintable.intrinsic_height();
         let caption = imp.caption_entry.as_markdown().await;
+        let self_destruct_type = Some(MessageSelfDestructType::Timer(
+            MessageSelfDestructTypeTimer::default(),
+        ));
 
         let file = InputFile::Local(InputFileLocal { path });
         let content = if send_as_file {
@@ -154,13 +157,18 @@ impl SendMediaWindow {
                 width,
                 height,
                 caption,
-                self_destruct_time: 0,
+                self_destruct_type,
                 has_spoiler: false,
             })
         };
 
+        let reply_to = Some(MessageReplyTo::Message(MessageReplyToMessage {
+            chat_id,
+            message_id: 0,
+        }));
+
         // TODO: maybe show an error dialog when this fails?
-        if tdlib::functions::send_message(chat_id, 0, 0, None, content, client_id)
+        if tdlib::functions::send_message(chat_id, 0, reply_to, None, content, client_id)
             .await
             .is_ok()
         {


### PR DESCRIPTION
This PR updates tdlib-rs to 0.10.0 and tdlib to 1.8.19.

## Checklist before merge
 - [x] Update the bundled tdlib in the flatpak manifest once it's built.
 - [x] Update tdlib-rs and remove temporary git repo once 0.10.0 is released.
 - [x] Fix the `block-list` property in `src/model/chat.rs` ~(it's currently commented out).~
 - [x] Fix the `reply-to` property in `src/model/message.rs` ~(it's currently commented out).~
 - [x] Improve general code quality and discuss approaches.