### PR TITLE
build(libadwaita): Use ` -Wno-incompatible-pointer-types`

### DIFF
--- a/build-aux/app.drey.PaperPlane.Devel.json
+++ b/build-aux/app.drey.PaperPlane.Devel.json
@@ -129,6 +129,7 @@
         {
             "name": "libadwaita",
             "buildsystem": "meson",
+            "build-options" : { "cflags": "-O2 -g -Wno-incompatible-pointer-types" },
             "config-opts": [
                 "-Dvapi=false",
                 "-Dtests=false",


### PR DESCRIPTION
CI suddenly complains about `-Werror=incompatible-pointer-types`:

../src/adw-about-window.c:2007:12: error: assignment to ‘GPtrArray *’ {aka ‘struct _GPtrArray *’} from incompatible pointer type ‘AsReleases *’ {aka ‘struct _AsReleases *’} [-Werror=incompatible-pointer-types]
 2007 |   releases = as_component_get_releases (component);

So, let's override build options to get rid of that.