### PR TITLE
style(message-venue): Don't touch indicators opacity

### DIFF
--- a/src/ui/session/content/message_row/bubble.rs
+++ b/src/ui/session/content/message_row/bubble.rs
@@ -262,8 +262,8 @@ impl MessageBubble {
         self.update_indicators_position();
     }
 
-    pub(crate) fn add_label_class(&self, class: &str) {
-        self.imp().message_label.add_css_class(class);
+    pub(crate) fn add_message_label_class(&self, class: &str) {
+        self.imp().message_label.add_label_class(class);
     }
 
     pub(crate) fn set_suffix(&self, prefix: Option<&gtk::Widget>) {

--- a/src/ui/session/content/message_row/label.rs
+++ b/src/ui/session/content/message_row/label.rs
@@ -211,6 +211,10 @@ impl MessageLabel {
         }
     }
 
+    pub(crate) fn add_label_class(&self, class: &str) {
+        self.imp().label.add_css_class(class);
+    }
+
     pub(crate) fn indicators(&self) -> Option<ui::MessageIndicators> {
         self.imp().indicators.borrow().clone()
     }

--- a/src/ui/session/content/message_row/venue.rs
+++ b/src/ui/session/content/message_row/venue.rs
@@ -94,8 +94,8 @@ impl MessageBaseExt for MessageVenue {
         }
 
         imp.message_bubble.update_from_message(message, true);
-        imp.message_bubble.add_label_class("caption");
-        imp.message_bubble.add_label_class("dim-label");
+        imp.message_bubble.add_message_label_class("caption");
+        imp.message_bubble.add_message_label_class("dim-label");
 
         // Update the message.
         let handler_id =


### PR DESCRIPTION
Before:
![Bildschirmfoto vom 2023-09-28 21-44-30](https://github.com/paper-plane-developers/paper-plane/assets/3630213/7a237d40-4596-4811-9e49-84a8fb8427ea)

After
![Bildschirmfoto vom 2023-09-28 21-45-18](https://github.com/paper-plane-developers/paper-plane/assets/3630213/fe57401f-9c7e-4d54-93d9-b87e944b01a6)
