### PR TITLE
chore: Fix some string typos

### DIFF
--- a/data/app.drey.PaperPlane.metainfo.xml.in.in
+++ b/data/app.drey.PaperPlane.metainfo.xml.in.in
@@ -64,7 +64,7 @@
       <description>
         <p>The third beta release of Paper Plane 0.1.0 should in the first place fix a build error on Flathub:</p>
         <ul>
-          <li>Added registered categories to te desktop file to fix a build error on Flathub.</li>
+          <li>Added registered categories to the desktop file to fix a build error on Flathub.</li>
           <li>Dependencies have been updated.</li>
           <li>Turkish translations have been updated, thanks to @sabriunal.</li>
         </ul>

--- a/src/application.rs
+++ b/src/application.rs
@@ -197,7 +197,7 @@ impl Application {
                 "OpenStreetMap® is open data, licensed under the \
                 <a href=\"https://opendatacommons.org/licenses/odbl\">\
                 Open Data Commons Open Database License </a> (ODbL) by the \
-                <a href=\"https://osmfoundation.org\">aOpenStreetMap Foundation</a> (OSMF).",
+                <a href=\"https://osmfoundation.org\">OpenStreetMap Foundation</a> (OSMF).",
             )),
         );
 

--- a/src/ui/session/content/message_row/mod.rs
+++ b/src/ui/session/content/message_row/mod.rs
@@ -173,7 +173,7 @@ impl Row {
         };
 
         let dialog = adw::MessageDialog::builder()
-            .heading(gettext("Confirm model::Message Deletion"))
+            .heading(gettext("Confirm Message Deletion"))
             .body_use_markup(true)
             .body(message)
             .transient_for(&window)


### PR DESCRIPTION
I found these minor string typos while translating the app in Weblate.
After a brief review of the .pot file, it seems that these were the only ones.
