### PR TITLE
docs(readme): Add dependencies `blueprint-compiler` and `rlottie`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,11 @@ The following packages are required to build Paper Plane:
 
 - meson
 - cargo
+- blueprint-compiler
 - GTK >= 4.10 (with the patch included in the build-aux directory)
 - libadwaita >= 1.4
 - libshumate >= 1.0.0
+- rlottie >= 0.2
 - [TDLib 1.8.19](https://github.com/tdlib/td/commit/2589c3fd46925f5d57e4ec79233cd1bd0f5d0c09)
 - [Telegram API Credentials](https://my.telegram.org/) (optional, but recommended)
 


### PR DESCRIPTION
Fixes

```
error: failed to run custom build command for `rlottie-sys v0.2.9`

Caused by:
  process didn't exit successfully: `/home/al/git-extra/paper-plane/_build/src/release/build/rlottie-sys-362e63de3f824b8c/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=RLOTTIE_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=RLOTTIE_STATIC
  cargo:rerun-if-env-changed=RLOTTIE_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

  --- stderr
  thread 'main' panicked at /home/al/git-extra/paper-plane/_build/cargo-home/registry/src/index.crates.io-6f17d22bba15001f/rlottie-sys-0.2.9/build.rs:6:10:
  Unable to find rlottie: `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS="1" PKG_CONFIG_ALLOW_SYSTEM_LIBS="1" "pkg-config" "--libs" "--cflags" "rlottie"` did not exit successfully: exit status: 1
  error: could not find system library 'rlottie' required by the 'rlottie-sys' crate

  --- stderr
  Package rlottie was not found in the pkg-config search path.
  Perhaps you should add the directory containing `rlottie.pc'
  to the PKG_CONFIG_PATH environment variable
  Package 'rlottie', required by 'virtual:world', not found

  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
[32/34] Generating src/ui/blueprints with a custom command
upgrade: 'bind-property' is no longer needed. Use 'bind' instead. (blueprint 0.8.2)
at ../src/ui/login/phone_number.blp line 18 column 18:
  18 |        visible: bind-property exit_button.sensitive;
     |                 ^

upgrade: 'bind-property' is no longer needed. Use 'bind' instead. (blueprint 0.8.2)
at ../src/ui/session/mod.blp line 19 column 26:
  19 |          selected-chat: bind-property content.chat bidirectional;
     |                         ^

upgrade: 'bind-property' is no longer needed. Use 'bind' instead. (blueprint 0.8.2)
at ../src/ui/session/sidebar/chat_folder/bar.blp line 41 column 29:
  41 |        selected-chat-list: bind-property template.selected-chat-list bidirectional;
     |                            ^

[33/34] Generating src/ui/ui-resources_gresource with a custom command
FAILED: src/paper-plane
/usr/bin/env CARGO_HOME=/home/al/git-extra/paper-plane/_build/cargo-home /home/al/.cargo/bin/cargo build --manifest-path /home/al/git-extra/paper-plane/Cargo.toml --target-dir /home/al/git-extra/paper-plane/_build/src --release && cp src/release/paper-plane src/paper-plane
ninja: build stopped: subcommand failed.
```

and

```
Program blueprint-compiler found: NO
Fallback to subproject blueprint-compiler which provides program blueprint-compiler

data/resources/meson.build:6:12: ERROR: Automatic wrap-based subproject downloading is disabled
```