### PR TITLE
build(flatpak): Use old gl renderer

### DIFF
--- a/build-aux/app.drey.PaperPlane.Devel.json
+++ b/build-aux/app.drey.PaperPlane.Devel.json
@@ -14,6 +14,7 @@
         "--share=network",
         "--share=ipc",
         "--device=dri",
+        "--env=GSK_RENDERER=gl",
         "--env=G_MESSAGES_DEBUG=none",
         "--env=RUST_BACKTRACE=1"
     ],


### PR DESCRIPTION
Our chat background is not yet compatible with the new ngl renderer.
Until then we are still using the old gl renderer.