### PR TITLE
refactor: Use type aliases for ids

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod expressions;
 mod i18n;
 mod model;
 mod strings;
+mod types;
 mod utils;
 
 use std::path::PathBuf;

--- a/src/model/chat_list.rs
+++ b/src/model/chat_list.rs
@@ -13,6 +13,7 @@ use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 
 use crate::model;
+use crate::types::ChatId;
 use crate::utils;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, glib::Enum)]
@@ -220,7 +221,7 @@ impl ChatList {
 
 fn find_chat_item_position(
     list: &RefMut<BTreeMap<i64, model::ChatListItem>>,
-    chat_id: i64,
+    chat_id: ChatId,
 ) -> Option<(usize, i64)> {
     list.iter()
         .enumerate()

--- a/src/model/client.rs
+++ b/src/model/client.rs
@@ -12,6 +12,7 @@ use gtk::subclass::prelude::*;
 
 use crate::config;
 use crate::model;
+use crate::types::ClientId;
 use crate::utils;
 
 /// A struct for storing information about a session's database.
@@ -35,7 +36,7 @@ mod imp {
         #[property(get, set, construct_only)]
         pub(super) remove_if_auth: OnceCell<bool>,
         #[property(get, set, construct_only)]
-        pub(super) id: OnceCell<i32>,
+        pub(super) id: OnceCell<ClientId>,
         #[property(get, set, construct_only)]
         pub(super) database_info: OnceCell<model::BoxedDatabaseInfo>,
         #[property(get)]
@@ -80,13 +81,13 @@ impl Client {
     pub(crate) fn new(
         client_manager: &model::ClientManager,
         remove_if_auth: bool,
-        client_id: i32,
+        id: ClientId,
         database_info: model::DatabaseInfo,
     ) -> Self {
         glib::Object::builder()
             .property("client-manager", client_manager)
             .property("remove-if-auth", remove_if_auth)
-            .property("id", client_id)
+            .property("id", id)
             .property("database-info", model::BoxedDatabaseInfo(database_info))
             .build()
     }

--- a/src/model/client_manager.rs
+++ b/src/model/client_manager.rs
@@ -15,6 +15,7 @@ use indexmap::map::Entry;
 use indexmap::IndexMap;
 
 use crate::model;
+use crate::types::ClientId;
 use crate::utils;
 use crate::APPLICATION_OPTS;
 
@@ -161,13 +162,13 @@ impl ClientManager {
 
     fn add_client(
         &self,
-        client_id: i32,
+        id: ClientId,
         database_info: model::DatabaseInfo,
         remove_if_auth: bool,
     ) -> model::Client {
-        let client = model::Client::new(self, remove_if_auth, client_id, database_info);
+        let client = model::Client::new(self, remove_if_auth, id, database_info);
         let (position, _) = self.imp().0.borrow_mut().insert_full(
-            client_id,
+            id,
             // Important: Here, we basically say that we just want to wait for
             // `AuthorizationState::Ready` and skip the login process.
             client.clone(),
@@ -233,9 +234,9 @@ impl ClientManager {
         }
     }
 
-    pub(crate) fn handle_update(&self, update: tdlib::enums::Update, client_id: i32) {
+    pub(crate) fn handle_update(&self, update: tdlib::enums::Update, id: ClientId) {
         let mut list = self.imp().0.borrow_mut();
-        if let Entry::Occupied(entry) = list.entry(client_id) {
+        if let Entry::Occupied(entry) = list.entry(id) {
             if let tdlib::enums::Update::NotificationGroup(group) = update {
                 let session = entry
                     .get()

--- a/src/model/client_state_session.rs
+++ b/src/model/client_state_session.rs
@@ -10,6 +10,9 @@ use glib::Properties;
 use gtk::glib;
 
 use crate::model;
+use crate::types::ChatId;
+use crate::types::SecretChatId;
+use crate::types::UserId;
 use crate::utils;
 
 mod imp {
@@ -135,8 +138,8 @@ impl ClientStateSession {
     }
 
     /// Returns the `model::Chat` of the specified id, if present.
-    pub(crate) fn try_chat(&self, chat_id: i64) -> Option<model::Chat> {
-        self.imp().chats.borrow().get(&chat_id).cloned()
+    pub(crate) fn try_chat(&self, id: ChatId) -> Option<model::Chat> {
+        self.imp().chats.borrow().get(&id).cloned()
     }
 
     /// Returns the `model::Chat` of the specified id. Panics if the chat is not present.
@@ -144,8 +147,8 @@ impl ClientStateSession {
     /// Note that TDLib guarantees that types are always returned before their ids,
     /// so if you use an id returned by TDLib, it should be expected that the
     /// relative `model::Chat` exists in the list.
-    pub(crate) fn chat(&self, chat_id: i64) -> model::Chat {
-        self.try_chat(chat_id)
+    pub(crate) fn chat(&self, id: ChatId) -> model::Chat {
+        self.try_chat(id)
             .expect("Failed to get expected model::Chat")
     }
 
@@ -171,7 +174,7 @@ impl ClientStateSession {
     /// Note that TDLib guarantees that types are always returned before their ids,
     /// so if you use an id returned by TDLib, it should be expected that the
     /// relative `model::User` exists in the list.
-    pub(crate) fn user(&self, user_id: i64) -> model::User {
+    pub(crate) fn user(&self, user_id: UserId) -> model::User {
         self.imp().users.borrow().get(&user_id).unwrap().clone()
     }
 
@@ -208,11 +211,11 @@ impl ClientStateSession {
     /// Note that TDLib guarantees that types are always returned before their ids,
     /// so if you use an id returned by TDLib, it should be expected that the
     /// relative `model::SecretChat` exists in the list.
-    pub(crate) fn secret_chat(&self, secret_chat_id: i32) -> model::SecretChat {
+    pub(crate) fn secret_chat(&self, id: SecretChatId) -> model::SecretChat {
         self.imp()
             .secret_chats
             .borrow()
-            .get(&secret_chat_id)
+            .get(&id)
             .expect("Failed to get expected model::SecretChat")
             .clone()
     }

--- a/src/model/message.rs
+++ b/src/model/message.rs
@@ -9,6 +9,7 @@ use gtk::subclass::prelude::*;
 
 use crate::expressions;
 use crate::model;
+use crate::types::MessageSenderId;
 
 #[derive(Clone, Debug, glib::Boxed)]
 #[boxed_type(name = "MessageSender")]
@@ -37,7 +38,7 @@ impl MessageSender {
         }
     }
 
-    pub(crate) fn id(&self) -> i64 {
+    pub(crate) fn id(&self) -> MessageSenderId {
         match self {
             Self::User(user) => user.id(),
             Self::Chat(chat) => chat.id(),

--- a/src/model/message_forward_info.rs
+++ b/src/model/message_forward_info.rs
@@ -6,6 +6,7 @@ use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 
 use crate::model;
+use crate::types::MessageId;
 
 #[derive(Clone, Debug, glib::Boxed)]
 #[boxed_type(name = "MessageForwardOrigin")]
@@ -30,7 +31,7 @@ pub(crate) enum MessageForwardOrigin {
 }
 
 impl MessageForwardOrigin {
-    pub(crate) fn id(&self) -> Option<i64> {
+    pub(crate) fn id(&self) -> Option<MessageId> {
         Some(match self {
             Self::User(user) => user.id(),
             Self::Chat { chat, .. } | Self::Channel { chat, .. } => chat.id(),

--- a/src/model/sponsored_message.rs
+++ b/src/model/sponsored_message.rs
@@ -6,6 +6,7 @@ use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 
 use crate::model;
+use crate::types::MessageId;
 
 mod imp {
     use super::*;
@@ -16,7 +17,7 @@ mod imp {
         #[property(get, set, construct_only)]
         pub(super) chat: OnceCell<model::Chat>,
         #[property(get, set, construct_only)]
-        pub(super) message_id: OnceCell<i64>,
+        pub(super) message_id: OnceCell<MessageId>,
         #[property(get, set, construct_only)]
         pub(super) content: OnceCell<model::BoxedMessageContent>,
         #[property(get, set, construct_only)]

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -7,6 +7,7 @@ use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 
 use crate::model;
+use crate::types::UserId;
 
 mod imp {
     use super::*;
@@ -17,7 +18,7 @@ mod imp {
         #[property(get, set, construct_only)]
         pub(super) session: glib::WeakRef<model::ClientStateSession>,
         #[property(get, set, construct_only)]
-        pub(super) id: OnceCell<i64>,
+        pub(super) id: OnceCell<UserId>,
         #[property(get)]
         pub(super) user_type: RefCell<model::BoxedUserType>,
         #[property(get)]

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -5,6 +5,7 @@ use gtk::glib;
 use crate::i18n::gettext_f;
 use crate::i18n::ngettext_f;
 use crate::model;
+use crate::types::MessageId;
 use crate::utils;
 
 pub(crate) fn chat_action(action: &model::ChatAction) -> String {
@@ -822,16 +823,12 @@ fn message_game_score(
     }
 }
 
-fn message_pin_message(
-    message_id: i64,
-    chat: &model::Chat,
-    sender: &model::MessageSender,
-) -> String {
+fn message_pin_message(id: MessageId, chat: &model::Chat, sender: &model::MessageSender) -> String {
     use tdlib::enums::MessageContent::*;
 
     // TODO: Add a way to retrieve the message and update the string
     // in case we don't have the message stored locally.
-    let string = match chat.message(message_id) {
+    let string = match chat.message(id) {
         Some(message) => match message.content().0 {
             MessageText(data) => {
                 const TEXT_LENGTH: usize = 32;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,7 @@
+pub(crate) type ClientId = i32;
+pub(crate) type UserId = i64;
+pub(crate) type ChatId = i64;
+pub(crate) type SecretChatId = i32;
+pub(crate) type MessageId = i64;
+pub(crate) type MessageSenderId = i64;
+pub(crate) type ChatFolderId = i32;

--- a/src/ui/client_manager_view.rs
+++ b/src/ui/client_manager_view.rs
@@ -8,6 +8,8 @@ use gtk::subclass::prelude::*;
 use gtk::CompositeTemplate;
 
 use crate::model;
+use crate::types::ChatId;
+use crate::types::ClientId;
 use crate::ui;
 use crate::utils;
 use crate::APPLICATION_OPTS;
@@ -168,7 +170,7 @@ impl ClientManagerView {
         }));
     }
 
-    pub(crate) fn select_chat(&self, client_id: i32, chat_id: i64) {
+    pub(crate) fn select_chat(&self, client_id: ClientId, chat_id: ChatId) {
         if self
             .active_client()
             .filter(|client| client.id() == client_id)

--- a/src/ui/session/content/chat_action_bar.rs
+++ b/src/ui/session/content/chat_action_bar.rs
@@ -16,6 +16,7 @@ use crate::expressions;
 use crate::i18n::gettext_f;
 use crate::model;
 use crate::strings;
+use crate::types::MessageId;
 use crate::ui;
 use crate::utils;
 
@@ -417,11 +418,11 @@ impl ChatActionBar {
         }
     }
 
-    fn load_message_to_edit(&self, message_id: i64) {
+    fn load_message_to_edit(&self, id: MessageId) {
         if let Some(chat) = self.chat() {
             let client_id = chat.session_().client_().id();
 
-            if let Some(message) = chat.message(message_id) {
+            if let Some(message) = chat.message(id) {
                 match message.content().0 {
                     tdlib::enums::MessageContent::MessageText(data) => {
                         utils::block_on(async move {
@@ -755,12 +756,12 @@ impl ChatActionBar {
         self.notify("chat");
     }
 
-    pub(crate) fn reply_to_message_id(&self, message_id: i64) {
-        self.set_state(ChatActionBarState::Replying(message_id));
+    pub(crate) fn reply_to_message_id(&self, id: MessageId) {
+        self.set_state(ChatActionBarState::Replying(id));
     }
 
-    pub(crate) fn edit_message_id(&self, message_id: i64) {
-        self.set_state(ChatActionBarState::Editing(message_id));
+    pub(crate) fn edit_message_id(&self, id: MessageId) {
+        self.set_state(ChatActionBarState::Editing(id));
     }
 
     fn update_stack_page(&self) {

--- a/src/ui/session/content/message_row/photo.rs
+++ b/src/ui/session/content/message_row/photo.rs
@@ -11,12 +11,12 @@ use gtk::subclass::prelude::*;
 use gtk::CompositeTemplate;
 
 use crate::model;
+use crate::types::MessageId;
 use crate::ui;
 use crate::ui::MessageBaseExt;
 use crate::utils;
 
 mod imp {
-
     use super::*;
 
     #[derive(Debug, Default, CompositeTemplate)]
@@ -141,7 +141,7 @@ impl ui::MessageBaseExt for MessagePhoto {
 }
 
 impl MessagePhoto {
-    fn message_id(&self) -> Option<i64> {
+    fn message_id(&self) -> Option<MessageId> {
         self.imp().message.upgrade().map(|message| message.id())
     }
 

--- a/src/ui/session/mod.rs
+++ b/src/ui/session/mod.rs
@@ -61,6 +61,7 @@ pub(crate) use self::sidebar::Selection as SidebarSelection;
 pub(crate) use self::sidebar::Sidebar;
 pub(crate) use self::switcher::Switcher;
 use crate::model;
+use crate::types::ChatId;
 use crate::ui;
 use crate::utils;
 
@@ -176,11 +177,11 @@ impl Session {
         self.imp().model.upgrade()
     }
 
-    pub(crate) fn select_chat(&self, chat_id: i64) {
-        match self.model().unwrap().try_chat(chat_id) {
+    pub(crate) fn select_chat(&self, id: ChatId) {
+        match self.model().unwrap().try_chat(id) {
             Some(chat) => self.imp().sidebar.set_selected_chat(Some(&chat)),
             None => utils::spawn(clone!(@weak self as obj => async move {
-                match tdlib::functions::create_private_chat(chat_id, true, obj.model().unwrap().client_().id()).await {
+                match tdlib::functions::create_private_chat(id, true, obj.model().unwrap().client_().id()).await {
                     Ok(tdlib::enums::Chat::Chat(data)) => obj.imp().sidebar.set_selected_chat(obj.model().unwrap().try_chat(data.id).as_ref()),
                     Err(e) => log::warn!("Failed to create private chat: {:?}", e),
                 }

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -10,6 +10,8 @@ use gtk::CompositeTemplate;
 use crate::config;
 use crate::model;
 use crate::strings;
+use crate::types::ChatId;
+use crate::types::ClientId;
 use crate::ui;
 use crate::utils;
 use crate::Application;
@@ -116,7 +118,7 @@ impl Window {
         glib::Object::builder().property("application", app).build()
     }
 
-    pub(crate) fn select_chat(&self, client_id: i32, chat_id: i64) {
+    pub(crate) fn select_chat(&self, client_id: ClientId, chat_id: ChatId) {
         self.client_manager_view().select_chat(client_id, chat_id);
     }
 


### PR DESCRIPTION
This makes the code easier to understand and maintain.